### PR TITLE
fix bug: FsRestfulApi.download接口下载_0.dolphin文件抛空指针异常bug  fix bug: DownloadAction未进行异常处理，导致异常信息写入数据流 新增功能：增加流传输结果集功能，主要解决目前无法分页以及分页传输大量结果集的性能问题

### DIFF
--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractHttpClient.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractHttpClient.scala
@@ -201,6 +201,12 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
   protected def responseToResult(response: Response, requestAction: Action): Result = {
     val result = requestAction match {
       case download: DownloadAction =>
+        val statusCode = response.getStatusCode
+        if(statusCode != 200) {
+           val responseBody = response.getResponseBody
+           val url = response.getUri.toString
+           throw new HttpClientResultException(s"URL $url request failed! ResponseBody is $responseBody." )
+        }
         download.write(response.getResponseBodyAsStream)
         Result()
       case heartbeat: HeartbeatAction =>

--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -346,7 +346,12 @@ public class FsRestfulApi implements FsRestfulRemote {
             int bytesRead = 0;
             response.setCharacterEncoding(charset);
             java.nio.file.Path source = Paths.get(fsPath.getPath());
-            response.addHeader("Content-Type", Files.probeContentType(source));
+            String contentType = Files.probeContentType(source);
+            if(!StringUtils.isEmpty(contentType)) {
+                response.addHeader("Content-Type", contentType);
+            } else {
+                response.addHeader("Content-Type", "multipart/form-data");
+            }
             response.addHeader("Content-Disposition", "attachment;filename="
                     + new File(fsPath.getPath()).getName());
             outputStream = response.getOutputStream();

--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -374,6 +374,88 @@ public class FsRestfulApi implements FsRestfulRemote {
         }
     }
 
+     /**
+     * @param req
+     * @param response
+     * @param json
+     * @throws IOException
+     */
+    @POST
+    @Path("/resultdownload")
+    @Override
+    public void resultDownload(@Context HttpServletRequest req,
+                         @Context HttpServletResponse response,
+                         @RequestBody Map<String, String> json) throws IOException, WorkSpaceException {
+        FileSystem fileSystem = null;
+        InputStream inputStream = null;
+        ServletOutputStream outputStream = null;
+        com.webank.wedatasphere.linkis.common.io.resultset.ResultSetReader<? extends MetaData, ? extends Record> resultSetReader = null;
+        try {
+            String charset = json.get("charset");
+            String userName = SecurityFilter.getLoginUsername(req);
+            String path = json.get("path");
+            if (StringUtils.isEmpty(path)) {
+                throw new WorkSpaceException("Path(路径)：" + path + "Is empty!(为空！)");
+            }
+            if (StringUtils.isEmpty(charset)) {
+                charset = "utf-8";
+            }
+            FsPath fsPath = new FsPath(path);
+            fileSystem = fsService.getFileSystem(userName, fsPath);
+            fsValidate(fileSystem);
+            if (!fileSystem.exists(fsPath)) {
+                throw new WorkSpaceException("The downloaded directory does not exist!(下载的目录不存在!)");
+            }
+            ResultSetFactory instance = ResultSetFactory$.MODULE$.getInstance();
+            ResultSet<? extends MetaData, ? extends Record> resultSet = instance.getResultSetByPath(fsPath);
+            resultSetReader = ResultSetReader.getResultSetReader(resultSet, fileSystem.read(fsPath));
+            MetaData metaData = resultSetReader.getMetaData();
+            outputStream = response.getOutputStream();
+            response.setCharacterEncoding(charset);
+            response.addHeader("Content-Type", "multipart/form-data");
+            if (metaData instanceof TableMetaData) {
+                ArrayList<String> resulstsetColumn = new ArrayList<>();
+                while (resultSetReader.hasNext()) {
+                    Record record = resultSetReader.getRecord();
+                    TableRecord tableRecord = (TableRecord) record;
+                    Object[] row = tableRecord.row();
+                    for (Object o : row) {
+                        resulstsetColumn.add(o == null ? "NULL" : o.toString());
+                    }
+                    //字段之间tab分割
+                    String rs = org.apache.commons.lang.StringUtils.join(resulstsetColumn, "\t");
+                    outputStream.write(rs.getBytes("utf-8"));
+                    outputStream.write(System.getProperty("line.separator").getBytes());                                     
+                    resulstsetColumn.clear();
+                } 
+            }
+            if (metaData instanceof LineMetaData) {
+                     while (resultSetReader.hasNext()) {
+                    Record record = resultSetReader.getRecord();
+                    LineRecord lineRecord = (LineRecord) record;
+                        outputStream.write(lineRecord.getLine().getBytes("utf-8"));
+                            outputStream.write(System.getProperty("line.separator").getBytes());                                     
+                 } 
+            }
+        } catch (Exception e) {
+            LOGGER.error("output fail", e);
+            response.reset();
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType("text/plain; charset=utf-8");
+            PrintWriter writer = response.getWriter();
+            writer.append("error(错误):" + e.getMessage());
+            writer.flush();
+            writer.close();
+        } finally {
+                resultSetReader.close();
+            if (outputStream != null) {
+                outputStream.flush();
+            }
+            StorageUtils.close(outputStream, inputStream, null);
+        }
+    }
+
+
     @GET
     @Path("/isExist")
     @Override

--- a/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/remote/FsRestfulRemote.java
+++ b/publicService/workspace/src/main/java/com/webank/wedatasphere/linkis/filesystem/restful/remote/FsRestfulRemote.java
@@ -61,6 +61,9 @@ public interface FsRestfulRemote {
     @PostMapping("/api/filesystem/download")
     void download(@Context HttpServletRequest req, @Context HttpServletResponse response, @RequestBody Map<String,String> json) throws IOException, WorkSpaceException;
 
+    @PostMapping("/api/filesystem/resultdownload")
+    void resultDownload(@Context HttpServletRequest req, @Context HttpServletResponse response, @RequestBody Map<String,String> json) throws IOException, WorkSpaceException;
+
     @GetMapping("/api/filesystem/isExit")
     Response isExist(@Context HttpServletRequest req, @QueryParam("path")String path) throws IOException, WorkSpaceException;
 


### PR DESCRIPTION
Bug原因：

Spring cloud gateway  Finchley.RELEASE  org.springframework.cloud.gateway.filter.NettyRoutingFilter
exchange.getAttributes().put("original_response_content_type", headers.getContentType());
没有判空。该问题在Finchley.SR2版本已经修复。

linkis升级Spring cloud gateway版本风险较大，建议规避bug；