### PR TITLE
第三方系统集成linkis，Token认证方式，Token校验Bug

### DIFF
--- a/gateway/core/src/main/scala/com/webank/wedatasphere/linkis/gateway/security/token/TokenAuthentication.scala
+++ b/gateway/core/src/main/scala/com/webank/wedatasphere/linkis/gateway/security/token/TokenAuthentication.scala
@@ -73,11 +73,19 @@ object TokenAuthentication extends Logging {
       SecurityFilter.filterResponse(gatewayContext, message)
       return false
     }
-    var token = gatewayContext.getRequest.getHeaders.get(TOKEN_KEY)(0)
-    var tokenUser = gatewayContext.getRequest.getHeaders.get(TOKEN_USER_KEY)(0)
+    var token = "";
+    var tokenUser = "";
+    val requestHeaders = gatewayContext.getRequest.getHeaders
+    if (requestHeaders.containsKey(TOKEN_KEY) && requestHeaders.containsKey(TOKEN_USER_KEY)) {
+      token = requestHeaders.get(TOKEN_KEY)(0)
+      tokenUser = requestHeaders.get(TOKEN_USER_KEY)(0)
+    }
     if(StringUtils.isBlank(token) || StringUtils.isBlank(tokenUser)) {
-      token = gatewayContext.getRequest.getCookies.get(TOKEN_KEY)(0).getValue
-      tokenUser = gatewayContext.getRequest.getCookies.get(TOKEN_USER_KEY)(0).getValue
+      val cookies = gatewayContext.getRequest.getCookies
+      if (cookies.containsKey(TOKEN_KEY) && cookies.containsKey(TOKEN_USER_KEY)) {
+        token = cookies.get(TOKEN_KEY)(0).getValue
+        tokenUser = cookies.get(TOKEN_USER_KEY)(0).getValue
+      }
       if(StringUtils.isBlank(token) || StringUtils.isBlank(tokenUser)) {
         val message = Message.noLogin(s"请在Header或Cookie中同时指定$TOKEN_KEY 和 $TOKEN_USER_KEY，以便完成token认证！") << gatewayContext.getRequest.getRequestURI
         SecurityFilter.filterResponse(gatewayContext, message)


### PR DESCRIPTION
**error code class:package com.webank.wedatasphere.linkis.gateway.security.token.TokenAuthentication**

![image](https://user-images.githubusercontent.com/30142780/102474372-845d2880-4093-11eb-8456-c921aa8a015a.png)

```
def tokenAuth(gatewayContext: GatewayContext): Boolean = {
    。。。
    var token = gatewayContext.getRequest.getHeaders.get(TOKEN_KEY)(0)
    var tokenUser = gatewayContext.getRequest.getHeaders.get(TOKEN_USER_KEY)(0)
    if(StringUtils.isBlank(token) || StringUtils.isBlank(tokenUser)) {
      token = gatewayContext.getRequest.getCookies.get(TOKEN_KEY)(0).getValue
      tokenUser = gatewayContext.getRequest.getCookies.get(TOKEN_USER_KEY)(0).getValue
      if(StringUtils.isBlank(token) || StringUtils.isBlank(tokenUser)) {
        val message = Message.noLogin(s"请在Header或Cookie中同时指定$TOKEN_KEY 和 $TOKEN_USER_KEY，以便完成token认证！") << gatewayContext.getRequest.getRequestURI
        SecurityFilter.filterResponse(gatewayContext, message)
        return false
      }
    }
    。。。
  }