### PR TITLE
Enhance EngineManager, newly defines and implements EngineConnManager module

### DIFF
--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-linux-launch/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-linux-launch/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-linux-launch</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-manager-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-linux-launch/src/main/scala/com/webank/wedatasphere/linkis/ecm/linux/launch/LinuxProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-linux-launch/src/main/scala/com/webank/wedatasphere/linkis/ecm/linux/launch/LinuxProcessEngineConnLaunch.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.linux.launch
+
+import com.webank.wedatasphere.linkis.ecm.core.launch.ProcessEngineConnLaunch
+
+
+
+class LinuxProcessEngineConnLaunch extends ProcessEngineConnLaunch {
+
+  override protected def execFile: Array[String] = Array("sh", getPreparedExecFile)
+
+  override protected def sudoCommand(user: String, command: String): Array[String] =
+    Array("sudo", "su", "-", user, "-c", command)
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-manager-core</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-computation-governance-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <!--todo 依赖关系修改-->
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/engineconn/EngineConn.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/engineconn/EngineConn.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.engineconn
+
+import java.io.Closeable
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.ecm.core.launch.{EngineConnLaunchRunner, EngineConnManagerEnv}
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnCreationDesc
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait EngineConn extends Closeable {
+
+  def getTickedId: String
+
+  def setTickedId(tickedId: String)
+
+  def getServiceInstance: ServiceInstance
+
+  def setServiceInstance(serviceInstance: ServiceInstance): Unit
+
+  def getResource: NodeResource
+
+  def setResource(resource: NodeResource): Unit
+
+  def getLabels: util.List[Label[_]]
+
+  def setLabels(labels: util.List[Label[_]]): Unit
+
+  def getStatus: NodeStatus
+
+  def setStatus(status: NodeStatus): Unit
+
+  def getCreationDesc: EngineConnCreationDesc
+
+  def setCreationDesc(desc: EngineConnCreationDesc): Unit
+
+  def getEngineConnInfo: EngineConnInfo
+
+  def setEngineConnInfo(engineConnInfo: EngineConnInfo): Unit
+
+  def getEngineConnManagerEnv: EngineConnManagerEnv
+
+  def setEngineConnManagerEnv(env: EngineConnManagerEnv): Unit
+
+  def getEngineConnLaunchRunner: EngineConnLaunchRunner
+
+  def setEngineConnLaunchRunner(runner: EngineConnLaunchRunner): Unit
+
+  def setPid(pid: String): Unit
+
+  def getPid: String
+
+  override def close(): Unit = {}
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/engineconn/EngineConnInfo.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/engineconn/EngineConnInfo.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.engineconn
+
+
+class EngineConnInfo {
+
+  private var errorCode: Int = 0
+  private var errorMsg: String = _
+
+  def setErrorCode(errorCode: Int): Unit = this.errorCode = errorCode
+
+  def getErrorCode: Int = errorCode
+
+  def setErrorMsg(errorMsg: String): Unit = this.errorMsg = errorMsg
+
+  def getErrorMsg: String = errorMsg
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/engineconn/YarnEngineConn.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/engineconn/YarnEngineConn.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.engineconn
+
+
+trait YarnEngineConn extends EngineConn {
+
+  def getApplicationId: String
+
+  def setApplicationId(applicationId: String): Unit
+
+  def getApplicationURL: String
+
+  def setApplicationURL(applicationURL: String): Unit
+
+  def getYarnMode: String
+
+  def setYarnMode(yarnMode: String): Unit
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/DiscoveryMsgGenerator.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/DiscoveryMsgGenerator.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+
+trait DiscoveryMsgGenerator {
+
+  def generate(engineConnManagerEnv: EngineConnManagerEnv): java.util.Map[String, String]
+
+}
+
+class EurekaDiscoveryMsgGenerator extends DiscoveryMsgGenerator {
+  override def generate(engineConnManagerEnv: EngineConnManagerEnv): util.Map[String, String] =
+    engineConnManagerEnv.properties.get("eureka.client.serviceUrl.defaultZone")
+      .map(v => Map("eureka.client.serviceUrl.defaultZone" -> v)).getOrElse[Map[String,String]](Map.empty)
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/EngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/EngineConnLaunch.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
+
+
+
+trait EngineConnLaunch {
+
+  def setEngineConnLaunchRequest(request: EngineConnLaunchRequest): Unit
+
+  def setEngineConnManagerEnv(engineConnManagerEnv: EngineConnManagerEnv): Unit
+
+  def launch(): Unit
+
+  def kill(): Unit
+
+  def isAlive: Boolean
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/EngineConnLaunchRunner.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/EngineConnLaunchRunner.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+
+trait EngineConnLaunchRunner extends Runnable {
+
+  /**
+   *
+   * @param launch
+   */
+  def setEngineConnLaunch(launch: EngineConnLaunch): Unit
+
+  def getEngineConnLaunch: EngineConnLaunch
+
+  def stop(): Unit
+
+}
+class EngineConnLaunchRunnerImpl extends EngineConnLaunchRunner {
+
+  private var launch: EngineConnLaunch = _
+  /**
+    *
+    * @param launch
+    */
+  override def setEngineConnLaunch(launch: EngineConnLaunch): Unit = this.launch = launch
+
+  override def getEngineConnLaunch: EngineConnLaunch = launch
+
+  override def stop(): Unit = launch.kill()
+
+  override def run(): Unit = {
+    launch.launch()
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/EngineConnManagerEnv.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/EngineConnManagerEnv.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+
+trait EngineConnManagerEnv {
+
+  val engineConnManagerHomeDir: String
+  val engineConnWorkDir: String
+  val engineConnLogDirs: String
+  val engineConnTempDirs: String
+  val engineConnManagerHost: String
+  val engineConnManagerPort: String
+  val linkDirs: Map[String, String]
+  val properties: Map[String, String]
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineCommandBuilder.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineCommandBuilder.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+import java.io.OutputStream
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.LaunchConstants
+import org.apache.commons.io.IOUtils
+
+
+trait ProcessEngineCommandBuilder {
+
+  def setCommand(command: Array[String]): Unit
+
+  def setEnv(key: String, value: String): Unit
+
+  def newLine(command: Array[String])
+
+  def link(fromPath: String, toPath: String)
+
+  def mkdir(dir: String): Unit
+
+  def writeTo(output: OutputStream): Unit
+
+  def replaceExpansionMarker(value: String): String
+
+}
+
+abstract class ShellProcessEngineCommandBuilder extends ProcessEngineCommandBuilder {
+
+  private val LINE_SEPARATOR = System.getProperty("line.separator")
+  private val sb = new StringBuilder
+
+  def newLine(command: String): Unit = newLine(Array(command))
+
+  override def newLine(command: Array[String]): Unit = {
+    command.foreach(sb ++= _)
+    sb ++= LINE_SEPARATOR
+  }
+
+  def writeTo(output: OutputStream): Unit = {
+    IOUtils.write(sb, output)
+  }
+
+  override def replaceExpansionMarker(value: String): String = value.replaceAll(LaunchConstants.EXPANSION_MARKER_LEFT, "\\${")
+    .replaceAll(LaunchConstants.EXPANSION_MARKER_RIGHT, "}")
+}
+
+class UnixProcessEngineCommandBuilder extends ShellProcessEngineCommandBuilder {
+
+  newLine("#!/bin/bash")
+
+  private def addErrorCheck(): Unit = {
+    newLine("linkis_engineconn_errorcode=$?")
+    newLine("if [ $linkis_engineconn_errorcode -ne 0 ]")
+    newLine("then")
+    newLine("  exit $linkis_engineconn_errorcode")
+    newLine("fi")
+  }
+
+  override def setCommand(command: Array[String]): Unit = {
+    newLine(Array(s"exec /bin/bash -c ${"\""}${command.mkString(" ")}${"\""}"))
+    addErrorCheck()
+  }
+
+  override def setEnv(key: String, value: String): Unit = newLine(Array("export ", key, "=\"", value, "\""))
+
+  override def link(fromPath: String, toPath: String): Unit = {
+    newLine(Array("ln -sf \"", fromPath, "\" \"", toPath, "\""))
+    addErrorCheck()
+  }
+
+  override def mkdir(dir: String): Unit = {
+    newLine(Array("mkdir -p ", dir))
+    addErrorCheck()
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineCommandExec.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineCommandExec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+import java.io.File
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+
+
+trait ProcessEngineCommandExec {
+
+  def execute(): Unit
+
+  def getProcess: Process
+
+}
+
+class ShellProcessEngineCommandExec(command: Array[String], baseDir: String,
+                                    environment: util.Map[String, String], timeout: Long) extends
+  ProcessEngineCommandExec with Logging {
+
+  private var process: Process = _
+
+  def this(command: Array[String], baseDir: String) = this(command, baseDir, null, 0)
+
+  def this(command: Array[String]) = this(command, null)
+
+  override def execute(): Unit = {
+
+    info(s"Invoke subProcess, base dir ${this.baseDir} cmd is: ${command.mkString}")
+    val builder = new ProcessBuilder(command: _*)
+    if (environment != null) builder.environment.putAll(this.environment)
+    if (baseDir != null) builder.directory(new File(this.baseDir))
+    builder.redirectErrorStream(true)
+    process = builder.start
+  }
+
+  override def getProcess: Process = process
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.launch
+
+import java.io.{File, InputStream, OutputStream}
+import java.net.ServerSocket
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+import com.webank.wedatasphere.linkis.governance.common.utils.{EngineConnArgumentsBuilder, EngineConnArgumentsParser}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EnvConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.Environment._
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.LaunchConstants._
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.{Environment, ProcessEngineConnLaunchRequest}
+import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.commons.lang.StringUtils
+
+import scala.collection.JavaConversions._
+
+
+trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
+
+  private var request: ProcessEngineConnLaunchRequest = _
+  private var engineConnManagerEnv: EngineConnManagerEnv = _
+  private var discoveryMsgGenerator: DiscoveryMsgGenerator = _
+  private var processBuilder: ProcessEngineCommandBuilder = _
+  private var preparedExecFile: String = _
+  private var process: Process = _
+
+  private var engineConnPort: String = _
+
+  protected def newProcessEngineConnCommandBuilder(): ProcessEngineCommandBuilder = new UnixProcessEngineCommandBuilder
+
+  protected def newProcessEngineConnCommandExec(command: Array[String], workDir: String): ProcessEngineCommandExec =
+    new ShellProcessEngineCommandExec(command, workDir)
+
+  override def setEngineConnLaunchRequest(request: EngineConnLaunchRequest): Unit = request match {
+    case processEngineConnLaunchRequest: ProcessEngineConnLaunchRequest =>
+      this.request = processEngineConnLaunchRequest
+    case _ => //TODO exception
+  }
+
+  override def setEngineConnManagerEnv(engineConnManagerEnv: EngineConnManagerEnv): Unit = this.engineConnManagerEnv = engineConnManagerEnv
+
+  def setDiscoveryMsgGenerator(discoveryMsgGenerator: DiscoveryMsgGenerator): Unit = this.discoveryMsgGenerator = discoveryMsgGenerator
+
+  def getEngineConnLaunchRequest: EngineConnLaunchRequest = request
+
+  private def initializeEnv(): Unit = {
+    val environment = request.environment
+    def putIfExists(enum: Environment): Unit = {
+      val key = enum.toString
+      val conf = CommonVars.apply(key, "")
+      if(StringUtils.isNotBlank(conf.getValue)) environment.put(key, conf.getValue)
+    }
+    Environment.values foreach {
+      case USER => environment.put(USER.toString, request.user)
+      case ECM_HOME => environment.put(ECM_HOME.toString, engineConnManagerEnv.engineConnManagerHomeDir)
+      case PWD => environment.put(PWD.toString, engineConnManagerEnv.engineConnWorkDir)
+      case LOG_DIRS => environment.put(LOG_DIRS.toString, engineConnManagerEnv.engineConnLogDirs)
+      case TEMP_DIRS => environment.put(TEMP_DIRS.toString, engineConnManagerEnv.engineConnTempDirs)
+      case ECM_HOST => environment.put(ECM_HOST.toString, engineConnManagerEnv.engineConnManagerHost)
+      case ECM_PORT => environment.put(ECM_PORT.toString, engineConnManagerEnv.engineConnManagerPort)
+      case HADOOP_HOME => putIfExists(HADOOP_HOME)
+      case HADOOP_CONF_DIR => putIfExists(HADOOP_CONF_DIR)
+      case HIVE_CONF_DIR => putIfExists(HIVE_CONF_DIR)
+      case RANDOM_PORT => environment.put(RANDOM_PORT.toString, findAvailPort().toString)
+      case _ =>
+    }
+  }
+
+  private def findAvailPort(): Int = {
+    val socket = new ServerSocket(0)
+    Utils.tryFinally(socket.getLocalPort)(IOUtils.closeQuietly(socket))
+  }
+
+  private def addAvailPort(value: String): String = {
+    var existsRandomPort = value.contains(CLASS_PATH_SEPARATOR)
+    var newValue = value
+    while(existsRandomPort) {
+      newValue = value.replaceFirst(CLASS_PATH_SEPARATOR, findAvailPort().toString)
+      existsRandomPort = value.contains(CLASS_PATH_SEPARATOR)
+    }
+    newValue
+  }
+
+  override def launch(): Unit = {
+    request.necessaryEnvironments.foreach{e =>
+      val env = CommonVars(e, "")
+      if(StringUtils.isEmpty(env.getValue))
+        throw new ErrorException(30000, s"Necessary environment $e is not exists!(必须的环境变量 $e 不存在！)") //TODO exception
+      else request.environment.put(e, env.getValue)
+    }
+    prepareCommand()
+    val exec = newProcessEngineConnCommandExec(sudoCommand(request.user, execFile.mkString(" ")), engineConnManagerEnv.engineConnWorkDir)
+    exec.execute()
+    process = exec.getProcess
+  }
+
+  protected def execFile: Array[String]
+
+  def getEngineConnPort: String = engineConnPort
+
+  protected def getCommandArgs: Array[String] = {
+    if (request.creationDesc.properties.exists { case (k, v) => k.contains(" ") || (v != null && v.contains(" ")) })
+      throw new ErrorException(30000, "Startup parameters contain spaces!(启动参数中包含空格！)") //TODO exception
+    val arguments = EngineConnArgumentsBuilder.newBuilder()
+    engineConnPort = findAvailPort().toString
+    var springConf = Map("spring.application.name" -> GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue,
+      "server.port" -> engineConnPort, "spring.profiles.active" -> "engineconn",
+      "logging.config" -> s"classpath:${EnvConfiguration.LOG4J2_XML_FILE.getValue}") ++: discoveryMsgGenerator.generate(engineConnManagerEnv)
+    request.creationDesc.properties.filter(_._1.startsWith("spring.")).foreach { case (k, v) =>
+      springConf = springConf += (k -> v)
+    }
+    arguments.addSpringConf(springConf.toMap)
+    var engineConnConf = Map("ticketId" -> request.ticketId, "user" -> request.user)
+    engineConnConf = engineConnConf ++: request.labels.map(l => EngineConnArgumentsParser.LABEL_PREFIX + l.getLabelKey -> l.getStringValue).toMap
+    engineConnConf = engineConnConf ++: request.creationDesc.properties.filterNot(_._1.startsWith("spring.")).toMap
+    arguments.addEngineConnConf(engineConnConf)
+    EngineConnArgumentsParser.getEngineConnArgumentsParser.parseToArgs(arguments.build())
+  }
+
+  override def kill(): Unit = process.destroy()
+
+  override def isAlive: Boolean = process.isAlive
+
+  protected def prepareCommand(): Unit = {
+    processBuilder = newProcessEngineConnCommandBuilder()
+    engineConnManagerEnv.linkDirs.foreach{case (k, v) => processBuilder.link(k, v)}
+    initializeEnv()
+    request.environment.foreach{ case (k, v) =>
+      var value = v.replaceAll(CLASS_PATH_SEPARATOR, File.pathSeparator)
+      value = addAvailPort(value)
+      processBuilder.setEnv(k, processBuilder.replaceExpansionMarker(value))
+    }
+    val execCommand = request.commands.map(processBuilder.replaceExpansionMarker(_)).map(addAvailPort) ++ getCommandArgs
+    //execCommand = sudoCommand(request.user, execCommand.mkString(" "))
+    processBuilder.setCommand(execCommand)
+    preparedExecFile = new File(engineConnManagerEnv.engineConnWorkDir, "engineConnExec.sh").getPath
+    val output = getFileOutputStream
+    Utils.tryFinally(processBuilder.writeTo(output))(output.close())
+  }
+
+  protected def sudoCommand(user: String, command: String): Array[String]
+
+  protected def getFileOutputStream: OutputStream = FileUtils.openOutputStream(new File(preparedExecFile))
+
+  protected def getPreparedExecFile: String = preparedExecFile
+
+  def getProcessInputStream:InputStream = process.getInputStream
+
+  def processWaitFor:Int =process.waitFor
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMAsyncListenerBus.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMAsyncListenerBus.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.listener
+
+import com.webank.wedatasphere.linkis.common.listener.ListenerEventBus
+
+
+class ECMAsyncListenerBus(capacity: Int, name: String)
+                         (consumerThreadSize: Int, threadMaxFreeTime: Long)
+  extends ListenerEventBus[ECMEventListener, ECMEvent](capacity, name)(consumerThreadSize, threadMaxFreeTime) {
+  /**
+   * Post an event to the specified listener. `onPostEvent` is guaranteed to be called in the same
+   * thread for all listeners.
+   */
+  override protected def doPostEvent(listener: ECMEventListener, event: ECMEvent): Unit = listener.onEvent(event)
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMEvent.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.listener;
+
+import com.webank.wedatasphere.linkis.common.listener.Event;
+
+
+public interface ECMEvent extends Event {
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMEventListener.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMEventListener.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.listener
+
+import com.webank.wedatasphere.linkis.common.listener.{Event, EventListener}
+import com.webank.wedatasphere.linkis.common.utils.Logging
+
+
+trait ECMEventListener extends EventListener with Logging {
+
+  def onEvent(event: ECMEvent)
+
+  override def onEventError(event: Event, t: Throwable): Unit = {
+    error(s"async message invoke failed ${event.toString}", t)
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMSyncListenerBus.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/listener/ECMSyncListenerBus.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.listener
+
+import com.webank.wedatasphere.linkis.common.listener.ListenerBus
+
+class ECMSyncListenerBus extends ListenerBus[ECMEventListener, ECMEvent] {
+  /**
+   * Post an event to the specified listener. `onPostEvent` is guaranteed to be called in the same
+   * thread for all listeners.
+   */
+  override protected def doPostEvent(listener: ECMEventListener, event: ECMEvent): Unit = listener.onEvent(event)
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/metrics/ECMMetrics.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/metrics/ECMMetrics.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.metrics
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+
+
+
+trait ECMMetrics {
+
+  def getStartingEngineConns: Array[_ <: EngineConn]
+
+  def getRunningEngineConns: Array[EngineConn]
+
+  def getSucceedEngineConns: Array[EngineConn]
+
+  def getFailedEngineConns: Array[EngineConn]
+
+  def increaseStartingEngineConn(engineConn: EngineConn): Unit
+
+  def increaseRunningEngineConn(engineConn: EngineConn): Unit
+
+  def increaseSuccessEngineConn(engineConn: EngineConn): Unit
+
+  def increaseFailedEngineConn(engineConn: EngineConn): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/report/ECMHealthReport.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/report/ECMHealthReport.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.report
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.Resource
+
+
+trait ECMHealthReport extends NodeHealthReport {
+
+  def setProtectedResource(protectedResource: Resource): Unit
+
+  def getProtectResource: Resource
+
+  def setOverload(nodeOverLoadInfo: NodeOverLoadInfo): Unit
+
+  def getOverload: NodeOverLoadInfo
+
+  def setRunningEngineConns(runningEngines: Array[EngineConn])
+
+  def getRunningEngineConns: Array[EngineConn]
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/report/NodeHealthReport.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/report/NodeHealthReport.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.core.report
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.Resource
+
+
+trait NodeHealthReport {
+
+  def getReportTime: Long
+
+  def setReportTime(reportTime: Long): Unit
+
+  def getNodeStatus: NodeStatus
+
+  def setNodeStatus(nodeStatus: NodeStatus): Unit
+
+  def setNodeMsg(msg: String): Unit
+
+  def getNodeMsg: String
+
+  def getUsedResource: Resource
+
+  def setUsedResource(resource: Resource): Unit
+
+  def getTotalResource: Resource
+
+  def setTotalResource(resource: Resource): Unit
+
+  def setNodeId(nodeId: String): Unit
+
+  def getNodeId: String
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-manager-server</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-manager-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-linux-launch</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-bml-client</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-storage</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+            <version>${json4s.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                    <include>**/*.yml</include>
+                </includes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/assembly/distribution.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/assembly/distribution.xml
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-engineconn-manager</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>linkis-engineconn-manager</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <!--<fileSet>
+            <directory>${basedir}/bin</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>bin</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>-->
+        <!--<fileSet>
+            <directory>.</directory>
+            <excludes>
+                <exclude>*/**</exclude>
+            </excludes>
+            <outputDirectory>logs</outputDirectory>
+        </fileSet>-->
+    </fileSets>
+
+</assembly>
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/java/com/webank/wedatasphere/linkis/ecm/server/ECMApplication.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/java/com/webank/wedatasphere/linkis/ecm/server/ECMApplication.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server;
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication;
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.ecm.core.listener.ECMAsyncListenerBus;
+import com.webank.wedatasphere.linkis.ecm.core.listener.ECMSyncListenerBus;
+import com.webank.wedatasphere.linkis.ecm.server.context.ECMContext;
+import com.webank.wedatasphere.linkis.ecm.server.listener.ECMClosedEvent;
+import com.webank.wedatasphere.linkis.ecm.server.listener.ECMReadyEvent;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+
+import static com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration.ECM_ASYNC_BUS_WAITTOEMPTY_TIME;
+
+
+public class ECMApplication extends DataWorkCloudApplication {
+
+    private static ECMContext ecmContext;
+
+    private volatile static boolean ready;
+
+    private static ServiceInstance ecmServiceInstance;
+
+    private static String[] parmas;
+
+    public static void main(String[] args) throws ReflectiveOperationException {
+        parmas = args;
+        DataWorkCloudApplication.main(args);
+    }
+
+    public static ECMContext getContext() {
+        return ecmContext;
+    }
+
+    public static void setContext(ECMContext context) {
+        ecmContext = context;
+    }
+
+    public static ServiceInstance getECMServiceInstance() {
+        return ecmServiceInstance;
+    }
+
+    public static void setECMServiceInstance(ServiceInstance serviceInstance) {
+        ecmServiceInstance = serviceInstance;
+    }
+
+    public static boolean isReady() {
+        return ready;
+    }
+
+    public static void setReady(boolean applicationReady) {
+        ready = applicationReady;
+    }
+
+    public static String[] getParmas() {
+        return parmas;
+    }
+}
+
+
+@Configuration
+class ECMApplicationListener {
+
+    private final Log logger = LogFactory.getLog(this.getClass());
+
+    @EventListener
+    public void onApplicationReady(ApplicationReadyEvent event) {
+        ServiceInstance serviceInstance = DataWorkCloudApplication.getServiceInstance();
+        ECMApplication.setECMServiceInstance(serviceInstance);
+        ECMContext context = event.getApplicationContext().getBean(ECMContext.class);
+        ECMApplication.setContext(context);
+        ECMAsyncListenerBus emAsyncListenerBus = context.getECMAsyncListenerBus();
+        ECMSyncListenerBus emSyncListenerBus = context.getECMSyncListenerBus();
+        emAsyncListenerBus.start();
+        ECMReadyEvent ecmReadyEvent = new ECMReadyEvent(ECMApplication.getParmas());
+        emAsyncListenerBus.postToAll(ecmReadyEvent);
+        emSyncListenerBus.postToAll(ecmReadyEvent);
+        ECMApplication.setReady(true);
+        logger.info(String.format("ECM:%s is ready", serviceInstance));
+    }
+
+    @EventListener
+    public void onApplicationClosed(ContextClosedEvent contextClosedEvent) {
+        ServiceInstance serviceInstance = DataWorkCloudApplication.getServiceInstance();
+        ECMApplication.setReady(false);
+        ECMClosedEvent ecmClosedEvent = new ECMClosedEvent();
+        ECMApplication.getContext().getECMSyncListenerBus().postToAll(ecmClosedEvent);
+        ECMAsyncListenerBus ecmAsyncListenerBus = ECMApplication.getContext().getECMAsyncListenerBus();
+        ecmAsyncListenerBus.postToAll(ecmClosedEvent);
+        logger.info(String.format("wait ECM:%s asyncBus empty", serviceInstance));
+        try {
+            ecmAsyncListenerBus.waitUntilEmpty(ECM_ASYNC_BUS_WAITTOEMPTY_TIME());
+        } catch (Throwable e) {
+            logger.error("wait ECM asyncBus empty failed", e);
+        }
+        logger.info("ECM asyncBus is empty");
+        ecmAsyncListenerBus.stop();
+        logger.info("ECM is closed");
+    }
+
+}
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/resources/application.yml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+server:
+  port: 9102
+spring:
+  application:
+    name: linkis-cg-engineconnmanager
+
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://127.0.0.1:20303/eureka/
+  instance:
+    metadata-map:
+      test: wedatasphere
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh,info
+  health:
+    db:
+      enabled: false
+logging:
+  config: classpath:log4j2.xml
+
+ribbon:
+  ReadTimeout: 60000
+  ConnectTimeout: 60000

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/resources/linkis-server.properties
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/resources/linkis-server.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 WeBank
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##restful
+wds.linkis.server.restful.scan.packages=com.webank.wedatasphere.linkis.em.restful
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/resources/log4j2.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration status="error" monitorInterval="30">
+    <appenders>
+        <RollingFile name="RollingFile" fileName="${env:SERVER_LOG_PATH}/linkis.log"
+                     filePattern="${env:SERVER_LOG_PATH}/$${date:yyyy-MM}/linkis-log-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-40t] %c{1.} (%L) [%M] - %msg%xEx%n"/>
+            <SizeBasedTriggeringPolicy size="100MB"/>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <appender-ref ref="RollingFile"/>
+        </root>
+    </loggers>
+</configuration>
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/conf/ECMConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/conf/ECMConfiguration.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.conf
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+import com.webank.wedatasphere.linkis.common.utils.ByteTimeUtils
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+
+import scala.concurrent.duration.Duration
+
+
+object ECMConfiguration {
+
+  //listenerbus
+  val ECM_ASYNC_BUS_CAPACITY: Int = CommonVars("wds.linkis.ecm.async.bus.capacity", 500).getValue
+  val ECM_ASYNC_BUS_NAME: String = CommonVars("wds.linkis.ecm.async.bus.name", "em_async_bus").getValue
+  val ECM_ASYNC_BUS_CONSUMER_SIZE: Int = CommonVars("wds.linkis.ecm.async.bus.consumer.size", 30).getValue
+  val ECM_ASYNC_BUS_THREAD_MAX_FREE_TIME: Long = CommonVars("wds.linkis.ecm.async.bus.max.free.time", ByteTimeUtils.timeStringAsMs("2m")).getValue
+  val ECM_ASYNC_BUS_WAITTOEMPTY_TIME: Long = CommonVars("wds.linkis.ecm.async.bus.waittoempty.time", 5000L).getValue
+
+  //resource
+  val ECM_MAX_MEMORY_AVAILABLE: Long = CommonVars[Long]("wds.linkis.ecm.memory.max", ByteTimeUtils.byteStringAsBytes("80g")).getValue
+  val ECM_MAX_CORES_AVAILABLE: Int = CommonVars[Integer]("wds.linkis.ecm.cores.max", 50).getValue
+  val ECM_MAX_CREATE_INSTANCES: Int = CommonVars[Integer]("wds.linkis.ecm.engineconn.instances.max", 50).getValue
+
+  val ECM_PROTECTED_MEMORY: Long = CommonVars[Long]("wds.linkis.ecm.protected.memory", ByteTimeUtils.byteStringAsBytes("4g")).getValue
+  val ECM_PROTECTED_CORES: Int = CommonVars[Integer]("wds.linkis.ecm.protected.cores.max", 2).getValue
+  val ECM_PROTECTED_INSTANCES: Int = CommonVars[Integer]("wds.linkis.ecm.protected.engine.instances", 2).getValue
+
+  val MANAGER_SPRING_NAME: String = GovernanceCommonConf.MANAGER_SPRING_NAME.getValue
+
+  val ENGINE_CONN_MANAGER_SPRING_NAME: String = GovernanceCommonConf.ENGINE_CONN_MANAGER_SPRING_NAME.getValue
+
+  val ECM_HEALTH_REPORT_PERIOD: Long = CommonVars("wds.linkis.ecm.health.report.period", 5).getValue
+
+  val ECM_HEALTH_REPORT_DELAY: Long = CommonVars("wds.linkis.ecm.health.report.delay", 10).getValue
+
+  val ENGINECONN_SPRING_NAME: String = CommonVars("wds.linkis.engineconn.spring.name", "linkis-cg-engineplugin").getValue
+
+  val ECM_HOME_DIR: String = CommonVars("wds.linkis.ecm.home.dir", this.getClass.getResource("/").getPath).getValue
+
+  val ENGINECONN_ROOT_DIR: String = CommonVars("wds.linkis.engineconn.root.dir", s"${ECM_HOME_DIR}engineConnRootDir").getValue
+
+  val ENGINECONN_PUBLIC_DIR: String = CommonVars("wds.linkis.engineconn.public.dir", s"$ENGINECONN_ROOT_DIR${File.separator}engineConnPublickDir").getValue
+
+  val ECM_LAUNCH_MAX_THREAD_SIZE: Int = CommonVars("wds.linkis.ecm.launch.max.thread.size", 100).getValue
+
+  val ECM_EUREKA_DEFAULTZONE: String = CommonVars("wds.linkis.eureka.defaultZone", "http://127.0.0.1:20303/eureka/").getValue
+
+  /**
+    * engineconn创建时间，如果为0，则使用ms中默认的
+    */
+  val ENGINECONN_CREATE_DURATION: Duration = Duration(CommonVars("wds.linkis.ecm.engineconn.create.duration", 0).getValue, TimeUnit.MILLISECONDS)
+
+  val WAIT_ENGINECONN_PID = CommonVars("wds.linkis.engineconn.wait.callback.pid", new TimeType("3s"))
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/context/DefaultECMContext.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/context/DefaultECMContext.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.context
+
+import com.webank.wedatasphere.linkis.ecm.core.listener.{ECMAsyncListenerBus, ECMSyncListenerBus}
+import com.webank.wedatasphere.linkis.ecm.core.metrics.ECMMetrics
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration._
+import com.webank.wedatasphere.linkis.ecm.server.metrics.DefaultECMMetrics
+import org.springframework.stereotype.Component
+
+
+@Component
+class DefaultECMContext extends ECMContext {
+
+  private val emSyncListenerBus = new ECMSyncListenerBus
+
+  private val emAsyncListenerBus = new ECMAsyncListenerBus(ECM_ASYNC_BUS_CAPACITY, ECM_ASYNC_BUS_NAME)(ECM_ASYNC_BUS_CONSUMER_SIZE, ECM_ASYNC_BUS_THREAD_MAX_FREE_TIME)
+
+  private val metrics = new DefaultECMMetrics
+
+
+  override def getECMAsyncListenerBus: ECMAsyncListenerBus = emAsyncListenerBus
+
+  override def getECMSyncListenerBus: ECMSyncListenerBus = emSyncListenerBus
+
+  override def getECMMetrics: ECMMetrics = metrics
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/context/ECMContext.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/context/ECMContext.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.context
+
+import com.webank.wedatasphere.linkis.ecm.core.listener.{ECMAsyncListenerBus, ECMSyncListenerBus}
+import com.webank.wedatasphere.linkis.ecm.core.metrics.ECMMetrics
+
+
+trait ECMContext {
+
+  def getECMAsyncListenerBus: ECMAsyncListenerBus
+
+  def getECMSyncListenerBus: ECMSyncListenerBus
+
+  def getECMMetrics:ECMMetrics
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/converter/ECMEngineConverter.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/converter/ECMEngineConverter.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.converter
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.{EngineConn, YarnEngineConn}
+import com.webank.wedatasphere.linkis.ecm.server.engineConn.DefaultYarnEngineConn
+import org.springframework.beans.BeanUtils
+
+
+object ECMEngineConverter {
+
+  def engineConn2YarnEngineConn(engineConn: EngineConn)(implicit updateFunction: YarnEngineConn => Unit): YarnEngineConn = {
+    val conn = new DefaultYarnEngineConn
+    BeanUtils.copyProperties(engineConn, conn)
+    updateFunction(conn)
+    conn
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/engineConn/DefaultEngineConn.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/engineConn/DefaultEngineConn.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.engineConn
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.{EngineConn, EngineConnInfo}
+import com.webank.wedatasphere.linkis.ecm.core.launch.{EngineConnLaunchRunner, EngineConnManagerEnv}
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnCreationDesc
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+class DefaultEngineConn extends EngineConn {
+
+  /**
+   * starting :初始状态
+   * success:成功启动并且安全退出
+   * Failed：启动失败
+   * Running：容器运行中
+   */
+  @volatile private var status: NodeStatus = _
+
+  private var tickedId: String = _
+
+  private var resource: NodeResource = _
+
+  private var labels: util.List[Label[_]] = _
+
+  private var engineConnCreationDesc: EngineConnCreationDesc = _
+
+  private var engineConnInfo: EngineConnInfo = _
+
+  private var ecmEnv: EngineConnManagerEnv = _
+
+  private var engineConnLaunchRunner: EngineConnLaunchRunner = _
+
+  private var instance: ServiceInstance = _
+
+  private var pid: String = _
+
+  override def getResource: NodeResource = resource
+
+  override def setResource(resource: NodeResource): Unit = this.resource = resource
+
+  override def getLabels: util.List[Label[_]] = labels
+
+  override def setLabels(labels: util.List[Label[_]]): Unit = this.labels = labels
+
+  override def getStatus: NodeStatus = status
+
+  override def getCreationDesc: EngineConnCreationDesc = engineConnCreationDesc
+
+  override def getEngineConnInfo: EngineConnInfo = engineConnInfo
+
+  override def getEngineConnLaunchRunner: EngineConnLaunchRunner = engineConnLaunchRunner
+
+  override def setEngineConnLaunchRunner(runner: EngineConnLaunchRunner): Unit = this.engineConnLaunchRunner = runner
+
+  override def setEngineConnInfo(engineConnInfo: EngineConnInfo): Unit = this.engineConnInfo = engineConnInfo
+
+  override def getTickedId: String = tickedId
+
+  override def setTickedId(tickedId: String): Unit = this.tickedId = tickedId
+
+  override def setStatus(status: NodeStatus): Unit = this.status = status
+
+  override def setCreationDesc(engineConnCreationDesc: EngineConnCreationDesc): Unit = this.engineConnCreationDesc = engineConnCreationDesc
+
+  override def getServiceInstance: ServiceInstance = instance
+
+  override def setServiceInstance(instance: ServiceInstance): Unit = this.instance = instance
+
+  override def getPid: String = pid
+
+  override def setPid(pid: String): Unit = this.pid = pid
+
+  override def getEngineConnManagerEnv: EngineConnManagerEnv = ecmEnv
+
+  override def setEngineConnManagerEnv(env: EngineConnManagerEnv): Unit = this.ecmEnv = env
+
+  override def toString = s"DefaultEngineConn($status, $tickedId, $resource, $labels, $engineConnCreationDesc, $engineConnInfo, $ecmEnv, $engineConnLaunchRunner, $instance, $pid)"
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/engineConn/DefaultYarnEngineConn.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/engineConn/DefaultYarnEngineConn.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.engineConn
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.YarnEngineConn
+
+
+class DefaultYarnEngineConn extends DefaultEngineConn with YarnEngineConn {
+
+  var applicationId: String = _
+
+  var applicationURL: String = _
+
+  var yarnMode: String = _
+
+  override def getApplicationId: String = applicationId
+
+  override def setApplicationId(applicationId: String): Unit = this.applicationId = applicationId
+
+  override def getApplicationURL: String = applicationURL
+
+  override def setApplicationURL(applicationURL: String): Unit = this.applicationURL = applicationURL
+
+  override def getYarnMode: String = yarnMode
+
+  override def setYarnMode(yarnMode: String): Unit = this.yarnMode = yarnMode
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/exception/ECMErrorException.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/exception/ECMErrorException.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.exception
+
+import com.webank.wedatasphere.linkis.common.exception.{ErrorException, WarnException}
+
+
+class ECMErrorException(errorCode: Int, desc: String) extends ErrorException(errorCode, desc) {
+  def this(errorCode: Int, desc: String, t: Throwable) {
+    this(errorCode, desc)
+    this.initCause(t)
+  }
+}
+
+class ECMWarnException(errCode: Int, desc: String) extends WarnException(errCode, desc)
+
+
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/listener/ECMReadyEvent.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/listener/ECMReadyEvent.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.listener
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.ecm.core.listener.ECMEvent
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.ResponseEngineConnPid
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.protocol.callback.{YarnAPPIdCallbackProtocol, YarnInfoCallbackProtocol}
+
+
+case class ECMReadyEvent(params: Array[String]) extends ECMEvent
+
+case class ECMClosedEvent() extends ECMEvent
+
+case class EngineConnStatusChageEvent(from: NodeStatus, to: NodeStatus) extends ECMEvent
+
+case class YarnAppIdCallbackEvent(protocol: YarnAPPIdCallbackProtocol) extends ECMEvent
+
+case class YarnInfoCallbackEvent(protocol: YarnInfoCallbackProtocol) extends ECMEvent
+
+case class EngineConnPidCallbackEvent(protocol: ResponseEngineConnPid) extends ECMEvent
+
+case class EngineConnAddEvent(conn: EngineConn) extends ECMEvent
+
+case class EngineConnStatusChangeEvent(tickedId: String, updateStatus: NodeStatus) extends ECMEvent
+
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/metrics/DefaultECMMetrics.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/metrics/DefaultECMMetrics.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.metrics
+
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.ecm.core.metrics.ECMMetrics
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus._
+
+import scala.collection.JavaConversions._
+
+
+class DefaultECMMetrics extends ECMMetrics {
+
+
+  private val startingEngineConnCount = new AtomicInteger(0)
+
+  private val runningEngineConnCount = new AtomicInteger(0)
+
+  private val successEngineConnCount = new AtomicInteger(0)
+
+  private val failedEngineConnCount = new AtomicInteger(0)
+
+  private val startingEngineConnMap = new ConcurrentHashMap[String, EngineConn](64)
+
+  private val runningEngineConnMap = new ConcurrentHashMap[String, EngineConn](64)
+
+  private val successEngineConnMap = new ConcurrentHashMap[String, EngineConn](64)
+
+  private val failedEngineConnMap = new ConcurrentHashMap[String, EngineConn](64)
+
+  override def getStartingEngineConns: Array[EngineConn] = getEngineConns(startingEngineConnMap)
+
+  override def getRunningEngineConns: Array[EngineConn] = getEngineConns(runningEngineConnMap)
+
+  override def getSucceedEngineConns: Array[EngineConn] = getEngineConns(successEngineConnMap)
+
+  override def getFailedEngineConns: Array[EngineConn] = getEngineConns(failedEngineConnMap)
+
+  private val getEngineConns = (map: ConcurrentHashMap[String, EngineConn]) => map.values().toSeq.toArray
+
+  private val decreaseEngineConnMetric = (engineConn: EngineConn, map: ConcurrentHashMap[String, EngineConn], count: AtomicInteger) => {
+    val conn = map.remove(engineConn.getTickedId)
+    if (conn != null) {
+      count.decrementAndGet()
+    }
+  }
+
+  private val increaseEngineConnMetric = (engineConn: EngineConn, map: ConcurrentHashMap[String, EngineConn], count: AtomicInteger, status: NodeStatus) => {
+    if (engineConn.getStatus.equals(status)) {
+      count.incrementAndGet()
+      map.put(engineConn.getTickedId, engineConn)
+    }
+  }
+
+  override def increaseStartingEngineConn(engineConn: EngineConn): Unit = {
+    increaseEngineConnMetric(engineConn, startingEngineConnMap, startingEngineConnCount, Starting)
+  }
+
+  def decreseStartingEngineConn(engineConn: EngineConn): Unit = {
+    decreaseEngineConnMetric(engineConn, startingEngineConnMap, startingEngineConnCount)
+  }
+
+  override def increaseRunningEngineConn(engineConn: EngineConn): Unit = {
+    increaseEngineConnMetric(engineConn, runningEngineConnMap, runningEngineConnCount, Running)
+  }
+
+  def decreseRunningEngineConn(engineConn: EngineConn): Unit = {
+    decreaseEngineConnMetric(engineConn, runningEngineConnMap, runningEngineConnCount)
+  }
+
+  override def increaseSuccessEngineConn(engineConn: EngineConn): Unit = {
+    increaseEngineConnMetric(engineConn, successEngineConnMap, successEngineConnCount, Success)
+  }
+
+  def decreaseSuccessEngineConn(engineConn: EngineConn): Unit = {
+    decreaseEngineConnMetric(engineConn, successEngineConnMap, successEngineConnCount)
+  }
+
+  override def increaseFailedEngineConn(engineConn: EngineConn): Unit = {
+    increaseEngineConnMetric(engineConn, failedEngineConnMap, failedEngineConnCount, Failed)
+  }
+
+  def decreaseFailedEngineConn(engineConn: EngineConn): Unit = {
+    decreaseEngineConnMetric(engineConn, failedEngineConnMap, failedEngineConnCount)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/report/DefaultECMHealthReport.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/report/DefaultECMHealthReport.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.report
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.ecm.core.report.ECMHealthReport
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.Resource
+
+
+class DefaultECMHealthReport extends ECMHealthReport {
+
+  private var protectedResource: Resource = _
+
+  private var totalResource: Resource = _
+
+  private var usedResource: Resource = _
+
+  private var overload: NodeOverLoadInfo = _
+
+  private var runningEngineConns: Array[EngineConn] = _
+
+  private var reportTime: Long = _
+
+  private var nodeStatus: NodeStatus = _
+
+  private var nodeMsg: String = _
+
+  private var nodeId: String = _
+
+  override def setProtectedResource(protectedResource: Resource): Unit = this.protectedResource = protectedResource
+
+  override def getProtectResource: Resource = protectedResource
+
+  override def setOverload(overload: NodeOverLoadInfo): Unit = this.overload = overload
+
+  override def getOverload: NodeOverLoadInfo = overload
+
+  override def setRunningEngineConns(runningEngines: Array[EngineConn]): Unit = this.runningEngineConns = runningEngineConns
+
+  override def getRunningEngineConns: Array[EngineConn] = runningEngineConns
+
+  override def getReportTime: Long = reportTime
+
+  override def setReportTime(reportTime: Long): Unit = this.reportTime = reportTime
+
+  override def getNodeStatus: NodeStatus = nodeStatus
+
+  override def setNodeStatus(nodeStatus: NodeStatus): Unit = this.nodeStatus = nodeStatus
+
+  override def setNodeMsg(nodeMsg: String): Unit = this.nodeMsg = nodeMsg
+
+  override def getNodeMsg: String = nodeMsg
+
+  override def getUsedResource: Resource = usedResource
+
+  override def setUsedResource(usedResource: Resource): Unit = this.usedResource = usedResource
+
+  override def getTotalResource: Resource = totalResource
+
+  override def setTotalResource(totalResource: Resource): Unit = this.totalResource = totalResource
+
+  override def setNodeId(nodeId: String): Unit = this.nodeId = nodeId
+
+  override def getNodeId: String = nodeId
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ECMHealthService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ECMHealthService.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.ecm.core.report.ECMHealthReport
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{NodeHeartbeatMsg, NodeHeartbeatRequest}
+
+
+trait ECMHealthService{
+
+  def getLastEMHealthReport: ECMHealthReport
+
+  def reportHealth(report: ECMHealthReport): Unit
+
+  def generateHealthReport(reportTime:Long): ECMHealthReport
+
+  def dealNodeHeartbeatRequest(nodeHeartbeatRequest: NodeHeartbeatRequest): NodeHeartbeatMsg
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ECMMetricsService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ECMMetricsService.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+
+trait ECMMetricsService {
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ECMRegisterService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ECMRegisterService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.{RegisterEMRequest, StopEMRequest}
+
+
+trait ECMRegisterService {
+
+  def registerECM(event: RegisterEMRequest): Unit
+
+  def unRegisterECM(event: StopEMRequest): Unit
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnKillService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnKillService.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineStopRequest, EngineStopResponse}
+
+
+trait EngineConnKillService {
+
+  def dealEngineConnStop(engineStopRequest: EngineStopRequest): EngineStopResponse
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnLaunchService.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, EngineConnLaunchRequest}
+
+
+
+trait EngineConnLaunchService {
+  /**
+    * launchEngine启动一个引擎的方法
+    *
+    * @param engineConnBuildRequest 封装了引擎启动的参数
+    */
+  def launchEngineConn(engineConnBuildRequest: EngineConnBuildRequest): EngineNode
+
+  def launchEngineConn(engineConnLaunchRequest: EngineConnLaunchRequest, duration: Long): EngineNode
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnListService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnListService.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import java.util
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.ecm.core.launch.EngineConnLaunchRunner
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.Resource
+
+
+/**
+ * The enginelistservice interface manages the interface started by the engine
+ * The most important submit method is to put the thread that starts the engine into the thread pool to start
+ * EngineListService接口管理引擎启动的接口
+ * 最重要的submit方法是将启动引擎的线程放入到线程池中进行启动
+ */
+trait EngineConnListService {
+
+  def init(): Unit
+
+  def getEngineConn(engineConnId: String): Option[EngineConn]
+
+  def getEngineConns: util.List[EngineConn]
+
+  def addEngineConn(engineConn: EngineConn): Unit
+
+  def killEngineConn(engineConnId: String): Unit
+
+  def getUsedResources: Resource
+
+  def submit(runner: EngineConnLaunchRunner): Option[EngineConn]
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnPidCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnPidCallbackService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.ResponseEngineConnPid
+
+
+trait EngineConnPidCallbackService {
+
+
+  def dealPid(protocol: ResponseEngineConnPid): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnStatusCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/EngineConnStatusCallbackService.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnStatusCallback
+
+
+trait EngineConnStatusCallbackService {
+
+  def dealEngineConnStatusCallback(protocol: EngineConnStatusCallback): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/LocalDirsHandleService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/LocalDirsHandleService.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+
+trait LocalDirsHandleService {
+
+  def getEngineConnManagerHomeDir: String
+
+  def getEngineConnWorkDir(user: String, ticketId: String): String
+
+  def getEngineConnPublicDir: String
+
+  def getEngineConnLogDir(user: String, ticketId: String): String
+
+  def getEngineConnTmpDir(user: String, ticketId: String): String
+
+  def cleanup(): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/LogCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/LogCallbackService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.protocol.callback.LogCallbackProtocol
+
+
+
+trait LogCallbackService {
+
+  def dealLog(protocol: LogCallbackProtocol): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ResourceLocalizationService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/ResourceLocalizationService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
+
+
+trait ResourceLocalizationService {
+
+  def handleInitEngineConnResources(request: EngineConnLaunchRequest, engineConn: EngineConn): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/YarnCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/YarnCallbackService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service
+
+import com.webank.wedatasphere.linkis.protocol.callback.{YarnAPPIdCallbackProtocol, YarnInfoCallbackProtocol}
+
+
+trait YarnCallbackService {
+
+  def dealApplicationId(protocol: YarnAPPIdCallbackProtocol): Unit
+
+  def dealApplicationURI(protocol: YarnInfoCallbackProtocol): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/AbstractEngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/AbstractEngineConnLaunchService.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.{EngineConn, EngineConnInfo}
+import com.webank.wedatasphere.linkis.ecm.core.launch._
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration._
+import com.webank.wedatasphere.linkis.ecm.server.engineConn.DefaultEngineConn
+import com.webank.wedatasphere.linkis.ecm.server.listener.{EngineConnAddEvent, EngineConnStatusChangeEvent}
+import com.webank.wedatasphere.linkis.ecm.server.service.{EngineConnLaunchService, ResourceLocalizationService}
+import com.webank.wedatasphere.linkis.ecm.server.util.ECMUtils
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus.Failed
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMEngineNode, EngineNode}
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnStatusCallbackToAM
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.apache.commons.lang.exception.ExceptionUtils
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContextExecutorService, Future}
+import scala.util.{Failure, Success}
+
+
+abstract class AbstractEngineConnLaunchService extends EngineConnLaunchService with Logging {
+
+
+  protected implicit val executor: ExecutionContextExecutorService = Utils.newCachedExecutionContext(ECM_LAUNCH_MAX_THREAD_SIZE, "EngineConn-Manager-Thread-")
+
+  protected var resourceLocalizationService: ResourceLocalizationService = _
+
+  def setResourceLocalizationService(service: ResourceLocalizationService): Unit = this.resourceLocalizationService = service
+
+
+  def beforeLaunch(conn: EngineConn, duration: Long): Unit = {}
+
+  def afterLaunch(conn: EngineConn, duration: Long): Unit = {}
+
+  override def launchEngineConn(request: EngineConnLaunchRequest, duration: Long): EngineNode = {
+    //1.创建engineConn和runner,launch 并设置基础属性
+    val conn = createEngineConn
+    val runner = createEngineConnLaunchRunner
+    val launch = createEngineConnLaunch
+    launch.setEngineConnLaunchRequest(request)
+    runner.setEngineConnLaunch(launch)
+    conn.setEngineConnLaunchRunner(runner)
+    conn.setLabels(request.labels)
+    conn.setCreationDesc(request.creationDesc)
+    conn.setResource(request.nodeResource)
+    conn.setTickedId(request.ticketId)
+    conn.setStatus(NodeStatus.Starting)
+    conn.setEngineConnInfo(new EngineConnInfo)
+    //2.资源本地化，并且设置ecm的env环境信息
+    getResourceLocalizationServie.handleInitEngineConnResources(request, conn)
+    //3.添加到list
+    ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnAddEvent(conn))
+    //4.run
+    try {
+      beforeLaunch(conn, duration)
+      runner.run()
+      launch match {
+        case pro: ProcessEngineConnLaunch =>
+          val serviceInstance = ServiceInstance(GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue, ECMUtils.getInstanceByPort(pro.getEngineConnPort))
+          conn.setServiceInstance(serviceInstance)
+        case _ =>
+      }
+
+      val future = Future {
+        afterLaunch(conn, duration)
+      }
+
+      future onComplete {
+        case Failure(t) =>
+          throw t
+        case Success(_) =>
+          info(s"init ${conn.getServiceInstance} succeed.")
+      }
+      //超时忽略，如果状态翻转了则直接返回
+      Utils.tryQuietly(Await.result(future, Duration(WAIT_ENGINECONN_PID.getValue.toLong, TimeUnit.MILLISECONDS)))
+    } catch {
+      //failed，1.被ms打断，2.超时，3.普通错误，比如process
+      case t: Throwable =>
+        error(s"init ${conn.getServiceInstance} failed, now stop and delete it. message: ${t.getMessage}")
+        conn.getEngineConnLaunchRunner.stop()
+        Sender.getSender(MANAGER_SPRING_NAME).send(EngineConnStatusCallbackToAM(conn.getServiceInstance,
+          NodeStatus.ShuttingDown, " wait init failed , reason " + ExceptionUtils.getRootCauseMessage(t)))
+        ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnStatusChangeEvent(conn.getTickedId, Failed))
+        throw t
+    }
+    val engineNode = new AMEngineNode()
+    engineNode.setLabels(conn.getLabels)
+
+    engineNode.setServiceInstance(conn.getServiceInstance)
+    engineNode.setOwner(request.user)
+    engineNode.setMark("process")
+    engineNode
+  }
+
+  def createEngineConn: EngineConn = new DefaultEngineConn
+
+
+  def createEngineConnLaunchRunner: EngineConnLaunchRunner = new EngineConnLaunchRunnerImpl
+
+
+  def createEngineConnLaunch: EngineConnLaunch
+
+
+  def getResourceLocalizationServie: ResourceLocalizationService = {
+    // TODO: null 抛出异常
+    this.resourceLocalizationService
+  }
+
+}
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.io.File
+import java.nio.file.Paths
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication
+import com.webank.wedatasphere.linkis.common.io.FsPath
+import com.webank.wedatasphere.linkis.common.utils.{Utils, ZipUtils}
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.ecm.core.launch.EngineConnManagerEnv
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration._
+import com.webank.wedatasphere.linkis.ecm.server.service.{LocalDirsHandleService, ResourceLocalizationService}
+import com.webank.wedatasphere.linkis.ecm.server.util.ECMUtils
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.ProcessEngineConnLaunchRequest
+import com.webank.wedatasphere.linkis.storage.FSFactory
+import com.webank.wedatasphere.linkis.storage.fs.FileSystem
+import com.webank.wedatasphere.linkis.storage.utils.{FileSystemUtils, StorageUtils}
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+
+class BmlResourceLocalizationService extends ResourceLocalizationService {
+
+  private implicit val fs: FileSystem = FSFactory.getFs(StorageUtils.FILE).asInstanceOf[FileSystem]
+
+  fs.init(null)
+
+  private val seperator = File.separator
+
+  private val schema = StorageUtils.FILE_SCHEMA
+
+  private var localDirsHandleService: LocalDirsHandleService = _
+
+  def setLocalDirsHandleService(localDirsHandleService: LocalDirsHandleService): Unit = this.localDirsHandleService = localDirsHandleService
+
+  override def handleInitEngineConnResources(request: EngineConnLaunchRequest, engineConn: EngineConn): Unit = {
+    // TODO: engineType判断是否下载到本地 unzip
+    //engine_type resourceId version判断是否更新，或者重新下载，将path给到properties
+    request match {
+      case request: ProcessEngineConnLaunchRequest =>
+        val files = request.bmlResources
+        val linkDirsP = new mutable.HashMap[String, String]
+        val user = request.user
+        val ticketId = request.ticketId
+        val workDir = createDirIfNotExit(localDirsHandleService.getEngineConnWorkDir(user, ticketId))
+        val emHomeDir = createDirIfNotExit(localDirsHandleService.getEngineConnManagerHomeDir)
+        val logDirs = createDirIfNotExit(localDirsHandleService.getEngineConnLogDir(user, ticketId))
+        val tmpDirs = createDirIfNotExit(localDirsHandleService.getEngineConnTmpDir(user, ticketId))
+        files.foreach(downloadBmlResource(request, linkDirsP, _, workDir))
+        engineConn.getEngineConnLaunchRunner.getEngineConnLaunch.setEngineConnManagerEnv(new EngineConnManagerEnv {
+          override val engineConnManagerHomeDir: String = emHomeDir
+          override val engineConnWorkDir: String = workDir
+          override val engineConnLogDirs: String = logDirs
+          override val engineConnTempDirs: String = tmpDirs
+          override val engineConnManagerHost: String = Utils.getComputerName
+          override val engineConnManagerPort: String = DataWorkCloudApplication.getApplicationContext.getEnvironment.getProperty("server.port")
+          override val linkDirs: Map[String, String] = linkDirsP.toMap
+          // TODO: 注册发现信息的配置化
+          override val properties: Map[String, String] = Map("eureka.client.serviceUrl.defaultZone" -> ECM_EUREKA_DEFAULTZONE)
+        })
+      case _ =>
+    }
+  }
+
+
+  private val bmlResourceSuffix = ".zip"
+
+  private def createDirIfNotExit(noSchemaPath: String): String = {
+    val fsPath = new FsPath(schema + noSchemaPath)
+    if (!fs.exists(fsPath)) {
+      FileSystemUtils.mkdirs(fs, fsPath, Utils.getJvmUser)
+      fs.setPermission(fsPath, "rwxrwx---")
+    }
+    noSchemaPath
+  }
+
+  def downloadBmlResource(request: ProcessEngineConnLaunchRequest, linkDirs: mutable.HashMap[String, String], resource: BmlResource, workDir: String): Unit = {
+    val resourceId = resource.getResourceId
+    val version = resource.getVersion
+    val user = request.user
+    resource.getVisibility match {
+      case BmlResource.BmlResourceVisibility.Public =>
+        val publicDir = localDirsHandleService.getEngineConnPublicDir
+        val bmlResourceDir = schema + Paths.get(publicDir, resourceId, version).toFile.getPath
+        val fsPath = new FsPath(bmlResourceDir)
+        if (!fs.exists(fsPath)) {
+          ECMUtils.downLoadBmlResourceToLocal(resource, user, fsPath.getPath)
+          val unzipDir = fsPath.getSchemaPath + File.separator + resource.getFileName.substring(0, resource.getFileName.lastIndexOf("."))
+          FileSystemUtils.mkdirs(fs, new FsPath(unzipDir), Utils.getJvmUser)
+          ZipUtils.unzip(bmlResourceDir + File.separator + resource.getFileName, unzipDir)
+          fs.delete(new FsPath(bmlResourceDir + File.separator + resource.getFileName))
+        }
+        //2.软连，并且添加到map
+        val dirAndFileList = fs.listPathWithError(fsPath)
+        dirAndFileList.getFsPaths.foreach {
+          case path: FsPath =>
+            val name = new File(path.getPath).getName
+            linkDirs.put(path.getPath, workDir + seperator + name)
+        }
+      case BmlResource.BmlResourceVisibility.Private =>
+        val fsPath = new FsPath(schema + workDir)
+        if (!fs.exists(fsPath)) {
+          FileSystemUtils.mkdirs(fs, fsPath, Utils.getJvmUser)
+          ECMUtils.downLoadBmlResourceToLocal(resource, user, fsPath.getPath)
+          ZipUtils.unzip(schema + workDir + File.separator + resource.getFileName, fsPath.getSchemaPath)
+          fs.delete(new FsPath(schema + workDir + File.separator + resource.getFileName))
+        }
+      case BmlResource.BmlResourceVisibility.Label =>
+    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultECMHealthService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultECMHealthService.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.ecm.core.listener.{ECMEvent, ECMEventListener}
+import com.webank.wedatasphere.linkis.ecm.core.report.ECMHealthReport
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration._
+import com.webank.wedatasphere.linkis.ecm.server.listener.{ECMClosedEvent, ECMReadyEvent}
+import com.webank.wedatasphere.linkis.ecm.server.report.DefaultECMHealthReport
+import com.webank.wedatasphere.linkis.ecm.server.service.{ECMHealthService, EngineConnListService}
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.{NodeHealthy, NodeStatus}
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.{NodeHealthyInfo, NodeOverLoadInfo}
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{CommonNodeResource, LoadInstanceResource}
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{NodeHeartbeatMsg, NodeHeartbeatRequest}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.springframework.beans.factory.annotation.Autowired
+
+
+class DefaultECMHealthService extends ECMHealthService with ECMEventListener {
+
+  val maxResource = new LoadInstanceResource(ECM_MAX_MEMORY_AVAILABLE, ECM_MAX_CORES_AVAILABLE, ECM_MAX_CREATE_INSTANCES)
+  val minResource = new LoadInstanceResource(ECM_PROTECTED_MEMORY, ECM_PROTECTED_CORES, ECM_PROTECTED_INSTANCES)
+  private val runtime: Runtime = Runtime.getRuntime
+
+  private val future = Utils.defaultScheduler.scheduleAtFixedRate(new Runnable {
+    override def run(): Unit = {
+      if (ECMApplication.isReady) {
+        reportHealth(getLastEMHealthReport)
+      }
+    }
+  }, ECM_HEALTH_REPORT_DELAY, ECM_HEALTH_REPORT_PERIOD, TimeUnit.SECONDS)
+
+  @Autowired
+  private var engineConnListService: EngineConnListService = _
+
+  override def getLastEMHealthReport: ECMHealthReport = {
+    val report = new DefaultECMHealthReport
+    report.setNodeId(ECMApplication.getECMServiceInstance.toString)
+    report.setNodeStatus(NodeStatus.Running)
+    report.setTotalResource(maxResource)
+    report.setProtectedResource(minResource)
+    report.setUsedResource(engineConnListService.getUsedResources)
+    report.setReportTime(new Date().getTime)
+    report.setRunningEngineConns(ECMApplication.getContext.getECMMetrics.getRunningEngineConns)
+    val info = new NodeOverLoadInfo
+    info.setMaxMemory(runtime.maxMemory())
+    info.setUsedMemory(runtime.totalMemory() - runtime.freeMemory())
+    // TODO: 根据系统获取当前操作系统负载
+    report.setOverload(info)
+    report
+  }
+
+  // TODO: 可能还需要个判断health状态的方法
+
+  override def reportHealth(report: ECMHealthReport): Unit = {
+    val heartbeat: NodeHeartbeatMsg = transferECMHealthReportToNodeHeartbeatMsg(report)
+    Sender.getSender(MANAGER_SPRING_NAME).send(heartbeat)
+  }
+
+  private def transferECMHealthReportToNodeHeartbeatMsg(report: ECMHealthReport) = {
+    val heartbeat = new NodeHeartbeatMsg
+    heartbeat.setOverLoadInfo(report.getOverload)
+    heartbeat.setStatus(report.getNodeStatus)
+    heartbeat.setServiceInstance(ECMApplication.getECMServiceInstance)
+    val resource = new CommonNodeResource
+    resource.setMaxResource(maxResource)
+    resource.setMinResource(minResource)
+    resource.setUsedResource(resource.getUsedResource)
+    heartbeat.setNodeResource(resource)
+    heartbeat.setHeartBeatMsg("")
+    val nodeHealthyInfo = new NodeHealthyInfo
+    nodeHealthyInfo.setMsg("")
+    nodeHealthyInfo.setNodeHealthy(NodeHealthy.Healthy)
+    heartbeat.setHealthyInfo(nodeHealthyInfo)
+    heartbeat
+  }
+
+  override def generateHealthReport(reportTime: Long): ECMHealthReport = {
+    // TODO: 历史查询
+    null
+  }
+
+  private def emShutdownHealthReport(event: ECMClosedEvent): Unit = {
+    val report = getLastEMHealthReport
+    report.setNodeStatus(NodeStatus.ShuttingDown)
+    reportHealth(report)
+  }
+
+  private def emReadyHealthReport(event: ECMReadyEvent): Unit = reportHealth(getLastEMHealthReport)
+
+
+  override def onEvent(event: ECMEvent): Unit = event match {
+    case event: ECMReadyEvent =>
+      emReadyHealthReport(event)
+    case event: ECMClosedEvent =>
+      cancelHealthReportThread(event)
+      emShutdownHealthReport(event)
+      presistenceLeftReports(event)
+    case _ =>
+  }
+
+  private def cancelHealthReportThread(event: ECMClosedEvent): Unit = {
+
+  }
+
+  private def presistenceLeftReports(event: ECMClosedEvent): Unit = {
+    // TODO: 持久化 剩余的reports
+  }
+
+  @Receiver
+  override def dealNodeHeartbeatRequest(nodeHeartbeatRequest: NodeHeartbeatRequest): NodeHeartbeatMsg = {
+    val hearlthReport = getLastEMHealthReport
+    transferECMHealthReportToNodeHeartbeatMsg(hearlthReport)
+  }
+
+
+  }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultECMMetricsService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultECMMetricsService.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import com.webank.wedatasphere.linkis.ecm.core.listener.{ECMEvent, ECMEventListener}
+import com.webank.wedatasphere.linkis.ecm.server.service.ECMMetricsService
+
+
+class DefaultECMMetricsService extends ECMMetricsService with ECMEventListener{
+  override def onEvent(event: ECMEvent): Unit = ???
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultECMRegisterService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultECMRegisterService.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.util
+import java.util.Collections
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.ecm.core.listener.{ECMEvent, ECMEventListener}
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration._
+import com.webank.wedatasphere.linkis.ecm.server.listener.{ECMClosedEvent, ECMReadyEvent}
+import com.webank.wedatasphere.linkis.ecm.server.service.ECMRegisterService
+import com.webank.wedatasphere.linkis.manager.common.entity.resource._
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.{RegisterEMRequest, StopEMRequest}
+import com.webank.wedatasphere.linkis.manager.label.constant.LabelKeyConstant
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+
+class DefaultECMRegisterService extends ECMRegisterService with ECMEventListener with Logging {
+
+  private implicit def readyEvent2RegisterECMRequest(event: ECMReadyEvent): RegisterEMRequest = {
+    val request = new RegisterEMRequest
+    val instance = Sender.getThisServiceInstance
+    request.setUser(Utils.getJvmUser)
+    request.setServiceInstance(instance)
+    request.setAlias(instance.getApplicationName)
+    request.setLabels(getLabelsFromArgs(event.params))
+    request.setNodeResource(getEMRegiterResourceFromConfiguration)
+    request
+  }
+
+  private def getLabelsFromArgs(params: Array[String]): util.Map[String, AnyRef] = {
+    import scala.collection.JavaConversions._
+    val labelRegex = """label\.(.+)\.(.+)=(.+)""".r
+    val labels = new util.HashMap[String, AnyRef]()
+    // TODO: magic
+    labels += LabelKeyConstant.SERVER_ALIAS_KEY -> Collections.singletonMap("alias", ENGINE_CONN_MANAGER_SPRING_NAME)
+    // TODO: group  by key
+    /*    params.foreach {
+          case labelRegex(key, valueKey, valueContent) => labels += key -> (valueKey, valueContent)
+          case _ =>
+        }*/
+    labels
+  }
+
+  private def getEMRegiterResourceFromConfiguration: NodeResource = {
+    val maxResource = new LoadInstanceResource(ECM_MAX_MEMORY_AVAILABLE, ECM_MAX_CORES_AVAILABLE, ECM_MAX_CREATE_INSTANCES)
+    val minResource = new LoadInstanceResource(ECM_PROTECTED_MEMORY, ECM_PROTECTED_CORES, ECM_PROTECTED_INSTANCES)
+    val nodeResource = new CommonNodeResource
+    nodeResource.setResourceType(ResourceType.LoadInstance)
+    nodeResource.setExpectedResource(Resource.getZeroResource(maxResource))
+    nodeResource.setLeftResource(maxResource)
+    nodeResource.setLockedResource(Resource.getZeroResource(maxResource))
+    nodeResource.setMaxResource(maxResource)
+    nodeResource.setMinResource(minResource)
+    nodeResource.setUsedResource(Resource.getZeroResource(maxResource))
+    nodeResource
+  }
+
+  override def onEvent(event: ECMEvent): Unit = event match {
+    case event: ECMReadyEvent => registerECM(event)
+    case event: ECMClosedEvent => unRegisterECM(event)
+    case _ =>
+  }
+
+  private implicit def closeEvent2StopECMRequest(event: ECMClosedEvent): StopEMRequest = {
+    val request = new StopEMRequest
+    val instance = Sender.getThisServiceInstance
+    request.setUser(Utils.getJvmUser)
+    request.setEm(instance)
+    request
+  }
+
+  override def registerECM(request: RegisterEMRequest): Unit = {
+    info("start register ecm")
+    Sender.getSender(MANAGER_SPRING_NAME).send(request)
+  }
+
+  override def unRegisterECM(request: StopEMRequest): Unit = {
+    info("start unRegister ecm")
+    Sender.getSender(MANAGER_SPRING_NAME).send(request)
+  }
+
+}
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnKillService.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnKillService.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.common.utils.Utils;
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn;
+import com.webank.wedatasphere.linkis.ecm.server.service.EngineConnKillService;
+import com.webank.wedatasphere.linkis.ecm.server.service.EngineConnListService;
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineStopRequest;
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineStopResponse;
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineSuicideRequest;
+import com.webank.wedatasphere.linkis.message.annotation.Receiver;
+import com.webank.wedatasphere.linkis.rpc.Sender;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class DefaultEngineConnKillService implements EngineConnKillService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultEngineConnKillService.class);
+
+    private EngineConnListService engineConnListService;
+
+    public void setEngineConnListService(EngineConnListService engineConnListService) {
+        this.engineConnListService = engineConnListService;
+    }
+
+    @Override
+    @Receiver
+    public EngineStopResponse dealEngineConnStop(EngineStopRequest engineStopRequest) {
+        EngineConn engineConn = getEngineConnByServiceInstance(engineStopRequest.getServiceInstance());
+        EngineStopResponse response = new EngineStopResponse();
+        if (null != engineConn) {
+            if(!killEngineConnByPid(engineConn)) {
+                response.setStopStatus(false);
+                response.setMsg("Kill engine " + engineConn.getServiceInstance().toString() + " failed.");
+            } else {
+                response.setStopStatus(true);
+                response.setMsg("Kill engine " + engineConn.getServiceInstance().toString() + " succeed.");
+            }
+        } else {
+            logger.warn("Cannot find engineconn : " + engineStopRequest.getServiceInstance().toString() + " in this engineConnManager engineConn list, cannot kill.");
+            response.setStopStatus(false);
+            response.setMsg("EngineConn " + engineStopRequest.getServiceInstance().toString() + " was not found in this engineConnManager.");
+        }
+        if (!response.getStopStatus()) {
+            EngineSuicideRequest request = new EngineSuicideRequest(engineStopRequest.getServiceInstance(), engineStopRequest.getUser());
+            try {
+                Sender.getSender(engineStopRequest.getServiceInstance()).send(request);
+                response.setStopStatus(true);
+                response.setMsg(response.getMsg() + " Now send suicide request to engine.");
+            } catch (Exception e) {
+                response.setMsg(response.getMsg() + " Sended suicide request to engine error, " + e.getMessage());
+            }
+        }
+        return response;
+    }
+
+    private EngineConn getEngineConnByServiceInstance(ServiceInstance serviceInstance) {
+        if (null == serviceInstance) {
+            return null;
+        }
+        List<EngineConn> engineConnList = engineConnListService.getEngineConns();
+        for (EngineConn engineConn : engineConnList) {
+            if (engineConn.getServiceInstance().equals(serviceInstance)) {
+                return engineConn;
+            }
+        }
+        return null;
+    }
+
+    private boolean killEngineConnByPid(EngineConn engineConn) {
+        logger.info("try to kill {} toString with pid({}).", engineConn.getServiceInstance().toString(), engineConn.getPid());
+        if (StringUtils.isNotBlank(engineConn.getPid())) {
+            String k15cmd = "sudo kill " + engineConn.getPid();
+            String k9cmd = "sudo kill -9 " + engineConn.getPid();
+            int tryNum = 1;
+            try {
+                while (isProcessAlive(engineConn.getPid()) && tryNum <= 3) {
+                    logger.info("{} still alive with pid({}), use shell command to kill it. try {}++", engineConn.getServiceInstance().toString(), engineConn.getPid(), tryNum++);
+                    if (tryNum < 3) {
+                        Utils.exec(k15cmd.split(" "), 3000L);
+                    } else {
+                        Utils.exec(k9cmd.split(" "), 3000L);
+                    }
+                    Thread.sleep(3000);
+                }
+            } catch (InterruptedException e) {
+                logger.error("Interrupted while killing engine {} with pid({})." + engineConn.getServiceInstance().toString(), engineConn.getPid());
+            }
+            if (isProcessAlive(engineConn.getPid())) {
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            logger.warn("cannot kill {} with empty pid.", engineConn.getServiceInstance().toString());
+            return false;
+        }
+    }
+
+    private boolean isProcessAlive(String pid) {
+        String findCmd = "\"ps -ef | grep " + pid + " | grep EngineConnServer | awk '{print \\\"exists_\\\"$2}' | grep " + pid + " \"";
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add("sudo");
+        cmdList.add("-S");
+        cmdList.add("bash");
+        cmdList.add("-c");
+        cmdList.add(findCmd);
+        try {
+            // todo
+            String rs = Utils.exec(cmdList.toArray(new String[0]), 5000L);
+            return null != rs && rs.contains("exists_" + pid);
+        } catch (Exception e) {
+            logger.error("Method isProcessAlive failed, " + e.getMessage());
+        }
+        return true;
+    }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnListService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnListService.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+
+import com.google.common.collect.Interners
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.{EngineConn, YarnEngineConn}
+import com.webank.wedatasphere.linkis.ecm.core.launch.EngineConnLaunchRunner
+import com.webank.wedatasphere.linkis.ecm.core.listener.{ECMEvent, ECMEventListener}
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.converter.ECMEngineConverter
+import com.webank.wedatasphere.linkis.ecm.server.listener._
+import com.webank.wedatasphere.linkis.ecm.server.service.EngineConnListService
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{Resource, ResourceType}
+
+import scala.collection.JavaConversions._
+
+
+class DefaultEngineConnListService extends EngineConnListService with ECMEventListener with Logging {
+  /**
+   * key:tickedId,value :engineConn
+   */
+  private val engineConnMap = new ConcurrentHashMap[String, EngineConn]
+
+  val lock = Interners.newWeakInterner[String]
+
+  override def init(): Unit = {}
+
+  override def getEngineConn(engineConnId: String): Option[EngineConn] = Option(engineConnMap.get(engineConnId))
+
+  override def getEngineConns: util.List[EngineConn] = engineConnMap.values().toList
+
+  override def addEngineConn(engineConn: EngineConn): Unit = {
+    if (ECMApplication.isReady)
+      engineConnMap.put(engineConn.getTickedId, engineConn)
+  }
+
+  override def killEngineConn(engineConnId: String): Unit = {
+    val conn = engineConnMap.remove(engineConnId)
+    if (conn != null) {
+      Utils.tryAndWarn{
+        conn.close()
+        info(s"engineconn ${conn.getPid} was closed.")
+      }
+    }
+  }
+
+  override def getUsedResources: Resource = engineConnMap.values().map(_.getResource.getMinResource).fold(Resource.initResource(ResourceType.Default))(_ + _)
+
+  override def submit(runner: EngineConnLaunchRunner): Option[EngineConn] = ???
+
+  def updateYarnAppId(event: YarnAppIdCallbackEvent): Unit = {
+    updateYarnEngineConn(x => x.setApplicationId(event.protocol.applicationId), event.protocol.nodeId)
+  }
+
+  def updateYarnEngineConn(implicit updateFunction: YarnEngineConn => Unit, nodeId: String): Unit = {
+    lock.intern(nodeId) synchronized {
+      engineConnMap.get(nodeId) match {
+        case e: YarnEngineConn => updateFunction(e)
+        case e: EngineConn =>
+          engineConnMap.put(nodeId, ECMEngineConverter.engineConn2YarnEngineConn(e))
+      }
+    }
+  }
+
+  def updateEngineConn(updateFunction: EngineConn => Unit, nodeId: String): Unit = {
+    lock.intern(nodeId) synchronized {
+      engineConnMap.get(nodeId) match {
+        case e: EngineConn => updateFunction(e)
+      }
+    }
+  }
+
+  def updateYarnInfo(event: YarnInfoCallbackEvent): Unit = {
+    updateYarnEngineConn(x => x.setApplicationURL(event.protocol.uri), event.protocol.nodeId)
+  }
+
+  def updatePid(event: EngineConnPidCallbackEvent): Unit = {
+    updateEngineConn(x => {
+      x.setPid(event.protocol.pid)
+      x.setServiceInstance(event.protocol.serviceInstance)
+    }, event.protocol.ticketId)
+  }
+
+  def updateEngineConnStatus(tickedId: String, updateStatus: NodeStatus): Unit = {
+    updateEngineConn(x => x.setStatus(updateStatus), tickedId)
+  }
+
+  override def onEvent(event: ECMEvent): Unit = {
+    info(s"Deal event $event")
+    event match {
+      case event: ECMClosedEvent => shutdownEngineConns(event)
+      case event: YarnAppIdCallbackEvent => updateYarnAppId(event)
+      case event: YarnInfoCallbackEvent => updateYarnInfo(event)
+      case event: EngineConnPidCallbackEvent => updatePid(event)
+      case EngineConnAddEvent(engineConn) => addEngineConn(engineConn)
+      case EngineConnStatusChangeEvent(tickedId, updateStatus) => updateEngineConnStatus(tickedId, updateStatus)
+      case _ =>
+    }
+  }
+
+  private def shutdownEngineConns(event: ECMClosedEvent): Unit = {
+    engineConnMap.keys().foreach(killEngineConn)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnPidCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnPidCallbackService.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.listener.EngineConnPidCallbackEvent
+import com.webank.wedatasphere.linkis.ecm.server.service.EngineConnPidCallbackService
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.ResponseEngineConnPid
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+
+
+class DefaultEngineConnPidCallbackService extends EngineConnPidCallbackService with Logging {
+
+  @Receiver
+  override def dealPid(protocol: ResponseEngineConnPid): Unit = {
+    //1.设置pid
+    //2.设置serviceInstance
+    //3.状态为running
+    ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnPidCallbackEvent(protocol))
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnStatusCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultEngineConnStatusCallbackService.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration.MANAGER_SPRING_NAME
+import com.webank.wedatasphere.linkis.ecm.server.listener.EngineConnStatusChangeEvent
+import com.webank.wedatasphere.linkis.ecm.server.service.EngineConnStatusCallbackService
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus.{Failed, Running}
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineConnStatusCallback, EngineConnStatusCallbackToAM}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.springframework.stereotype.Service
+
+
+@Service
+class DefaultEngineConnStatusCallbackService extends EngineConnStatusCallbackService with Logging {
+
+  @Receiver
+  override def dealEngineConnStatusCallback(protocol: EngineConnStatusCallback): Unit = {
+    info(s"Start to deal EngineConnStatusCallback $protocol")
+
+    if (NodeStatus.isAvailable(protocol.status)) {
+
+      ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnStatusChangeEvent(protocol.ticketId, Running))
+    } else {
+
+      Sender.getSender(MANAGER_SPRING_NAME).send(EngineConnStatusCallbackToAM(protocol.serviceInstance,
+        protocol.status, protocol.initErrorMsg))
+      ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnStatusChangeEvent(protocol.ticketId, Failed))
+    }
+
+    info(s"Finished to deal EngineConnStatusCallback $protocol")
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultLocalDirsHandleService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultLocalDirsHandleService.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.io.File
+import java.nio.file.Paths
+
+import com.webank.wedatasphere.linkis.common.io.FsPath
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration._
+import com.webank.wedatasphere.linkis.ecm.server.service.LocalDirsHandleService
+
+
+class DefaultLocalDirsHandleService extends LocalDirsHandleService {
+
+  // TODO: 检测当前磁盘的健康状态，如果目录满了，需要上报am
+
+  override def cleanup(): Unit = ???
+
+
+  override def getEngineConnManagerHomeDir: String = ECM_HOME_DIR
+
+  override def getEngineConnWorkDir(user: String, ticketId: String): String = new FsPath(Paths.get(ENGINECONN_ROOT_DIR, user, "workDir", ticketId).toFile.getPath).getPath
+
+  override def getEngineConnPublicDir: String = ENGINECONN_PUBLIC_DIR
+
+  override def getEngineConnLogDir(user: String, ticketId: String): String = s"${getEngineConnWorkDir(user, ticketId)}${File.separator}logs"
+
+  override def getEngineConnTmpDir(user: String, ticketId: String): String = s"${getEngineConnWorkDir(user, ticketId)}${File.separator}tmp"
+
+
+}
+
+

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultYarnCallbackService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/DefaultYarnCallbackService.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.listener.{YarnAppIdCallbackEvent, YarnInfoCallbackEvent}
+import com.webank.wedatasphere.linkis.ecm.server.service.YarnCallbackService
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.protocol.callback.{YarnAPPIdCallbackProtocol, YarnInfoCallbackProtocol}
+
+
+class DefaultYarnCallbackService extends YarnCallbackService {
+
+  @Receiver
+  override def dealApplicationId(protocol: YarnAPPIdCallbackProtocol): Unit = {
+    ECMApplication.getContext.getECMSyncListenerBus.postToAll(YarnAppIdCallbackEvent(protocol))
+  }
+
+  @Receiver
+  override def dealApplicationURI(protocol: YarnInfoCallbackProtocol): Unit = {
+    ECMApplication.getContext.getECMSyncListenerBus.postToAll(YarnInfoCallbackEvent(protocol))
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/LinuxProcessEngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/LinuxProcessEngineConnLaunchService.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import com.webank.wedatasphere.linkis.ecm.core.launch.{DiscoveryMsgGenerator, EngineConnLaunch, EurekaDiscoveryMsgGenerator}
+import com.webank.wedatasphere.linkis.ecm.linux.launch.LinuxProcessEngineConnLaunch
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration.{ENGINECONN_SPRING_NAME, _}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, EngineConnLaunchRequest}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf._
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+import scala.concurrent.duration.Duration
+
+
+class LinuxProcessEngineConnLaunchService extends ProcessEngineConnLaunchService {
+
+  /**
+   * launchEngine启动一个引擎的方法
+   *
+   * @param engineConnBuildRequest 封装了引擎启动的参数
+   */
+  @Receiver
+  def launchEngineConn(engineConnBuildRequest: EngineConnBuildRequest, smc: ServiceMethodContext): EngineNode = {
+    Sender.getSender(ENGINECONN_SPRING_NAME).ask(engineConnBuildRequest) match {
+      case request: EngineConnLaunchRequest if ENGINECONN_CREATE_DURATION._1 != 0L =>
+        launchEngineConn(request, ENGINECONN_CREATE_DURATION._1)
+      case request: EngineConnLaunchRequest =>
+        launchEngineConn(request, smc.getAttribute(DURATION_KEY).asInstanceOf[Duration]._1)
+    }
+  }
+
+  override def launchEngineConn(engineConnBuildRequest: EngineConnBuildRequest): EngineNode = {
+    Sender.getSender(ENGINECONN_SPRING_NAME).ask(engineConnBuildRequest) match {
+      case request: EngineConnLaunchRequest =>
+        launchEngineConn(request, ENGINECONN_CREATE_DURATION._1)
+    }
+  }
+
+  def createDiscoveryMsgGenerator: DiscoveryMsgGenerator = new EurekaDiscoveryMsgGenerator
+
+  override def createEngineConnLaunch: EngineConnLaunch = {
+    val launch = new LinuxProcessEngineConnLaunch
+    launch.setDiscoveryMsgGenerator(createDiscoveryMsgGenerator)
+    launch
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/ProcessEngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/ProcessEngineConnLaunchService.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.service.impl
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.ecm.core.launch.ProcessEngineConnLaunch
+import com.webank.wedatasphere.linkis.ecm.server.ECMApplication
+import com.webank.wedatasphere.linkis.ecm.server.conf.ECMConfiguration.MANAGER_SPRING_NAME
+import com.webank.wedatasphere.linkis.ecm.server.exception.ECMErrorException
+import com.webank.wedatasphere.linkis.ecm.server.listener.EngineConnStatusChangeEvent
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus._
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnStatusCallbackToAM
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang.exception.ExceptionUtils
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Future, TimeoutException}
+
+
+abstract class ProcessEngineConnLaunchService extends AbstractEngineConnLaunchService {
+
+  override def afterLaunch(conn: EngineConn, duration: Long): Unit = {
+    conn.getEngineConnLaunchRunner.getEngineConnLaunch match {
+      case launch: ProcessEngineConnLaunch => try {
+        processMonitorThread(conn, launch, duration)
+      } catch {
+        case e: ECMErrorException =>
+          warn("EngineConn init failed", e)
+          val logPath = conn.getEngineConnManagerEnv.engineConnWorkDir + "/logs"
+          Sender.getSender(MANAGER_SPRING_NAME).send(EngineConnStatusCallbackToAM(conn.getServiceInstance,
+            NodeStatus.ShuttingDown, "Failed to start EngineConn, reason: " + ExceptionUtils.getRootCauseMessage(e) + s"You can go to this path($logPath) to find the reason or ask the administrator for help"))
+      }
+      case _ =>
+    }
+  }
+
+  private def processMonitorThread(engineConn: EngineConn, launch: ProcessEngineConnLaunch, timeout: Long): Unit = {
+    val isCompleted: EngineConn => Boolean = engineConn => engineConn.getStatus == Success || engineConn.getStatus == Failed
+    val tickedId = engineConn.getTickedId
+    Future {
+      val iterator = IOUtils.lineIterator(launch.getProcessInputStream, "utf-8")
+      while (!isCompleted(engineConn) && iterator.hasNext) {
+        println(s"${engineConn.getTickedId}:${iterator.next()}")
+      }
+      val exitCode = Option(launch.processWaitFor)
+      if (exitCode.exists(_ != 0)) {
+        // TODO: 错误日志获取
+        ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnStatusChangeEvent(tickedId, ShuttingDown))
+      } else {
+        ECMApplication.getContext.getECMSyncListenerBus.postToAll(EngineConnStatusChangeEvent(tickedId, Success))
+      }
+    }
+    Utils.tryThrow(Utils.waitUntil(() => engineConn.getStatus != Starting, Duration(timeout, TimeUnit.MILLISECONDS))) {
+      case e: TimeoutException =>
+        throw new ECMErrorException(10000, s"wait for $engineConn initial timeout.")
+      case e: InterruptedException => //比如被ms cancel
+        throw new ECMErrorException(10000, s"wait for $engineConn initial interrupted.")
+      case t: Throwable =>
+        error(s"unexpected error, now shutdown it.")
+        throw t
+    }
+    if (engineConn.getStatus == ShuttingDown) {
+      throw new ECMErrorException(10000, s"Failed to init $engineConn, status shutting down")
+    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/spring/ECMSpringConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/spring/ECMSpringConfiguration.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.spring
+
+import com.webank.wedatasphere.linkis.ecm.core.listener.ECMEventListener
+import com.webank.wedatasphere.linkis.ecm.server.context.{DefaultECMContext, ECMContext}
+import com.webank.wedatasphere.linkis.ecm.server.service._
+import com.webank.wedatasphere.linkis.ecm.server.service.impl._
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.{Bean, Configuration}
+
+
+@Configuration
+class ECMSpringConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultEngineConnManagerContext: ECMContext = {
+    new DefaultECMContext
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultYarnCallbackService: YarnCallbackService = {
+    new DefaultYarnCallbackService
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getBmlResourceLocalizationService(context: ECMContext, localDirsHandleService: LocalDirsHandleService): ResourceLocalizationService = {
+    val service: BmlResourceLocalizationService = new BmlResourceLocalizationService
+    service.setLocalDirsHandleService(localDirsHandleService)
+    service
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultLogCallbackService: LogCallbackService = {
+    null
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultlocalDirsHandleService: LocalDirsHandleService = {
+    new DefaultLocalDirsHandleService
+  }
+
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultEngineConnPidCallbackService: EngineConnPidCallbackService = {
+    new DefaultEngineConnPidCallbackService
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultEngineConnListService(context: ECMContext): EngineConnListService = {
+    implicit val service: DefaultEngineConnListService = new DefaultEngineConnListService
+    registerSyncListener(context)
+    service
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getLinuxProcessEngineConnLaunchService(resourceLocalizationService: ResourceLocalizationService): EngineConnLaunchService = {
+    val service = new LinuxProcessEngineConnLaunchService
+    service.setResourceLocalizationService(resourceLocalizationService)
+    service
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultECMRegisterService(context: ECMContext): ECMRegisterService = {
+    implicit val service: DefaultECMRegisterService = new DefaultECMRegisterService
+    registerSyncListener(context)
+    service
+  }
+
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultECMHealthService(context: ECMContext): ECMHealthService = {
+    implicit val service: DefaultECMHealthService = new DefaultECMHealthService
+    registerSyncListener(context)
+    service
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  def getDefaultEngineConnKillService(engineConnListService: EngineConnListService): EngineConnKillService = {
+    val service = new DefaultEngineConnKillService
+    service.setEngineConnListService(engineConnListService)
+    service
+  }
+
+  private def registerSyncListener(context: ECMContext)(implicit listener: ECMEventListener): Unit = {
+    context.getECMSyncListenerBus.addListener(listener)
+  }
+
+  private def registerASyncListener(context: ECMContext)(implicit listener: ECMEventListener): Unit = {
+    context.getECMAsyncListenerBus.addListener(listener)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/util/ECMUtils.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/util/ECMUtils.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.ecm.server.util
+
+import java.io.{File, InputStream}
+import java.util
+
+import com.webank.wedatasphere.linkis.bml.client.{BmlClient, BmlClientFactory}
+import com.webank.wedatasphere.linkis.bml.protocol.BmlDownloadResponse
+import com.webank.wedatasphere.linkis.ecm.server.exception.ECMErrorException
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.rpc.Sender
+import com.webank.wedatasphere.linkis.storage.fs.FileSystem
+import org.apache.commons.io.{FileUtils, IOUtils}
+
+import scala.collection.JavaConversions._
+
+
+object ECMUtils {
+
+  private def download(resource: BmlResource, userName: String): util.Map[String, Object] = {
+    val client: BmlClient = createBMLClient(userName)
+    var response: BmlDownloadResponse = null
+    if (resource.getVersion == null) {
+      response = client.downloadShareResource(userName, resource.getResourceId)
+    } else {
+      response = client.downloadShareResource(userName, resource.getResourceId, resource.getVersion)
+    }
+    if (!response.isSuccess) throw new ECMErrorException(911115, "下载失败")
+    val map = new util.HashMap[String, Object]
+    map += "path" -> response.fullFilePath
+    map += "is" -> response.inputStream
+  }
+
+  def downLoadBmlResourceToLocal(resource: BmlResource, userName: String, path: String)(implicit fs: FileSystem): Unit = {
+    val is = download(resource, userName).get("is").asInstanceOf[InputStream]
+    val os = FileUtils.openOutputStream(new File(path + File.separator + resource.getFileName))
+    IOUtils.copy(is, os)
+    IOUtils.closeQuietly(os)
+    IOUtils.closeQuietly(is)
+  }
+
+  private def createBMLClient(userName: String): BmlClient = {
+    if (userName == null)
+      BmlClientFactory.createBmlClient()
+    else
+      BmlClientFactory.createBmlClient(userName)
+  }
+
+
+  private val address = Sender.getThisInstance.substring(0, Sender.getThisInstance.lastIndexOf(":"))
+
+  def getInstanceByPort(port: String): String = address + ":" + port
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn-manager/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-manager</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>linkis-engineconn-manager-core</module>
+        <module>linkis-engineconn-manager-server</module>
+        <module>linkis-engineconn-linux-launch</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
### What is the purpose of the change
fixes #571

In linkis1.0, the function of ECM is not powerful enough, one type of ECM can only start one underlying computing storage engine. It also does not support docking with other operating systems, and it is complicated to integrate with K8S. Since the new version of ECM's resourcerequestor and engine creator have been handed over to the engine conn plugin module, ecm2.0.0 is only responsible for parsing the launchenginerequest and starting a new engine through the EngineConnLaunch. The functions are more flexible and can support multiple types of computing storage engines.
### Brief change log
1. completes the function of ECM startup and management EngineConn

2. completes the function of ECM to download and manage the resource files corresponding to EngineConnPlugin

3. completes the function of ECM reporting their health status to Manager in real time

4. completes the ECM to accept the call Back function of EngineConn that is not started on this machine
