### PR TITLE
Adjust metadata database connection information

### DIFF
--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -43,9 +43,28 @@
             <version>${linkis.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.webank.wedatasphere.linkis</groupId>
-            <artifactId>linkis-mybatis</artifactId>
-            <version>${linkis.version}</version>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>1.3.2</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-boot-starter</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-boot-autoconfigure</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-beans</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.pagehelper</groupId>
+            <artifactId>pagehelper</artifactId>
+            <version>5.1.4</version>
         </dependency>
         <dependency>
             <groupId>com.diffplug.durian</groupId>

--- a/metadata/src/main/assembly/distribution.xml
+++ b/metadata/src/main/assembly/distribution.xml
@@ -182,7 +182,7 @@
                 <exclude>org.springframework:spring-context:jar</exclude>
                 <exclude>org.springframework:spring-core:jar</exclude>
                 <exclude>org.springframework:spring-expression:jar</exclude>
-                <exclude>org.springframework:spring-jcl:jar</exclude>
+                <!--<exclude>org.springframework:spring-jcl:jar</exclude>-->
                 <exclude>org.springframework:spring-web:jar</exclude>
                 <exclude>org.tukaani:xz:jar</exclude>
                 <exclude>org.yaml:snakeyaml:jar</exclude>

--- a/metadata/src/main/java/com/webank/wedatasphere/linkis/metadata/hive/config/LinkisMybatisConfig.java
+++ b/metadata/src/main/java/com/webank/wedatasphere/linkis/metadata/hive/config/LinkisMybatisConfig.java
@@ -64,15 +64,16 @@ public class LinkisMybatisConfig {
         boolean testWhileIdle = true;
         boolean testOnBorrow = true;
         boolean testOnReturn = true;
-        HiveConf hiveConf = HiveUtils.getDefaultConf(com.webank.wedatasphere.linkis.common.conf.Configuration.HADOOP_ROOT_USER().getValue());
-        String url = hiveConf.get("javax.jdo.option.ConnectionURL");
-        String username = hiveConf.get("javax.jdo.option.ConnectionUserName");
-        String password = hiveConf.get("javax.jdo.option.ConnectionPassword");
-        if(url == null || username == null && password == null){
+
+        String url =  DWSConfig.HIVE_META_URL.getValue();
+        String username =  DWSConfig.HIVE_META_USER.getValue();
+        String password = DWSConfig.HIVE_META_PASSWORD.getValue();
+        if(StringUtils.isBlank(url) || StringUtils.isBlank(username)  || StringUtils.isBlank(password)) {
+            HiveConf hiveConf = HiveUtils.getDefaultConf(com.webank.wedatasphere.linkis.common.conf.Configuration.HADOOP_ROOT_USER().getValue());
             logger.info("从配置文件中读取hive数据库连接地址");
-            url = DWSConfig.HIVE_META_URL.getValue();
-            username = DWSConfig.HIVE_META_USER.getValue();
-            password = DWSConfig.HIVE_META_PASSWORD.getValue();
+            url = hiveConf.get("javax.jdo.option.ConnectionURL");
+            username = hiveConf.get("javax.jdo.option.ConnectionUserName");
+            password = hiveConf.get("javax.jdo.option.ConnectionPassword");
         }
         logger.info("数据库连接地址信息=" + url);
         datasource.setUrl(url);


### PR DESCRIPTION
#154 

1.fix this bug
2.Adjust the priority order of hive metadata database connection configuration information
  Configuration in conf / linkis.properties takes precedence over hive conf