### PR TITLE
替换client包 底层http Api：org.apache.http.impl.client

### DIFF
--- a/bml/bmlserver/conf/log4j2.xml
+++ b/bml/bmlserver/conf/log4j2.xml
@@ -5,8 +5,8 @@
             <ThresholdFilter level="trace" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
         </Console>
-        <RollingFile name="RollingFile" fileName="/appcom/logs/linkis/BmlServer/BmlServer.log"
-                     filePattern="/appcom/logs/linkis/BmlServer/$${date:yyyy-MM}/BmlServer-log-%d{yyyy-MM-dd}-%i.log.gz">
+        <RollingFile name="RollingFile" fileName="logs/BmlServer.log"
+                     filePattern="logs/%d{yyyy-MM}/BmlServer-log-%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
             <DefaultRolloverStrategy max="20"/>

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractApacheHttpClient.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractApacheHttpClient.scala
@@ -145,7 +145,7 @@ abstract class AbstractApacheHttpClient(clientConfig: ClientConfig, clientName: 
         realURL = getRequestUrl(requestAction.getURL, requestAction.getRequestBody)
     }
     
-    if(clientConfig.getAuthenticationStrategy != null) clientConfig.getAuthenticationStrategy.login(requestAction, realURL) match {
+    if(clientConfig.getAuthenticationStrategy != null) clientConfig.getAuthenticationStrategy.login(requestAction, realURL.replaceAll(requestAction.getURL, "")) match {
       case authAction: HttpAuthentication =>
         val cookies = authAction.authToCookies
         if(cookies != null && cookies.nonEmpty) cookies.foreach(requestAction.addCookie)

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractApacheHttpClient.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractApacheHttpClient.scala
@@ -18,39 +18,57 @@ package com.webank.wedatasphere.linkis.httpclient
 
 import java.io.{File, InputStream}
 import java.util.concurrent.TimeUnit
-import com.ning.http.client.Response
-import com.ning.http.multipart.{FilePart, PartSource, StringPart}
+
 import com.webank.wedatasphere.linkis.common.conf.Configuration
 import com.webank.wedatasphere.linkis.common.io.{Fs, FsPath}
 import com.webank.wedatasphere.linkis.common.utils.Utils
 import com.webank.wedatasphere.linkis.httpclient.authentication.{AbstractAuthenticationStrategy, AuthenticationAction, HttpAuthentication}
 import com.webank.wedatasphere.linkis.httpclient.config.ClientConfig
 import com.webank.wedatasphere.linkis.httpclient.discovery.{AbstractDiscovery, Discovery, HeartbeatAction}
-import com.webank.wedatasphere.linkis.httpclient.exception.{HttpClientResultException, HttpMessageParseException}
+import com.webank.wedatasphere.linkis.httpclient.exception.HttpMessageParseException
 import com.webank.wedatasphere.linkis.httpclient.loadbalancer.{AbstractLoadBalancer, DefaultLoadbalancerStrategy, LoadBalancer}
 import com.webank.wedatasphere.linkis.httpclient.request._
 import com.webank.wedatasphere.linkis.httpclient.response._
-import dispatch._
+import com.webank.wedatasphere.linkis.httpclient.exception.HttpClientResultException
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang.StringUtils
 import org.apache.http.HttpException
+import org.apache.commons._
+import org.apache.http._
+import org.apache.http.client._
+import org.apache.http.client.methods.HttpPost
+import java.util.ArrayList
+import org.apache.http.message.BasicNameValuePair
+import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.json4s.jackson.Serialization.read
 import org.json4s.{DefaultFormats, Formats}
-
+import org.apache.http.client.methods.{HttpGet, HttpPost}
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.util.EntityUtils
 import scala.collection.Iterable
 import scala.collection.JavaConversions._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext,ExecutionContextExecutorService, Future}
+import org.apache.http.protocol.HTTP
+import org.apache.http.client.utils.URIBuilder
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.util.EntityUtils
+import org.apache.http.HttpEntity
+import org.apache.http.HttpResponse
+
 
 /**
   * Created by enjoyyin on 2019/5/20.
   */
-abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String) extends Client {
+abstract class AbstractApacheHttpClient(clientConfig: ClientConfig, clientName: String) extends Client {
 
   protected implicit val formats: Formats = DefaultFormats
   protected implicit val executors: ExecutionContext = Utils.newCachedExecutionContext(clientConfig.getMaxConnection, clientName, false)
   protected val httpTimeout: Duration = if (clientConfig.getReadTimeout > 0) Duration(clientConfig.getReadTimeout, TimeUnit.MILLISECONDS)
     else Duration.Inf
+    
+  protected val httpClient = HttpClients.createDefault() 
 
   if(clientConfig.getAuthenticationStrategy != null) clientConfig.getAuthenticationStrategy match {
     case auth: AbstractAuthenticationStrategy => auth.setClient(this)
@@ -89,27 +107,25 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
     if(!requestAction.isInstanceOf[HttpAction])
       throw new UnsupportedOperationException("only HttpAction supported, but the fact is " + requestAction.getClass)
     val action = prepareAction(requestAction.asInstanceOf[HttpAction])
-    val req = prepareReq(action)
-    val response = if(!clientConfig.isRetryEnabled) executeRequest(req, Some(waitTime).filter(_ > 0))
-      else clientConfig.getRetryHandler.retry(executeRequest(req, Some(waitTime).filter(_ > 0)), action.getClass.getSimpleName + "HttpRequest")
+    val response:CloseableHttpResponse = executeHttpAction(action)
     responseToResult(response, action)
   }
 
   override def execute(requestAction: Action, resultListener: ResultListener): Unit = {
-    if(!requestAction.isInstanceOf[HttpAction])
+    if(!requestAction.isInstanceOf[HttpAction]) {
       throw new UnsupportedOperationException("only HttpAction supported, but the fact is " + requestAction.getClass)
+    }
     val action = prepareAction(requestAction.asInstanceOf[HttpAction])
-    val req = prepareReq(action)
-    val response = executeAsyncRequest(req)
-    response.onSuccess{case r => resultListener.onSuccess(responseToResult(r, action))}
-    response.onFailure{case t => resultListener.onFailure(t)}
+    val response:CloseableHttpResponse = executeHttpAction(action)
+    //response.onSuccess{case r => resultListener.onSuccess(responseToResult(r, action))}
+    //response.onFailure{case t => resultListener.onFailure(t)}
   }
 
   protected def getRequestUrl(suffixUrl: String, requestBody: String): String = {
     val urlPrefix = loadBalancer.map(_.chooseServerUrl(requestBody)).getOrElse(clientConfig.getServerUrl)
     connectUrl(urlPrefix, suffixUrl)
   }
-
+  
   protected def connectUrl(prefix: String, suffix: String): String = {
     val prefixEnd = prefix.endsWith("/")
     val suffixStart = suffix.startsWith("/")
@@ -120,93 +136,82 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
 
   protected def prepareAction(requestAction: HttpAction): HttpAction = requestAction
 
-  protected def prepareReq(requestAction: HttpAction): Req = {
+  protected def executeHttpAction(requestAction: HttpAction) :CloseableHttpResponse = {
     var realURL = ""
-    var req = requestAction match {
+    requestAction match {
       case serverUrlAction: ServerUrlAction =>
-        realURL = serverUrlAction.serverUrl
-        dispatch.url(connectUrl(serverUrlAction.serverUrl, requestAction.getURL))
+        realURL = connectUrl(serverUrlAction.serverUrl, requestAction.getURL) 
       case _ =>
-        val url = getRequestUrl(requestAction.getURL, requestAction.getRequestBody)
-        realURL = url.replaceAll(requestAction.getURL, "")
-        dispatch.url(url)
+        realURL = getRequestUrl(requestAction.getURL, requestAction.getRequestBody)
     }
-    var request = requestAction match {
-      case upload: UploadAction =>
-        req = req.setContentType("multipart/form-data", Configuration.BDP_ENCODING.getValue).POST
-        if(upload.files != null && upload.files.nonEmpty) {
-          val fs = upload.user.map(getFsByUser(_, new FsPath(upload.files.head._2)))
-          upload.files.foreach { case (k, v) =>
-            if(StringUtils.isEmpty(v)) throw new HttpException(s"$k 的文件路径不能为空！")
-            val filePart = fs.map(f => if(f.exists(new FsPath(v))) new FilePart(k, new FsPartSource(f, v))
-              else throw new HttpException(s"File $v 不存在！")).getOrElse{
-                val f = new File(v)
-                if(!f.exists() || !f.isFile) throw new HttpException(s"File $v 不存在！")
-                else new FilePart(k, f)
-            }
-            req = req.addBodyPart(filePart)
-          }
-        }
-        if(upload.inputStreams != null)
-          upload.inputStreams.foreach { case (k, v) =>
-            val filePart = new FilePart(k, new PartSource{
-              val length = v.available
-              override def getLength: Long = length
-              override def getFileName: String = upload.inputStreamNames.getOrDefault(k, k)
-              override def createInputStream(): InputStream = v
-            })
-            req = req.addBodyPart(filePart)
-          }
-        upload match {
-          case get: GetAction => get.getParameters.foreach { case (k, v) => req = req.addBodyPart(new StringPart(k, v.toString)) }
-          case _ =>
-        }
-        req
-      case post: POSTAction =>
-        req = req.POST
-        if(!post.getParameters.isEmpty) post.getParameters.foreach{ case (k, v) => req = req.addQueryParameter(k, v.toString)}
-        if(post.getFormParams.nonEmpty) {
-          req.setContentType("application/x-www-form-urlencoded", Configuration.BDP_ENCODING.getValue) << post.getFormParams
-        } else req.setContentType("application/json", Configuration.BDP_ENCODING.getValue) << post.getRequestPayload
-      case get: GetAction =>
-        if(!get.getParameters.isEmpty) get.getParameters.foreach{ case (k, v) => req = req.addQueryParameter(k, v.toString)}
-        req.GET
-      case _ =>
-        req.POST.setBody(requestAction.getRequestBody)
-          .setContentType("application/json", Configuration.BDP_ENCODING.getValue)
-    }
+    
     if(clientConfig.getAuthenticationStrategy != null) clientConfig.getAuthenticationStrategy.login(requestAction, realURL) match {
       case authAction: HttpAuthentication =>
         val cookies = authAction.authToCookies
         if(cookies != null && cookies.nonEmpty) cookies.foreach(requestAction.addCookie)
         val headers = authAction.authToHeaders
-        if(headers != null && headers.nonEmpty) headers.foreach{case (k, v) => requestAction.addHeader(k, v.toString)}
+        if(headers != null && !headers.isEmpty()) {
+          headers.foreach{case (k,v) => requestAction.addHeader(k.toString(), v.toString())}
+          }
       case _ =>
     }
-    if(requestAction.getHeaders.nonEmpty) request = request <:< requestAction.getHeaders
-    if(requestAction.getCookies.nonEmpty) requestAction.getCookies.foreach(c => request = request.addCookie(c))
-    request
+   
+   var response: CloseableHttpResponse = null
+   requestAction match {
+      case post: POSTAction =>
+        val httpost = new HttpPost(realURL)
+        if(!post.getParameters.isEmpty) { 
+      		  var nvps = new ArrayList[NameValuePair]
+      		  post.getParameters.foreach{case (k,v) => nvps.add(new BasicNameValuePair(k, v.toString()))}
+      		  httpost.setEntity(new UrlEncodedFormEntity(nvps))
+      		}
+        var stringEntity  = new StringEntity(post.getRequestPayload,"UTF-8") 
+        stringEntity.setContentEncoding(Configuration.BDP_ENCODING.getValue)
+        stringEntity.setContentType("application/json") 
+        httpost.setEntity(stringEntity)
+        if(requestAction.getHeaders.nonEmpty){
+            requestAction.getHeaders.foreach{case (k, v) => httpost.addHeader(k.toString(), v.toString())}
+        }
+        response = httpClient.execute(httpost)
+      case get: GetAction =>
+          var builder = new URIBuilder(realURL)
+          if(!get.getParameters.isEmpty)  {
+            get.getParameters.foreach{case (k,v) => builder.addParameter(k.toString(), v.toString())}
+          }
+        	  val httpGet =  new HttpGet(builder.build())
+        	  if(requestAction.getHeaders.nonEmpty){
+             requestAction.getHeaders.foreach{case (k,v) => httpGet.addHeader(k.toString(), v.toString())}
+          }
+        	  response = httpClient.execute(httpGet);
+      case _ =>
+          val httpost = new HttpPost(realURL)
+          var stringEntity  = new StringEntity(requestAction.getRequestBody,"UTF-8") 
+          stringEntity.setContentEncoding(Configuration.BDP_ENCODING.getValue)
+          stringEntity.setContentType("application/json") 
+          httpost.setEntity(stringEntity)
+          if(requestAction.getHeaders.nonEmpty){
+             requestAction.getHeaders.foreach{case (k, v) => httpost.addHeader(k.toString(), v.toString())}
+          }
+          response = httpClient.execute(httpost)
+     }
+   response
   }
 
   protected def getFsByUser(user: String, path: FsPath): Fs
 
-  protected def executeRequest(req: Req, waitTime: Option[Long]): Response = {
-    val response = executeAsyncRequest(req)
-    Await.result(response, Duration(waitTime.getOrElse(clientConfig.getReadTimeout), TimeUnit.MILLISECONDS))
-  }
-
-  protected def executeAsyncRequest(req: Req): Future[Response] = Http(req > as.Response(r => r))
-
-  protected def responseToResult(response: Response, requestAction: Action): Result = {
+  protected def responseToResult(response: HttpResponse, requestAction: Action): Result = {
+    var entity = response.getEntity
     val result = requestAction match {
       case download: DownloadAction =>
-        val statusCode = response.getStatusCode
+        val statusCode = response.getStatusLine.getStatusCode
         if(statusCode != 200) {
-           val responseBody = response.getResponseBody
-           val url = response.getUri.toString
-           throw new HttpClientResultException(s"URL $url request failed! ResponseBody is $responseBody." )
+          var responseBody:String = null
+          if(entity != null){  
+            responseBody = EntityUtils.toString(entity, "UTF-8")
+           }
+           throw new HttpClientResultException(s"request failed! ResponseBody is $responseBody." )
         }
-        download.write(response.getResponseBodyAsStream)
+        download.write(entity.getContent)
         Result()
       case heartbeat: HeartbeatAction =>
         discovery.map {
@@ -218,8 +223,12 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
           case _ => throw new HttpMessageParseException("AuthenticationStrategy is not enable, login is not needed!")
         }
       case httpAction: HttpAction =>
-        httpResponseToResult(response, httpAction)
-          .getOrElse(throw new HttpMessageParseException("cannot parse message: " + response.getResponseBody))
+        var responseBody:String = null
+        if(entity != null){  
+           responseBody = EntityUtils.toString(entity, "UTF-8")
+        }
+        httpResponseToResult(response, httpAction,responseBody)
+          .getOrElse(throw new HttpMessageParseException("cannot parse message: " + responseBody))
     }
     result match {
       case userAction: UserAction => requestAction match {
@@ -231,10 +240,14 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
     result
   }
 
-  protected def httpResponseToResult(response: Response, requestAction: HttpAction): Option[Result]
+  protected def httpResponseToResult(response: HttpResponse, requestAction: HttpAction,responseBody: String): Option[Result]
 
-  protected def deserializeResponseBody(response: Response): Iterable[_] = {
-    val responseBody = response.getResponseBody
+  protected def deserializeResponseBody(response: HttpResponse): Iterable[_] = {
+    var entity = response.getEntity
+    var responseBody:String = null
+    if(entity != null){  
+        	responseBody = EntityUtils.toString(entity, "UTF-8")
+    } 
     if(responseBody.startsWith("{") && responseBody.endsWith("}"))
       read[Map[String, Object]](responseBody)
     else if(responseBody.startsWith("[") && responseBody.endsWith("}"))
@@ -249,16 +262,7 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
       case d: AbstractDiscovery => IOUtils.closeQuietly(d)
       case _ =>
     }
-    dispatch.Http.shutdown()
+    httpClient.close()
     executors.asInstanceOf[ExecutionContextExecutorService].shutdown()
   }
-}
-
-class FsPartSource (fs: Fs, path: String) extends PartSource {
-  val fsPath = fs.get(path)
-  override def getLength: Long = fsPath.getLength
-
-  override def createInputStream(): InputStream = fs.read(fsPath)
-
-  override def getFileName: String = fsPath.toFile.getName
 }

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractHttpClient.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractHttpClient.scala
@@ -18,7 +18,6 @@ package com.webank.wedatasphere.linkis.httpclient
 
 import java.io.{File, InputStream}
 import java.util.concurrent.TimeUnit
-
 import com.ning.http.client.Response
 import com.ning.http.multipart.{FilePart, PartSource, StringPart}
 import com.webank.wedatasphere.linkis.common.conf.Configuration

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractHttpClient.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/AbstractHttpClient.scala
@@ -61,7 +61,7 @@ import org.apache.http.HttpResponse
 /**
   * Created by enjoyyin on 2019/5/20.
   */
-abstract class AbstractApacheHttpClient(clientConfig: ClientConfig, clientName: String) extends Client {
+abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String) extends Client {
 
   protected implicit val formats: Formats = DefaultFormats
   protected implicit val executors: ExecutionContext = Utils.newCachedExecutionContext(clientConfig.getMaxConnection, clientName, false)

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/authentication/AbstractAuthenticationStrategy.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/authentication/AbstractAuthenticationStrategy.scala
@@ -18,7 +18,8 @@ package com.webank.wedatasphere.linkis.httpclient.authentication
 
 import java.util.concurrent.ConcurrentHashMap
 
-import com.ning.http.client.Response
+import org.apache.http.HttpEntity
+import org.apache.http.HttpResponse
 import com.webank.wedatasphere.linkis.httpclient.Client
 import com.webank.wedatasphere.linkis.httpclient.config.ClientConfig
 import com.webank.wedatasphere.linkis.httpclient.request.{Action, UserAction}
@@ -76,7 +77,7 @@ abstract class AbstractAuthenticationStrategy extends AuthenticationStrategy {
 
   protected def getAuthenticationAction(requestAction: Action, serverUrl: String): AuthenticationAction
 
-  def getAuthenticationResult(response: Response, requestAction: AuthenticationAction): AuthenticationResult
+  def getAuthenticationResult(response: HttpResponse, requestAction: AuthenticationAction): AuthenticationResult
 
   def isTimeout(authentication: Authentication): Boolean = System.currentTimeMillis() - authentication.getLastAccessTime >= sessionMaxAliveTime
 }

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/authentication/HttpAuthentication.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/authentication/HttpAuthentication.scala
@@ -20,7 +20,7 @@
 
 package com.webank.wedatasphere.linkis.httpclient.authentication
 
-import com.ning.http.client.cookie.Cookie
+import org.apache.http.cookie.Cookie
 
 /**
   * Created by enjoyyin on 2019/5/16.

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/discovery/AbstractDiscovery.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/discovery/AbstractDiscovery.scala
@@ -25,7 +25,8 @@ import java.net.ConnectException
 import java.util
 import java.util.concurrent.ScheduledFuture
 
-import com.ning.http.client.Response
+import org.apache.http.HttpEntity
+import org.apache.http.HttpResponse
 import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
 import com.webank.wedatasphere.linkis.httpclient.Client
 import com.webank.wedatasphere.linkis.httpclient.exception.DiscoveryException
@@ -129,7 +130,7 @@ abstract class AbstractDiscovery extends Discovery with Closeable with Logging {
 
   protected def getHeartbeatAction(serverUrl: String): HeartbeatAction
 
-  def getHeartbeatResult(response: Response, requestAction: HeartbeatAction): HeartbeatResult
+  def getHeartbeatResult(response: HttpResponse, requestAction: HeartbeatAction): HeartbeatResult
 
   override def addDiscoveryListener(discoveryListener: DiscoveryListener): Unit =
     discoveryListeners.add(discoveryListener)

--- a/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/request/HttpAction.scala
+++ b/core/httpclient/src/main/scala/com/webank/wedatasphere/linkis/httpclient/request/HttpAction.scala
@@ -22,7 +22,8 @@ package com.webank.wedatasphere.linkis.httpclient.request
 
 import java.util
 
-import com.ning.http.client.cookie.Cookie
+import org.apache.http.cookie.Cookie
+import org.apache.http.impl.cookie.BasicClientCookie
 
 /**
   * Created by enjoyyin on 2019/5/16.
@@ -36,9 +37,14 @@ trait HttpAction extends Action {
   def addHeader(key: String, value: String): Unit = headerParams.put(key, value)
 
   def getCookies: Array[Cookie] = cookies.toArray(new Array[Cookie](cookies.size()))
-  def addCookie(cookie: javax.servlet.http.Cookie): Unit =
-    cookies.add(Cookie.newValidCookie(cookie.getName, cookie.getValue, cookie.getDomain,
-      cookie.getValue, cookie.getPath, -1, cookie.getMaxAge, cookie.getSecure, true))
+  def addCookie(cookie: javax.servlet.http.Cookie): Unit = {
+    var newcookie:BasicClientCookie = new BasicClientCookie(cookie.getName, cookie.getValue)
+    newcookie.setDomain(cookie.getDomain)
+    newcookie.setPath(cookie.getPath)
+    newcookie.setSecure(true)
+    cookies.add(newcookie)
+  }
+
   def addCookie(cookie: Cookie): Unit = cookies.add(cookie)
 
   def getURL: String

--- a/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/DWSHttpClient.scala
+++ b/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/DWSHttpClient.scala
@@ -24,9 +24,9 @@ import java.text.SimpleDateFormat
 import java.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ning.http.client.Response
+import org.apache.http.HttpResponse
 import com.webank.wedatasphere.linkis.common.io.{Fs, FsPath}
-import com.webank.wedatasphere.linkis.httpclient.AbstractHttpClient
+import com.webank.wedatasphere.linkis.httpclient.AbstractApacheHttpClient
 import com.webank.wedatasphere.linkis.httpclient.discovery.Discovery
 import com.webank.wedatasphere.linkis.httpclient.dws.config.DWSClientConfig
 import com.webank.wedatasphere.linkis.httpclient.dws.discovery.DWSGatewayDiscovery
@@ -37,14 +37,14 @@ import com.webank.wedatasphere.linkis.httpclient.response.{HttpResult, ListResul
 import com.webank.wedatasphere.linkis.storage.FSFactory
 import org.apache.commons.beanutils.BeanUtils
 import org.apache.commons.lang.ClassUtils
-
+import org.apache.http.util.EntityUtils
 import scala.collection.JavaConversions.mapAsJavaMap
 
 /**
   * created by cooperyang on 2019/5/20.
   */
 class DWSHttpClient(clientConfig: DWSClientConfig, clientName: String)
-    extends AbstractHttpClient(clientConfig, clientName) {
+    extends AbstractApacheHttpClient(clientConfig, clientName) {
 
   override protected def createDiscovery(): Discovery = new DWSGatewayDiscovery
 
@@ -57,13 +57,16 @@ class DWSHttpClient(clientConfig: DWSClientConfig, clientName: String)
     requestAction
   }
 
-  override protected def httpResponseToResult(response: Response, requestAction: HttpAction): Option[Result] = {
-    val url = requestAction.getURL
+  override protected def httpResponseToResult(response: HttpResponse, requestAction: HttpAction,responseBody: String): Option[Result] = {
+    var entity = response.getEntity
+    val statusCode: Int = response.getStatusLine.getStatusCode
+    val url: String = requestAction.getURL 
+    val contentType: String = entity.getContentType.getValue
     DWSHttpMessageFactory.getDWSHttpMessageResult(url).map { case DWSHttpMessageResultInfo(_, clazz) =>
       clazz match {
         case c if ClassUtils.isAssignable(c, classOf[DWSResult]) =>
           val dwsResult = clazz.getConstructor().newInstance().asInstanceOf[DWSResult]
-          dwsResult.set(response.getResponseBody, response.getStatusCode, response.getUri.toString, response.getContentType)
+          dwsResult.set(responseBody, statusCode, url, contentType)
           BeanUtils.populate(dwsResult, dwsResult.getData)
           return Some(dwsResult)
         case _ =>
@@ -71,7 +74,7 @@ class DWSHttpClient(clientConfig: DWSClientConfig, clientName: String)
       def transfer(value: Result, map: Map[String, Object]): Unit = {
         value match {
           case httpResult: HttpResult =>
-            httpResult.set(response.getResponseBody, response.getStatusCode, response.getUri.toString, response.getContentType)
+            httpResult.set(responseBody, statusCode, url, contentType)
           case _ =>
         }
         val javaMap = mapAsJavaMap(map)
@@ -89,17 +92,18 @@ class DWSHttpClient(clientConfig: DWSClientConfig, clientName: String)
             transfer(value, map)
             value
           }.toArray
-          new ListResult(response.getResponseBody, results)
+          new ListResult(responseBody, results)
       }
     }.orElse(nonDWSResponseToResult(response, requestAction))
   }
 
-  protected def nonDWSResponseToResult(response: Response, requestAction: HttpAction): Option[Result] = None
+  protected def nonDWSResponseToResult(response: HttpResponse, requestAction: HttpAction): Option[Result] = None
 
   protected def fillResultFields(responseMap: util.Map[String, Object], value: Result): Unit = {}
 
   //TODO Consistent with workspace, plus expiration time(与workspace保持一致，加上过期时间)
   override protected def getFsByUser(user: String, path: FsPath): Fs = FSFactory.getFsByProxyUser(path, user)
+  
 }
 object DWSHttpClient {
   val jacksonJson = new ObjectMapper().setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ"))

--- a/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/authentication/StaticAuthenticationStrategy.scala
+++ b/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/authentication/StaticAuthenticationStrategy.scala
@@ -16,7 +16,7 @@
 
 package com.webank.wedatasphere.linkis.httpclient.dws.authentication
 
-import com.ning.http.client.Response
+import org.apache.http.HttpResponse
 import com.webank.wedatasphere.linkis.common.utils.ByteTimeUtils
 import com.webank.wedatasphere.linkis.httpclient.authentication.{AbstractAuthenticationStrategy, AuthenticationAction, AuthenticationResult}
 import com.webank.wedatasphere.linkis.httpclient.dws.exception.AuthenticationFailedException
@@ -51,7 +51,7 @@ class StaticAuthenticationStrategy(override protected val sessionMaxAliveTime: L
     action
   }
 
-  override def getAuthenticationResult(response: Response, requestAction: AuthenticationAction): AuthenticationResult = {
+  override def getAuthenticationResult(response: HttpResponse, requestAction: AuthenticationAction): AuthenticationResult = {
     new DWSAuthenticationResult(response, requestAction.serverUrl)
   }
 }

--- a/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/authentication/TokenAuthenticationStrategy.scala
+++ b/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/authentication/TokenAuthenticationStrategy.scala
@@ -18,8 +18,8 @@ package com.webank.wedatasphere.linkis.httpclient.dws.authentication
 
 import java.util
 
-import com.ning.http.client.Response
-import com.ning.http.client.cookie.Cookie
+import org.apache.http.cookie.Cookie
+import org.apache.http.HttpResponse
 import com.webank.wedatasphere.linkis.httpclient.authentication._
 import com.webank.wedatasphere.linkis.httpclient.dws.exception.AuthenticationFailedException
 import com.webank.wedatasphere.linkis.httpclient.request.{Action, UserAction}
@@ -51,7 +51,7 @@ class TokenAuthenticationStrategy(override protected val sessionMaxAliveTime: Lo
 
   override protected def getAuthenticationAction(requestAction: Action, serverUrl: String): AuthenticationAction = null
 
-  override def getAuthenticationResult(response: Response, requestAction: AuthenticationAction): AuthenticationResult = null
+  override def getAuthenticationResult(response: HttpResponse, requestAction: AuthenticationAction): AuthenticationResult = null
 
 }
 object TokenAuthenticationStrategy {

--- a/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/discovery/DWSGatewayDiscovery.scala
+++ b/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/discovery/DWSGatewayDiscovery.scala
@@ -20,7 +20,7 @@
 
 package com.webank.wedatasphere.linkis.httpclient.dws.discovery
 
-import com.ning.http.client.Response
+import org.apache.http.HttpResponse
 import com.webank.wedatasphere.linkis.httpclient.discovery.{AbstractDiscovery, HeartbeatAction, HeartbeatResult}
 import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHeartbeatAction
 import com.webank.wedatasphere.linkis.httpclient.dws.response.DWSHeartbeatResult
@@ -43,7 +43,7 @@ class DWSGatewayDiscovery extends AbstractDiscovery {
 
   override protected def getHeartbeatAction(serverUrl: String): HeartbeatAction = new DWSHeartbeatAction(serverUrl)
 
-  override def getHeartbeatResult(response: Response, requestAction: HeartbeatAction): HeartbeatResult = requestAction match {
+  override def getHeartbeatResult(response: HttpResponse, requestAction: HeartbeatAction): HeartbeatResult = requestAction match {
     case h: DWSHeartbeatAction => new DWSHeartbeatResult(response, h.serverUrl)
   }
 }

--- a/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/response/DWSAuthenticationResult.scala
+++ b/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/response/DWSAuthenticationResult.scala
@@ -18,22 +18,35 @@ package com.webank.wedatasphere.linkis.httpclient.dws.response
 
 import java.util
 
-import com.ning.http.client.Response
-import com.ning.http.client.cookie.Cookie
+import org.apache.http.HttpResponse
+import org.apache.http.cookie.Cookie
 import com.webank.wedatasphere.linkis.httpclient.authentication.{Authentication, AuthenticationResult, HttpAuthentication}
 import com.webank.wedatasphere.linkis.httpclient.exception.HttpMessageParseException
-
+import org.apache.http.util.EntityUtils
 import scala.collection.JavaConversions
 
 /**
   * created by cooperyang on 2019/5/22.
   */
-class DWSAuthenticationResult(response: Response, serverUrl: String) extends AuthenticationResult with DWSResult {
+class DWSAuthenticationResult(response: HttpResponse, serverUrl: String) extends AuthenticationResult with DWSResult {
 
-  set(response.getResponseBody, response.getStatusCode, response.getUri.toString, response.getContentType)
-  override def getAuthentication: Authentication = if(getStatus == 0) new HttpAuthentication {
+    var entity = response.getEntity
+    var responseBody: String = null
+    if (entity != null) {
+      responseBody = EntityUtils.toString(entity, "UTF-8")
+    }
+    val statusCode: Int = response.getStatusLine.getStatusCode
+    val url: String = serverUrl
+    val contentType: String = entity.getContentType.getValue
+    
+    
+    set(responseBody, statusCode, url, contentType)
+
+    override def getAuthentication: Authentication = if(getStatus == 0) new HttpAuthentication {
     private var lastAccessTime: Long = System.currentTimeMillis
-    override def authToCookies: Array[Cookie] = JavaConversions.asScalaBuffer(response.getCookies).toArray
+   
+    //TODO fix by hui.zhu
+    override def authToCookies: Array[Cookie] = Array.empty
 
     override def authToHeaders: util.Map[String, String] = new util.HashMap[String, String]()
 

--- a/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/response/DWSHeartbeatResult.scala
+++ b/gateway/gateway-httpclient-support/src/main/scala/com/webank/wedatasphere/linkis/httpclient/dws/response/DWSHeartbeatResult.scala
@@ -18,15 +18,26 @@ package com.webank.wedatasphere.linkis.httpclient.dws.response
 
 import java.util
 
-import com.ning.http.client.Response
+import org.apache.http.HttpResponse
+import org.apache.http.util.EntityUtils
 import com.webank.wedatasphere.linkis.httpclient.discovery.HeartbeatResult
 
 /**
   * created by cooperyang on 2019/5/22.
   */
-class DWSHeartbeatResult(response: Response, serverUrl: String) extends HeartbeatResult with DWSResult {
+class DWSHeartbeatResult(response: HttpResponse, serverUrl: String) extends HeartbeatResult with DWSResult {
 
-  set(response.getResponseBody, response.getStatusCode, response.getUri.toString, response.getContentType)
+  var entity = response.getEntity
+  var responseBody: String = null
+  if (entity != null) {
+    responseBody = EntityUtils.toString(entity, "UTF-8")
+  }
+  val statusCode: Int = response.getStatusLine.getStatusCode
+  val url: String = serverUrl
+  val contentType: String = entity.getContentType.getValue
+  set(responseBody, statusCode, url, contentType)
+  
+
   if(getStatus != 0) warn(s"heartbeat to gateway $serverUrl failed! message: $getMessage.")
   override val isHealthy: Boolean = getData.get("isHealthy") match {
     case b: java.lang.Boolean => b

--- a/ujes/entrance/src/main/scala/com/webank/wedatasphere/linkis/entrance/interceptor/impl/CommentInterceptor.scala
+++ b/ujes/entrance/src/main/scala/com/webank/wedatasphere/linkis/entrance/interceptor/impl/CommentInterceptor.scala
@@ -47,6 +47,7 @@ class CommentInterceptor extends EntranceInterceptor {
       case "sql" | "hql"  => requestPersistTask.setExecutionCode(SQLCommentHelper.dealComment(requestPersistTask.getExecutionCode))
       case "python" | "py" => requestPersistTask.setExecutionCode(PythonCommentHelper.dealComment(requestPersistTask.getExecutionCode))
       case "scala" | "java" => requestPersistTask.setExecutionCode(ScalaCommentHelper.dealComment(requestPersistTask.getExecutionCode))
+      case "sh" | "shell" =>
       case _ => requestPersistTask.setExecutionCode(SQLCommentHelper.dealComment(requestPersistTask.getExecutionCode))
     }
       requestPersistTask


### PR DESCRIPTION
httpcomponents-client 版本4.5.4，因为项目本身依赖该包，所以无需引入新的依赖。