### PR TITLE
Fix bug of bml server log config which writes an absolute log path

### DIFF
--- a/bml/bmlserver/conf/log4j2.xml
+++ b/bml/bmlserver/conf/log4j2.xml
@@ -5,8 +5,8 @@
             <ThresholdFilter level="trace" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
         </Console>
-        <RollingFile name="RollingFile" fileName="/appcom/logs/linkis/BmlServer/BmlServer.log"
-                     filePattern="/appcom/logs/linkis/BmlServer/$${date:yyyy-MM}/BmlServer-log-%d{yyyy-MM-dd}-%i.log.gz">
+        <RollingFile name="RollingFile" fileName="logs/BmlServer.log"
+                     filePattern="logs/%d{yyyy-MM}/BmlServer-log-%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
             <DefaultRolloverStrategy max="20"/>


### PR DESCRIPTION
There is a bug of bml server log config which writes an absolute log path:
bml/bmlserver/conf/log4j2.xml:
```xml
<RollingFile name="RollingFile" fileName="/appcom/logs/linkis/BmlServer/BmlServer.log"
                     filePattern="/appcom/logs/linkis/BmlServer/$${date:yyyy-MM}/BmlServer-log-%d{yyyy-MM-dd}-%i.log.gz">
```
which will cause start error:
```log
java.io.IOException: Could not create directory /appcom/logs/linkis/BmlServer
```