### PR TITLE
1.if job is successful, errCode and errDesc need to be null

### DIFF
--- a/ujes/entrance/src/main/java/com/webank/wedatasphere/linkis/entrance/parser/AbstractEntranceParser.java
+++ b/ujes/entrance/src/main/java/com/webank/wedatasphere/linkis/entrance/parser/AbstractEntranceParser.java
@@ -75,6 +75,11 @@ public abstract class AbstractEntranceParser extends EntranceParser {
                 && StringUtils.isNotEmpty(job.getErrorResponse().message())) {
                 ((RequestPersistTask) task).setErrDesc(job.getErrorResponse().message());
             }
+            //if job is successful, errCode and errDesc needs to be null
+            if (job.isSucceed()){
+                ((RequestPersistTask) task).setErrCode(null);
+                ((RequestPersistTask) task).setErrDesc(null);
+            }
         }else{
             logger.warn("not supported task type");
         }


### PR DESCRIPTION
close issue #327 
if job is successful, errCode and errDesc need to be null