### PR TITLE
Solve the problem that javafx cannot be found during compilation

### DIFF
--- a/core/cloudProtocol/src/main/scala/com/webank/wedatasphere/linkis/protocol/utils/ZuulEntranceUtils.scala
+++ b/core/cloudProtocol/src/main/scala/com/webank/wedatasphere/linkis/protocol/utils/ZuulEntranceUtils.scala
@@ -16,8 +16,6 @@
 
 package com.webank.wedatasphere.linkis.protocol.utils
 
-import javafx.beans.binding.LongExpression
-
 /**
   * created by enjoyyin on 2018/11/8
   * Description:


### PR DESCRIPTION
`import javafx.beans.binding.LongExpression`

remove unused import statement