### PR TITLE
Python Engine BML zip file support

### DIFF
--- a/bml/bml-engine-hook/src/main/scala/com/webank/wedatasphere/linkis/bml/conf/BmlHookConf.scala
+++ b/bml/bml-engine-hook/src/main/scala/com/webank/wedatasphere/linkis/bml/conf/BmlHookConf.scala
@@ -1,5 +1,6 @@
 package com.webank.wedatasphere.linkis.bml.conf
 
+import com.webank.wedatasphere.linkis.bml.utils.BmlHookUtils
 import com.webank.wedatasphere.linkis.common.conf.CommonVars
 
 /**
@@ -7,5 +8,5 @@ import com.webank.wedatasphere.linkis.common.conf.CommonVars
   * Description:
   */
 object BmlHookConf {
-  val WORK_DIR_STR = CommonVars("wds.linkis.bml.work.dir", "user.dir")
+  val WORK_DIR_STR = CommonVars("wds.linkis.bml.work.dir", BmlHookUtils.getCurrentWorkDir)
 }

--- a/bml/bml-engine-hook/src/main/scala/com/webank/wedatasphere/linkis/bml/hook/BmlEnginePreExecuteHook.scala
+++ b/bml/bml-engine-hook/src/main/scala/com/webank/wedatasphere/linkis/bml/hook/BmlEnginePreExecuteHook.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.util
 
 import com.webank.wedatasphere.linkis.bml.client.{BmlClient, BmlClientFactory}
+import com.webank.wedatasphere.linkis.bml.conf.BmlHookConf
 import com.webank.wedatasphere.linkis.bml.exception.BmlHookDownloadException
 import com.webank.wedatasphere.linkis.bml.utils.BmlHookUtils
 import com.webank.wedatasphere.linkis.common.exception.ErrorException
@@ -42,12 +43,13 @@ class BmlEnginePreExecuteHook extends EnginePreExecuteHook with Logging{
   val pathType:String = "file://"
 
   override def callPreExecuteHook(engineExecutorContext: EngineExecutorContext, executeRequest: ExecuteRequest, code: String): String = {
-    val workDir = BmlHookUtils.getCurrentWorkDir
+    val workDir = BmlHookConf.WORK_DIR_STR.getValue
     val jobId = engineExecutorContext.getJobId
+    var hookCode = code
     executeRequest match {
       case resourceExecuteRequest:ResourceExecuteRequest => val resources = resourceExecuteRequest.resources
-        if (null == resources) return code
-        resources foreach {
+        if (null == resources) return hookCode
+        val resourcePaths = resources map {
           case resource:util.Map[String, Object] => val fileName = resource.get(FILE_NAME_STR).toString
             val resourceId = resource.get(RESOURCE_ID_STR).toString
             val version = resource.get(VERSION_STR).toString
@@ -65,13 +67,23 @@ class BmlEnginePreExecuteHook extends EnginePreExecuteHook with Logging{
             }
             if (response.isSuccess){
               logger.info(s"for job $jobId resourceId $resourceId version $version download to path $fullPath ok")
+              fullPath
             }else{
               logger.warn(s"for job $jobId resourceId $resourceId version $version download to path $fullPath Failed")
+              null
             }
-          case _ => logger.warn("job resource cannot download")
+          case _ =>
+            logger.warn("job resource cannot download")
+            null
         }
+        hookCode = if (StringUtils.isNotBlank(hookCode)) hookCode else executeRequest.code
+        hookCode = callResourcesDownloadedHook(resourcePaths.toArray, engineExecutorContext, executeRequest, hookCode)
       case _ =>
     }
-    if (StringUtils.isNotBlank(code)) code else executeRequest.code
+    if (StringUtils.isNotBlank(hookCode)) hookCode else executeRequest.code
+  }
+
+  def callResourcesDownloadedHook(resourcePaths: Array[String], engineExecutorContext: EngineExecutorContext, executeRequest: ExecuteRequest, code: String): String = {
+    code
   }
 }

--- a/bml/bml-engine-hook/src/main/scala/com/webank/wedatasphere/linkis/bml/utils/BmlHookUtils.scala
+++ b/bml/bml-engine-hook/src/main/scala/com/webank/wedatasphere/linkis/bml/utils/BmlHookUtils.scala
@@ -1,7 +1,5 @@
 package com.webank.wedatasphere.linkis.bml.utils
 
-import com.webank.wedatasphere.linkis.common.utils.Utils
-
 /**
   * created by cooperyang on 2019/9/24
   * Description:

--- a/ujes/definedEngines/python/engine/src/main/scala/com/webank/wedatasphere/linkis/engine/hook/PythonBmlEnginePreExecuteHook.scala
+++ b/ujes/definedEngines/python/engine/src/main/scala/com/webank/wedatasphere/linkis/engine/hook/PythonBmlEnginePreExecuteHook.scala
@@ -1,0 +1,13 @@
+package com.webank.wedatasphere.linkis.engine.hook
+
+import com.webank.wedatasphere.linkis.bml.hook.BmlEnginePreExecuteHook
+import com.webank.wedatasphere.linkis.common.io.FsPath
+import com.webank.wedatasphere.linkis.engine.execute.EngineExecutorContext
+import com.webank.wedatasphere.linkis.scheduler.executer.ExecuteRequest
+
+class PythonBmlEnginePreExecuteHook extends BmlEnginePreExecuteHook {
+  override def callResourcesDownloadedHook(resourcePaths: Array[String], engineExecutorContext: EngineExecutorContext,
+                                           executeRequest: ExecuteRequest, code: String): String = {
+    (resourcePaths.map(path => s"sys.path.insert(0, '${new FsPath(path).getPath}')") ++ Array(code)).mkString("\n")
+  }
+}

--- a/ujes/definedEngines/python/enginemanager/src/main/resources/linkis-engine.properties
+++ b/ujes/definedEngines/python/enginemanager/src/main/resources/linkis-engine.properties
@@ -22,3 +22,4 @@ wds.linkis.server.component.exclude.classes=com.webank.wedatasphere.linkis.resou
 python.script=python
 #hadoop.config.dir=/appcom/config/hadoop-config
 wds.linkis.server.version=v1
+wds.linkis.engine.pre.hook.class=com.webank.wedatasphere.linkis.engine.hook.PythonBmlEnginePreExecuteHook


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When we use python engine, we want to add a series of user own defined classes and functions in our own python *.py files, but there is no way to add it to the python engine now.

我们在使用Pyhton引擎时，想要使用自定义的一系列自定义的类和函数（定义在一系列*.py文件中），但是现在的Python引擎无法满足该需求。

**Describe the solution you'd like**
We have solved the problem. Python engine can import bml resources like zip files which contain *.py files， and the bml resources are defined in "entrance/execute" interface params.configuration.runtime.resources, the struct is "[{'resourceId': ***, 'version': ***, 'filename': ***}]", when the python engine starts to execute some code, it will download the zip resources from bml service and import them into the python environment.

当前，我们已经解决了该问题。我们在"entrance/execute"接口中定义了一个参数"params.configuration.runtime.resources"，参数值为一个bml资源数组，结构为"[{'resourceId': ***, 'version': ***, 'filename': ***}]"，当Python引擎开始执行一段代码之前，将从BML服务下载对应的资源文件，并将它们导入Python环境中，从而实现使用自定义类和函数的功能。

**Describe alternatives you've considered**
None

**Additional context**
None