### PR TITLE
fix:filesystem-get-timeout-log with config

### DIFF
--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/conf/WorkSpaceConfiguration.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/conf/WorkSpaceConfiguration.java
@@ -30,5 +30,6 @@ public class WorkSpaceConfiguration {
     public static final CommonVars<Boolean> RESULT_SET_DOWNLOAD_IS_LIMIT = CommonVars$.MODULE$.apply("wds.linkis.workspace.resultset.download.is.limit",true);
     public static final CommonVars<Integer> RESULT_SET_DOWNLOAD_MAX_SIZE_CSV = CommonVars$.MODULE$.apply("wds.linkis.workspace.resultset.download.maxsize.csv",5000);
     public static final CommonVars<Integer> RESULT_SET_DOWNLOAD_MAX_SIZE_EXCEL = CommonVars$.MODULE$.apply("wds.linkis.workspace.resultset.download.maxsize.excel",5000);
+    public static final CommonVars<Integer> FILESYSTEM_GET_TIMEOUT = CommonVars$.MODULE$.apply("wds.linkis.workspace.filesystem.get.timeout", 2000);
 
 }

--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/conf/WorkSpaceConfiguration.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/conf/WorkSpaceConfiguration.java
@@ -30,6 +30,5 @@ public class WorkSpaceConfiguration {
     public static final CommonVars<Boolean> RESULT_SET_DOWNLOAD_IS_LIMIT = CommonVars$.MODULE$.apply("wds.linkis.workspace.resultset.download.is.limit",true);
     public static final CommonVars<Integer> RESULT_SET_DOWNLOAD_MAX_SIZE_CSV = CommonVars$.MODULE$.apply("wds.linkis.workspace.resultset.download.maxsize.csv",5000);
     public static final CommonVars<Integer> RESULT_SET_DOWNLOAD_MAX_SIZE_EXCEL = CommonVars$.MODULE$.apply("wds.linkis.workspace.resultset.download.maxsize.excel",5000);
-    public static final CommonVars<Integer> FILESYSTEM_GET_TIMEOUT = CommonVars$.MODULE$.apply("wds.linkis.workspace.filesystem.get.timeout", 2000);
 
 }

--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -27,6 +27,8 @@ import com.webank.wedatasphere.linkis.filesystem.exception.WorkSpaceException;
 import com.webank.wedatasphere.linkis.filesystem.restful.remote.FsRestfulRemote;
 import com.webank.wedatasphere.linkis.filesystem.service.FsService;
 import com.webank.wedatasphere.linkis.filesystem.util.Constants;
+import com.webank.wedatasphere.linkis.filesystem.util.FsUtil;
+import com.webank.wedatasphere.linkis.filesystem.util.FsUtil$;
 import com.webank.wedatasphere.linkis.filesystem.util.WorkspaceUtil;
 import com.webank.wedatasphere.linkis.server.Message;
 import com.webank.wedatasphere.linkis.server.security.SecurityFilter;
@@ -98,8 +100,9 @@ public class FsRestfulApi implements FsRestfulRemote {
 
     private void fsValidate(FileSystem fileSystem) throws WorkSpaceException {
         if (fileSystem == null){
-            throw new WorkSpaceException("The user has obtained the filesystem for more than " + WorkSpaceConfiguration.FILESYSTEM_GET_TIMEOUT.getValue().toString()
-                    + "ms. Please contact the administrator.（用户获取filesystem的时间超过" + WorkSpaceConfiguration.FILESYSTEM_GET_TIMEOUT.getValue().toString() + "ms，请联系管理员）");
+
+            throw new WorkSpaceException("The user has obtained the filesystem for more than " + FsUtil.FILESYSTEM_GET_TIMEOUT().getValue().toString()
+                    + "ms. Please contact the administrator.（用户获取filesystem的时间超过" + FsUtil.FILESYSTEM_GET_TIMEOUT().getValue().toString() + "ms，请联系管理员）");
         }
     }
 

--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -98,7 +98,8 @@ public class FsRestfulApi implements FsRestfulRemote {
 
     private void fsValidate(FileSystem fileSystem) throws WorkSpaceException {
         if (fileSystem == null){
-            throw new WorkSpaceException("The user has obtained the filesystem for more than 2s. Please contact the administrator.（用户获取filesystem的时间超过2s，请联系管理员）");
+            throw new WorkSpaceException("The user has obtained the filesystem for more than " + WorkSpaceConfiguration.FILESYSTEM_GET_TIMEOUT.getValue().toString()
+                    + "ms. Please contact the administrator.（用户获取filesystem的时间超过" + WorkSpaceConfiguration.FILESYSTEM_GET_TIMEOUT.getValue().toString() + "ms，请联系管理员）");
         }
     }
 


### PR DESCRIPTION
I change the config key wds.linkis.workspace.filesystem.get.timeout to 20000.But the exception log also print "2s"