### PR TITLE
Add the Persistence Module for Linkis Manager to provide the persistence capability.

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/pom.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!--<relativePath>../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-manager-persistence</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-label-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-mybatis</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-protocol</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-test -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/PersistenceSpringConfiguration.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/PersistenceSpringConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager;
+
+import com.webank.wedatasphere.linkis.manager.dao.*;
+import com.webank.wedatasphere.linkis.manager.persistence.*;
+import com.webank.wedatasphere.linkis.manager.persistence.impl.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PersistenceSpringConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ManagerPersistence getDefaultManagerPersistence(NodeManagerPersistence nodeManagerPersistence,
+                                                           NodeMetricManagerPersistence nodeMetricManagerPersistence,
+                                                           LabelManagerPersistence labelManagerPersistence,
+                                                           LockManagerPersistence lockManagerPersistence,
+                                                           ResourceManagerPersistence resourceManagerPersistence,
+                                                           ResourceLabelPersistence resourceLabelPersistence) {
+        DefaultManagerPersistence defaultManagerPersistence = new DefaultManagerPersistence();
+        defaultManagerPersistence.setResourceManagerPersistence(resourceManagerPersistence);
+        defaultManagerPersistence.setNodeMetricManagerPersistence(nodeMetricManagerPersistence);
+        defaultManagerPersistence.setNodeManagerPersistence(nodeManagerPersistence);
+        defaultManagerPersistence.setLockManagerPersistence(lockManagerPersistence);
+        defaultManagerPersistence.setLabelManagerPersistence(labelManagerPersistence);
+        defaultManagerPersistence.setResourceLabelPersistence(resourceLabelPersistence);
+        return defaultManagerPersistence;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public NodeManagerPersistence getDefaultNodeManagerPersistence(NodeManagerMapper nodeManagerMapper,
+                                                                   NodeMetricManagerMapper metricManagerMapper) {
+        DefaultNodeManagerPersistence defaultNodeManagerPersistence = new DefaultNodeManagerPersistence();
+        defaultNodeManagerPersistence.setMetricManagerMapper(metricManagerMapper);
+        defaultNodeManagerPersistence.setNodeManagerMapper(nodeManagerMapper);
+        return defaultNodeManagerPersistence;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LabelManagerPersistence getDefaultLabelManagerPersistence(LabelManagerMapper labelManagerMapper,
+                                                                     NodeManagerMapper nodeManagerMapper) {
+        DefaultLabelManagerPersistence defaultLabelManagerPersistence = new DefaultLabelManagerPersistence();
+        defaultLabelManagerPersistence.setLabelManagerMapper(labelManagerMapper);
+        defaultLabelManagerPersistence.setNodeManagerMapper(nodeManagerMapper);
+        return defaultLabelManagerPersistence;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LockManagerPersistence getDefaultLockManagerPersistence(LockManagerMapper lockManagerMapper) {
+        DefaultLockManagerPersistence defaultLockManagerPersistence = new DefaultLockManagerPersistence();
+        defaultLockManagerPersistence.setLockManagerMapper(lockManagerMapper);
+        return defaultLockManagerPersistence;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResourceManagerPersistence getDefaultResourceManagerPersistence(ResourceManagerMapper resourceManagerMapper,
+                                                                           NodeManagerMapper nodeManagerMapper,
+                                                                           LabelManagerMapper labelManagerMapper) {
+        DefaultResourceManagerPersistence defaultResourceManagerPersistence = new DefaultResourceManagerPersistence();
+        defaultResourceManagerPersistence.setLabelManagerMapper(labelManagerMapper);
+        defaultResourceManagerPersistence.setNodeManagerMapper(nodeManagerMapper);
+        defaultResourceManagerPersistence.setResourceManagerMapper(resourceManagerMapper);
+        return defaultResourceManagerPersistence;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public NodeMetricManagerPersistence getDefaultNodeMetricManagerPersistence(NodeManagerMapper nodeManagerMapper,
+                                                                               NodeMetricManagerMapper nodeMetricManagerMapper) {
+        DefaultNodeMetricManagerPersistence defaultNodeMetricManagerPersistence = new DefaultNodeMetricManagerPersistence();
+        defaultNodeMetricManagerPersistence.setNodeManagerMapper(nodeManagerMapper);
+        defaultNodeMetricManagerPersistence.setNodeMetricManagerMapper(nodeMetricManagerMapper);
+        return defaultNodeMetricManagerPersistence;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResourceLabelPersistence getDefaultResourceLabelPersistence(LabelManagerMapper labelManagerMapper,ResourceManagerMapper resourceManagerMapper) {
+        DefaultResourceLabelPersistence defaultResourceLabelPersistence = new DefaultResourceLabelPersistence();
+        defaultResourceLabelPersistence.setLabelManagerMapper(labelManagerMapper);
+        defaultResourceLabelPersistence.setResourceManagerMapper(resourceManagerMapper);
+        return defaultResourceLabelPersistence;
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/LabelManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/LabelManagerMapper.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.dao;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.label.LabelKeyValue;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Mapper
+public interface LabelManagerMapper {
+
+    @Options(useGeneratedKeys = true, keyProperty = "persistenceLabel.id", keyColumn = "id")
+    @Insert("INSERT INTO  linkis_manager_label (label_key,label_value,label_feature,label_value_size,update_time,create_time) VALUES" +
+            "(#{persistenceLabel.labelKey},#{persistenceLabel.stringValue},#{persistenceLabel.feature},#{persistenceLabel.labelValueSize},now(), now())")
+    void registerLabel(@Param("persistenceLabel") PersistenceLabel persistenceLabel);
+
+    @Insert("<script>" +
+            "INSERT INTO linkis_manager_label_value_relation (label_value_key,label_value_content,label_id,update_time,create_time) VALUES"
+            + "<foreach collection='labelValueKeyAndContent.entrySet()' separator=',' index='valueKey' item='valueContent'>"
+            + "(#{valueKey}, #{valueContent},#{labelId},now(),now())"
+            + "</foreach>"
+            + "</script>")
+    void registerLabelKeyValues(@Param("labelValueKeyAndContent") Map<String, String> labelValueKeyAndContent, @Param("labelId") int labelId);
+
+    @Select("select * from linkis_manager_label where id=#{id}")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    PersistenceLabel getLabel(@Param("id") int id);
+
+    @Delete("delete from linkis_manager_label  where id =#{id}")
+    void deleteLabel(@Param("id") int id);
+
+    @Delete("delete from linkis_manager_label  where label_key =#{labelKey} and label_value=#{labelStringValue} ")
+    void deleteByLabel(@Param("labelKey") String labelKey, @Param("labelStringValue") String labelStringValue);
+
+    @Delete("delete from linkis_manager_label_value_relation where label_id =#{id}")
+    void deleteLabelKeyVaules(@Param("id") int id);
+
+    @Update("update linkis_manager_label set label_key = #{persistenceLabel.labelKey},label_value = #{persistenceLabel.stringValue}," +
+            "label_feature=#{persistenceLabel.feature},label_value_size=#{persistenceLabel.labelValueSize},update_time=#{persistenceLabel.updateTime} where id=#{id}")
+    void updateLabel(@Param("id") int id, @Param("persistenceLabel") PersistenceLabel persistenceLabel);
+
+
+    @Insert({
+            "<script>",
+            "insert into linkis_manager_label_service_instance(label_id, service_instance, update_time,create_time) values ",
+            "<foreach collection='labelIds' item='labelId' index='index' separator=','>",
+            "(#{labelId}, #{instance},now(),now())",
+            "</foreach>",
+            "</script>"
+    })
+    void addLabelServiceInstance(@Param("instance") String instance, @Param("labelIds") List<Integer> labelIds);
+
+    @Select("<script> select b.* from " +
+            "( select label_id, count(1) as label_value_size from linkis_manager_label_value_relation where (label_value_key,label_value_content) IN"
+            + "<foreach collection='labelKeyValues.entrySet()' separator=',' index='key' item='value' open='(' close=')'>"
+            + "(#{key},#{value})"
+            + "</foreach> group by label_id) as a join linkis_manager_label as b on a.label_id = b.label_id  and a.label_value_size = b.label_value_size"
+            + "</script>")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    List<PersistenceLabel> getLabelsByLabelKeyValues(@Param("labelKeyValues") Map<String, String> labelKeyValues);
+
+
+    @Select("<script> select b.* from " +
+            "( select label_id,count(1) as label_value_size from linkis_manager_label_value_relation where (label_value_key,label_value_content) IN"
+            + "<foreach collection='labelKeyValues.entrySet()' separator=',' index='key' item='value' open='(' close=')'>"
+            + "(#{key},#{value})"
+            + "</foreach> group by label_id ) as a join linkis_manager_label as b on a.label_id = b.label_id and a.label_value_size = b.label_value_size and b.label_key=#{labelKey} "
+            + "</script>")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    PersistenceLabel getLabelByLabelKeyValues(@Param("labelKey") String labelKey, @Param("labelKeyValues") Map<String, String> labelKeyValues);
+
+    @Select("select * from linkis_manager_label where id in (select label_id from linkis_manager_label_service_instance where service_instance=#{instance})")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    List<PersistenceLabel> getLabelByServiceInstance(@Param("instance") String instance);
+
+    @Select("<script>" +
+            "select distinct label_id from linkis_manager_label_value_relation where (label_value_key,label_value_content) IN"
+            + "<foreach collection='labelKeyValues.entrySet()' separator=',' index='key' item='value' open='(' close=')'>"
+            + "(#{key},#{value})"
+            + "</foreach>"
+            + "</script>")
+    List<Integer> getLabelByLabelKeyValuesOverload(@Param("labelKeyValues") Map<String, String> labelKeyValues);
+
+
+    @Select("select * from linkis_manager_label where id in (select label_id from linkis_manager_label_resource A join linkis_manager_linkis_resources B on  A.resource_id = B.id  where A.resource_id = #{persistenceResource.id} )")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    List<PersistenceLabel> getLabelByResource(@Param("persistenceResource") PersistenceResource persistenceResource);
+
+//    @Insert("insert into linkis_manager_label_resource (label_id, resource_id, update_time, create_time)" +
+//            "values(#{labelId}, #{resourceId}, now(), now())")
+//   void addLabelResource(@Param("labelId")int labelId,@Param("resourceId")int resourceId);
+
+    @Insert({
+            "<script>",
+            "insert into linkis_manager_label_resource(label_id, resource_id,update_time, create_time) values ",
+            "<foreach collection='labelIds' item='labelId' index='index' separator=','>",
+            "(#{labelId},#{resourceId},now(), now())",
+            "</foreach>",
+            "</script>"
+    })
+    void addLabelsAndResource(@Param("resourceId") int resourceId, @Param("labelIds") List<Integer> labelIds);
+
+//    @Insert({
+//            "<script>",
+//            "insert into linkis_manager_label_resource(label_id, resource_id,update_time, create_time) values ",
+//            "<foreach collection='resourceIds' item='resourceId' index='index' separator=','>",
+//            "(#{labelId},#{resourceId},now(), now())",
+//            "</foreach>",
+//            "</script>"
+//    })
+//    void addLabelAndResources(@Param("labelId")int labelId,@Param("resourceIds")List<Integer> resourceIds);
+
+//    @Select("select id from linkis_manager_label where creator = #{creator}")
+//    List<Integer> getLabelIds (@Param("creator") String  creator);
+//
+//    @Select("select resource_id from linkis_manager_label_resource where label_id = #{labelId}")
+//    List<Integer> getResourceIdsByLabelId (@Param("labelId") int  labelId);
+//
+//    @Select("<script>" +
+//            "select * from linkis_manager_label_resource where id in("
+//            +"<foreach collection='labelIds' separator=',' item='labelId'>"
+//            + "#{labelId} "
+//            + "</foreach> "
+//            +")</script>")
+//    List<PersistenceResource> getResourcesByLabels (@Param("labelIds") List<Integer>  labelIds);
+
+    @Select("select * from linkis_manager_linkis_resources A join linkis_manager_label_resource B  on A.id = B.resource_id " +
+            "and B.label_id in (select id from linkis_manager_label where label_key=#{labelKey} and label_value=#{stringValue})")
+    @Results({
+            @Result(property = "maxResource", column = "max_resource"),
+            @Result(property = "minResource", column = "min_resource"),
+            @Result(property = "usedResource", column = "used_resource"),
+            @Result(property = "leftResource", column = "left_resource"),
+            @Result(property = "expectedResource", column = "expected_resource"),
+            @Result(property = "lockedResource", column = "locked_resource"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    List<PersistenceResource> getResourcesByLabel(@Param("labelKey") String labelKey, @Param("stringValue") String stringValue);
+
+    @Select("select label_id from linkis_manager_label_service_instance where service_instance = #{instance}")
+    List<Integer> getLabelIdsByInstance(@Param("instance") String instance);
+
+    @Select("select * from linkis_manager_label A join linkis_manager_label_service_instance B on A.id = B.label_id where B.service_instance = #{instance}")
+    List<PersistenceLabel> getLabelsByInstance(@Param("instance") String instance);
+
+    @Select("select * from linkis_manager_service_instance A join linkis_manager_label_service_instance B on A.instance = B.service_instance where B.label_id=#{labelId}")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    List<PersistenceNode> getInstanceByLabelId(@Param("labelId") int labelId);
+
+
+    @Select("<script>" +
+            "select service_instance from linkis_manager_label_service_instance where label_id in ("
+            + "<foreach collection='labelIds' separator=',' item='labelId'>"
+            + "#{labelId} "
+            + "</foreach> "
+            + ")</script>")
+    List<String> getInstanceIdsByLabelIds(@Param("labelIds") List<Integer> labelIds);
+
+    @Select("<script>" +
+            "select * from linkis_manager_label where id in ("
+            + "<foreach collection='labelIds' separator=',' item='labelId'>"
+            + "#{labelId} "
+            + "</foreach> "
+            + ")</script>")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    List<PersistenceLabel> getLabelsByLabelIds(@Param("labelIds") List<Integer> labelIds);
+
+    @Insert({
+            "<script>",
+            "insert into linkis_manager_label_user(username, label_id,update_time, create_time) values ",
+            "<foreach collection='labelIds' item='labelId' index='index' separator=','>",
+            "(#{userName},#{labelId},now(), now())",
+            "</foreach>",
+            "</script>"
+    })
+    void addLabelsByUser(@Param("userName") String userName, @Param("labelIds") List<Integer> labelIds);
+
+    @Select("select username from linkis_manager_label_user where label_id = #{labelId}")
+    List<String> getUserNameByLabelId(@Param("labelId") int labelId);
+
+    @Select("<script>" +
+            "select distinct username from linkis_manager_label_user where label_id in ("
+            + "<foreach collection='labelIds' separator=',' item='labelId'>"
+            + "#{labelId} "
+            + "</foreach> "
+            + ")</script>")
+    List<String> getUserNamesByLabelIds(@Param("labelIds") List<Integer> labelIds);
+
+    @Select("select * from linkis_manager_label A join linkis_manager_label_user B on A.id = B.label_id and B.username = #{userName}")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    List<PersistenceLabel> getLabelsByUser(@Param("userName") String userName);
+
+    @Select("select * from linkis_manager_label where label_key = #{labelKey}")
+    @Results({
+            @Result(property = "labelKey", column = "label_key"),
+            @Result(property = "feature", column = "label_feature"),
+            @Result(property = "labelValueSize", column = "label_value_size"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "stringValue", column = "label_value")
+    })
+    List<PersistenceLabel> getLabelsByLabelKey(@Param("labelKey") String labelKey);
+
+    @Delete("delete from linkis_manager_label_resource A join linkis_manager_linkis_resources B on A.resource_id = B.id and B.ticketId=#{ticketId}")
+    void deleteLabelResourceByByTicketId(@Param("ticketId") String ticketId);
+
+
+    @Delete({"<script>" +
+            "delete from linkis_manager_label_service_instance where service_instance = #{instance} and label_id in "
+            + "<foreach collection='labelIds' item='labelId' index='index'  open='(' separator=',' close=')'>"
+            + "#{labelId}"
+            + "</foreach>"
+            + "</script>"
+    })
+    void deleteLabelIdsAndInstance(@Param("instance") String instance, @Param("labelIds") List<Integer> labelIds);
+
+
+    @Delete({"<script>" +
+            "delete from linkis_manager_label_user where username = #{userName} and label_id in "
+            + "<foreach collection='labelIds' item='labelId' index='index'  open='(' separator=',' close=')'>"
+            + "#{labelId}"
+            + "</foreach>"
+            + "</script>"
+    })
+    void deleteLabelIdsByUser(@Param("userName") String userName, @Param("labelIds") List<Integer> labelIds);
+
+    @Delete("delete from linkis_manager_label_user where label_id=#{labelId}")
+    void deleteUserById(int labelId);
+
+    /**
+     * 通过lavel value 同时返回instance信息和label信息
+     *
+     * @param labelKeyAndValuesMap
+     * @return
+     */
+    List<Map<String, Object>> dimListNodeRelationsByKeyValueMap(@Param("keyValueMap") Map<String, Map<String, String>> labelKeyAndValuesMap, @Param("valueRelation") String name);
+
+    /**
+     * 通过instance信息，同时返回instance信息和label信息
+     *
+     * @param serviceInstances
+     * @return
+     */
+    List<Map<String, Object>> listLabelRelationByServiceInstance(@Param("nodes") List<ServiceInstance> serviceInstances);
+
+    /**
+     * 通过labelkey 和StringValue找到唯一的label
+     *
+     * @param labelKey
+     * @param stringValue
+     * @return
+     */
+    PersistenceLabel getLabelByKeyValue(@Param("labelKey") String labelKey, @Param("stringValue") String stringValue);
+
+    List<ServiceInstance> getNodeByLabelKeyValue(@Param("labelKey") String labelKey, @Param("stringValue") String stringValue);
+
+    /**
+     * @param values,可能是多个label的散列 all 和 and 类型的 查询
+     * @return
+     */
+    List<PersistenceLabel> listResourceLabelByValues(@Param("values") List<LabelKeyValue> values);
+
+    /**
+     * 通过labelId获取到resource
+     *
+     * @param labelId
+     * @return
+     */
+    List<PersistenceResource> listResourceByLaBelId(Integer labelId);
+
+    /**
+     * 通过label的keyvalues再找到resource
+     * 和{@link LabelManagerMapper#dimListLabelByKeyValueMap(Map, String)} 区别只是多了关联和资源表,并且返回是resource
+     *
+     * @param keyValueMap
+     * @return
+     */
+    List<PersistenceResource> dimListResourceBykeyValueMap(@Param("keyValueMap") Map<String, Map<String, String>> keyValueMap, @Param("valueRelation") String name);
+
+    /**
+     * 通过labelId删除资源，还有资源和label的关联，并不会删除label表记录
+     *
+     * @param labelId
+     */
+    void deleteResourceByLabelId(Integer labelId);
+    void deleteResourceByLabelIdInDirect(Integer labelId);
+
+    /**
+     * 同 {@link LabelManagerMapper#deleteResourceByLabelId(Integer)}
+     * 和下面的batchdelete有点重复，主要是sql给的是= batch 的话给的是in
+     *
+     * @param singletonMap
+     */
+    void deleteResourceByLabelKeyValuesMaps(@Param("labelKeyValues") Map<String, Map<String, String>> singletonMap);
+    void deleteResourceByLabelKeyValuesMapsInDirect(@Param("labelKeyValues") Map<String, Map<String, String>> singletonMap);
+
+    /**
+     * 批量删除 不删除label
+     *
+     * @param notBlankIds
+     */
+    void batchDeleteResourceByLabelId(@Param("labelIds") List<Integer> notBlankIds);
+    void batchDeleteResourceByLabelIdInDirect(@Param("labelIds") List<Integer> notBlankIds);
+
+    /**
+     * 批量删除 不删除label
+     *
+     * @param keyValueMaps
+     */
+    void batchDeleteResourceByLabelKeyValuesMaps(@Param("labelKeyValues") Map<String, Map<String, String>> keyValueMaps);
+
+    /**
+     * ALL,AND搜索，根据key，value找到label集合，不对instance和resource进行关联，效率稍比{@link LabelManagerMapper#dimListLabelByKeyValueMap(Map, String)}
+     *
+     * @param keyValueMap
+     * @return
+     */
+    @Deprecated
+    List<PersistenceLabel> listLabelByKeyValueMap(@Param("keyValueMap") Map<String, Map<String, String>> keyValueMap);
+
+    /**
+     * 模糊搜索，根据value，valueRelation 找到label集合，不对instance和resource进行关联
+     *
+     * @param valueList
+     * @return
+     */
+    List<PersistenceLabel> dimListLabelByValueList(@Param("valueList") List<Map<String, String>> valueList, @Param("valueRelation") String valueRelation);
+
+    /**
+     * 模糊搜索，根据key，value，valueRelation 找到label集合，不对instance和resource进行关联
+     *
+     * @param keyValueMap
+     * @param name
+     * @return
+     */
+    List<PersistenceLabel> dimListLabelByKeyValueMap(@Param("keyValueMap") Map<String, Map<String, String>> keyValueMap, @Param("valueRelation") String name);
+
+    /**
+     * 和{@link LabelManagerMapper#dimListLabelByKeyValueMap(Map, String)} 区别只是多了关联和资源表
+     *
+     * @param labelKeyAndValuesMap
+     * @param name
+     * @return
+     */
+    List<PersistenceLabel> dimlistResourceLabelByKeyValueMap(@Param("keyValueMap") Map<String, Map<String, String>> labelKeyAndValuesMap, @Param("valueRelation") String name);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/LockManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/LockManagerMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.dao;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface LockManagerMapper {
+    @Insert("insert into linkis_manager_lock (lock_object, time_out, update_time, create_time)" +
+            "values(#{jsonObject}, #{timeOut}, now(), now())")
+    void lock(@Param("jsonObject") String jsonObject, @Param("timeOut") Long timeOut);
+
+    @Delete("delete  from linkis_manager_lock where lock_object = #{jsonObject}")
+    void unlock(String jsonObject);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/NodeManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/NodeManagerMapper.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.dao;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode;
+import org.apache.ibatis.annotations.*;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.util.List;
+
+@Mapper
+public interface NodeManagerMapper {
+
+    @Insert({"insert into linkis_manager_service_instance(instance,name,owner,mark,update_time,create_time,updator,creator)"
+            + "values(#{instance},#{name},#{owner},#{mark},#{updateTime},#{createTime},#{updator},#{creator})"})
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void addNodeInstance(PersistenceNode node) throws DuplicateKeyException;
+
+
+    @Update({"update linkis_manager_service_instance set instance = #{persistenceNode.instance}, owner = #{persistenceNode.owner},mark = #{persistenceNode.mark},name = #{persistenceNode.name}," +
+            "update_time = #{persistenceNode.updateTime},updator = #{persistenceNode.updator},creator = #{persistenceNode.creator} where instance = #{instance}"})
+    void updateNodeInstance(@Param("instance") String instance, @Param("persistenceNode") PersistenceNode persistenceNode);
+
+    @Delete("delete from  linkis_manager_service_instance where instance = #{instance}")
+    void removeNodeInstance(@Param("instance") String instance);
+
+
+    @Select("select * from  linkis_manager_service_instance where owner = #{owner}")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    List<PersistenceNode> getNodeInstancesByOwner(@Param("owner") String owner);
+
+
+    @Select("select * from  linkis_manager_service_instance")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    List<PersistenceNode> getAllNodes();
+
+    @Update({ "update linkis_manager_service_instance set owner = #{persistenceNode.owner},mark = #{persistenceNode.mark},name = #{persistenceNode.name}," +
+            "update_time = #{persistenceNode.updateTime},create_time = #{persistenceNode.createTime},updator = #{persistenceNode.updator},creator = #{persistenceNode.creator} where instance = #{instance}"})
+    void updateNodeInstanceOverload(PersistenceNode persistenceNode);
+
+    @Select("select id from  linkis_manager_service_instance where instance = #{instance}")
+    int getNodeInstanceId (@Param("instance") String instance);
+
+    @Select("select id from  linkis_manager_service_instance where instance = #{instance}")
+    int getIdByInstance (@Param("instance") String instance);
+
+    @Select("<script>" +
+            "select id from linkis_manager_service_instance where instance in("
+            +"<foreach collection='instances' separator=',' item='instance'>"
+            + "#{instance} "
+            + "</foreach> "
+            +")</script>")
+    List<Integer> getNodeInstanceIds (@Param("serviceInstances") List<String> instances);
+
+    @Select("select * from linkis_manager_service_instance where instance = #{instance}")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    PersistenceNode getNodeInstance(@Param("instance") String instance);
+
+    @Select("select * from  linkis_manager_service_instance where id = #{id}")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    PersistenceNode getNodeInstanceById(@Param("id") int id);
+
+    @Select("select * from linkis_manager_service_instance where instance in (select em_instance from linkis_manager_engine_em where engine_instance in (select instance from linkis_manager_service_instance where instance=#{instance}))")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    PersistenceNode getEMNodeInstanceByEngineNode(@Param("instance") String  instance);
+
+
+
+    @Select("select * from linkis_manager_service_instance where instance in ( select engine_instance from linkis_manager_engine_em where em_instance in (select instance from linkis_manager_service_instance where instance=#{instance}))")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    List<PersistenceNode> getNodeInstances(@Param("instance")String  instance);
+
+
+    @Select("<script>" +
+            "select * from linkis_manager_service_instance where instance in("
+            +"<foreach collection='instances' separator=',' item='instance'>"
+            + "#{instance} "
+            + "</foreach> "
+            +")</script>")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    List<PersistenceNode> getNodesByInstances(@Param("engineNodeIds")List<String> instances);
+
+
+
+    @Insert("insert into  linkis_manager_engine_em (engine_instance, em_instance, update_time, create_time)" +
+            "values(#{engineNodeInstance}, #{emNodeInstance}, now(), now())")
+    void addEngineNode(@Param("engineNodeInstance") String  engineNodeInstance, @Param("emNodeInstance") String emNodeInstance);
+
+
+    @Delete("delete from  linkis_manager_engine_em where engine_instance = #{engineNodeInstance} and em_instance = #{emNodeInstance}")
+    void deleteEngineNode(@Param("engineNodeInstance") String  engineNodeInstance, @Param("emNodeInstance") String  emNodeInstance);
+
+    @Select("select engine_id from  linkis_manager_engine_em where em_id = #{emId}")
+    List<Integer> getEngineNodeIDsByEMId (@Param("emId") int emId);
+
+    @Select("select em_id from  linkis_manager_engine_em where engine_id = #{engineNodeId}")
+    int getEMIdByEngineId(@Param("engineNodeId") int engineNodeId);
+
+    @Select("select id from linkis_manager_service_instance where owner = #{owner}")
+    List<Integer> getNodeInstanceIdsByOwner(@Param("owner") String  owner);
+
+    void updateNodeRelation(@Param("tickedId") String tickedId, @Param("instance") String instance);
+
+    void updateNodeLabelRelation(@Param("tickedId") String tickedId, @Param("instance") String instance);
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/NodeMetricManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/NodeMetricManagerMapper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.dao;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetrics;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetricsEntity;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+
+public interface NodeMetricManagerMapper {
+
+    @Insert("insert into  linkis_manager_service_instance_metrics (instance, instance_status, overload, heartbeat_msg,healthy_status,update_time,create_time)" +
+            "values(#{nodeMetrics.instance},#{nodeMetrics.status},#{nodeMetrics.overLoad},#{nodeMetrics.heartBeatMsg},#{nodeMetrics.healthy},now(),now())")
+    void addNodeMetrics(@Param("nodeMetrics") PersistenceNodeMetrics nodeMetrics);
+
+    @Select("select count(instance) from  linkis_manager_service_instance_metrics where instance = #{instance}")
+    int checkInstanceExist(@Param("instance") String  instance);
+
+
+    @Select("<script>" +
+            "select * from linkis_manager_service_instance_metrics where instance in("
+            +"<foreach collection='instances' separator=',' item='instance'>"
+            + "#{instance}"
+            + "</foreach>"
+            +")</script>")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "instance", column = "instance"),
+            @Result(property = "heartBeatMsg", column = "heartbeat_msg"),
+            @Result(property = "status", column = "instance_status"),
+            @Result(property = "healthy", column = "healthy_status")
+    })
+    List<PersistenceNodeMetrics> getNodeMetricsByInstances(@Param("instances") List<String > instances);
+
+    @Select("select * from linkis_manager_service_instance_metrics where instance = #{instance}")
+    @Results({
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time"),
+            @Result(property = "instance", column = "instance"),
+            @Result(property = "heartBeatMsg", column = "heartbeat_msg"),
+            @Result(property = "status", column = "instance_status"),
+            @Result(property = "healthy", column = "healthy_status")
+    })
+    PersistenceNodeMetrics getNodeMetricsByInstance(@Param("instance") String instance);
+
+    @Update({"<script> update linkis_manager_service_instance_metrics" +
+            "<trim prefix=\"set\" suffixOverrides=\",\">" +
+            "<if test=\"nodeMetrics.status != null\">instance_status = #{nodeMetrics.status},</if>" +
+            "<if test=\"nodeMetrics.overLoad != null\"> overload = #{nodeMetrics.overLoad},</if>" +
+            "<if test=\"nodeMetrics.heartBeatMsg != null\">  heartbeat_msg = #{nodeMetrics.heartBeatMsg},</if>" +
+            "<if test=\"nodeMetrics.healthy != null\">  healthy_status=#{nodeMetrics.healthy}, </if>" +
+            "<if test=\"nodeMetrics.updateTime != null\">  update_time=#{nodeMetrics.updateTime},</if>" +
+            "<if test=\"nodeMetrics.createTime != null\">   create_time=#{nodeMetrics.createTime},</if>" +
+            "</trim> where instance = #{instance}" +
+            "</script>"})
+    void updateNodeMetrics(@Param("nodeMetrics") PersistenceNodeMetrics nodeMetrics, @Param("instance") String instance);
+
+    @Delete("delete from linkis_manager_service_instance_metrics where instance in (select instance from linkis_manager_service_instance where instance=#{instance})")
+    void deleteNodeMetrics(@Param("instance") String instance);
+
+    @Delete("delete from linkis_manager_service_instance_metrics where instance = #{instance}")
+    void deleteNodeMetricsByInstance(@Param("instance") String instance);
+
+    @Select("select A.name,B.* from linkis_manager_service_instance A join linkis_manager_service_instance_metrics B where A.instance =  B.instance")
+    @Results({
+            @Result(property = "instance", column = "instance"),
+            @Result(property = "heartBeatMsg", column = "heartbeat_msg"),
+            @Result(property = "status", column = "instance_status"),
+            @Result(property = "healthy", column = "healthy_status"),
+            @Result(property = "updateTime", column = "update_time"),
+            @Result(property = "createTime", column = "create_time")
+    })
+    @ResultType(PersistenceNodeMetricsEntity.class)
+    List<PersistenceNodeMetricsEntity>  getAllNodeMetrics();
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/ResourceManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/ResourceManagerMapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.dao;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import org.apache.ibatis.annotations.*;
+
+import java.util.List;
+
+@Mapper
+public interface ResourceManagerMapper {
+    @Options(useGeneratedKeys = true, keyProperty = "id", keyColumn = "id")
+    //@SelectKey(statement = "select last_insert_id() AS id", keyProperty = "id", before = false, resultType = int.class)
+    @Insert("INSERT INTO  linkis_manager_linkis_resources VALUES" +
+            "(#{id},#{maxResource},#{minResource},#{usedResource},#{leftResource},#{expectedResource},#{lockedResource},#{resourceType},#{ticketId},now(),now(),#{updator},#{creator})")
+    void registerResource(PersistenceResource persistenceResource);
+
+    @Update({ "update linkis_manager_linkis_resources set max_resource = #{persistenceResource.maxResource},min_resource = #{persistenceResource.minResource}, " +
+            "used_resource=#{persistenceResource.usedResource},left_resource=#{persistenceResource.leftResource},expected_resource=#{persistenceResource.expectedResource}," +
+            "locked_resource=#{persistenceResource.lockedResource},resourceType=#{persistenceResource.resourceType}," +
+            "update_time=#{persistenceResource.updateTime},create_time=#{persistenceResource.createTime} where ticketId = #{ticketId}"})
+    void nodeResourceUpdate(@Param("ticketId") String ticketId,@Param("persistenceResource") PersistenceResource persistenceResource);
+
+    @Update({"update linkis_manager_linkis_resources set max_resource = #{persistenceResource.maxResource},min_resource = #{persistenceResource.minResource}," +
+            "used_resource=#{persistenceResource.usedResource},left_resource=#{persistenceResource.leftResource},expected_resource=#{persistenceResource.expectedResource}," +
+            "locked_resource=#{persistenceResource.lockedResource},resourceType=#{persistenceResource.resourceType},ticketId=#{persistenceResource.ticketId}," +
+            "update_time=#{persistenceResource.updateTime},create_time=#{persistenceResource.createTime} where id = #{resourceId}"})
+    void nodeResourceUpdateByResourceId(@Param("resourceId") int resourceId,@Param("persistenceResource") PersistenceResource persistenceResource);
+
+    @Select("select id from linkis_manager_linkis_resources where ticketId is null and id in ( select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id=B.label_id and B.service_instance=#{instance})")
+    int getNodeResourceUpdateResourceId(@Param("instance") String  instance);
+
+//    @Select("select * from linkis_manager_linkis_resources where  id  in  \n" +
+//            "(select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id=B.label_id  and B.service_instance_id=#{serviceInstanceId})")
+//    @Results({
+//            @Result(property = "maxResource", column = "max_resource"),
+//            @Result(property = "minResource", column = "min_resource"),
+//            @Result(property = "usedResource", column = "used_resource"),
+//            @Result(property = "leftResource", column = "left_resource"),
+//            @Result(property = "expectedResource", column = "expected_resource"),
+//            @Result(property = "lockedResource", column = "locked_resource"),
+//            @Result(property = "updateTime", column = "update_time"),
+//            @Result(property = "createTime", column = "create_time"),
+//
+//    })
+//    List<PersistenceResource> getResourceByServiceInstanceId(@Param("serviceInstanceId") int serviceInstanceId);
+//
+//    @Select("select * from linkis_manager_linkis_resources where id = #{id}")
+//    PersistenceResource getResourceById(@Param("id") int id);
+//
+//    @Delete("delete from linkis_manager_linkis_resources where id = #{id}")
+//    void deleteResourceById(@Param("id") int id);
+
+    @Delete("delete from linkis_manager_label_resource where label_id in (select label_id from linkis_manager_label_service_instance where service_instance=#{instance})")
+    void deleteResourceAndLabelId(@Param("instance") String  instance);
+
+    @Delete("delete from linkis_manager_linkis_resources where id in " +
+            "(select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id=B.label_id and B.service_instance = #{instance} )")
+    void deleteResourceByInstance(@Param("instance") String  instance);
+
+    @Delete("delete from linkis_manager_linkis_resources where ticketId = #{ticketId}")
+    void deleteResourceByTicketId(@Param("ticketId") String ticketId);
+
+//    @Select("select * from linkis_manager_linkis_resources where id = #{id} adn resourceType = #{resourceType}")
+//    PersistenceResource getResourceByIdAndType(@Param("id") int id,@Param("resourceType") String resourceType);
+
+    @Select("select * from linkis_manager_linkis_resources where resourceType = #{resourceType} and" +
+            " id in (select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id = B.label_id and B.service_instance=#{instance})")
+    List<PersistenceResource> getResourceByInstanceAndResourceType(@Param("instance") String   instance,@Param("resourceType") String   resourceType);
+
+    @Select("select * from linkis_manager_linkis_resources where id in " +
+            "(select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id = B.label_id and B.service_instance= #{instance})")
+    List<PersistenceResource> getResourceByServiceInstance(@Param("instance") String   instance);
+
+    @Select("select * from linkis_manager_linkis_resources where ticketId = #{ticketId}")
+    PersistenceResource getNodeResourceByTicketId(@Param("ticketId") String ticketId);
+
+    @Select("select * from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource A join linkis_manager_lable_user B on A.label_id=B.label_id AND B.user_name=#{userName})")
+    List<PersistenceResource> getResourceByUserName(@Param("userName") String  userName);
+
+    @Select("select * from linkis_manager_label where id in (select label_id from linkis_manager_label_resource A join linkis_manager_linkis_resources B on A.resource_id=B.id and B.ticketId=#{ticketId})")
+    List<PersistenceLabel> getLabelsByTicketId(@Param("ticketId") String ticketId);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/LabelManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/LabelManagerMapper.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+
+
+<mapper namespace="com.webank.wedatasphere.linkis.manager.dao.LabelManagerMapper">
+
+    <select id="dimListNodeRelationsByKeyValueMap" resultType="java.util.HashMap">
+        <foreach collection="keyValueMap" index="key" item="value" separator="union all">
+            SELECT l.id AS 'id',l.label_value_size AS 'labelValueSize',l.label_key AS 'labelKey',l.label_value AS
+            'stringValue',si.instance,si.name AS 'applicationName'
+            FROM linkis_manager_label l, linkis_manager_label_service_instance lsi,linkis_manager_label_value_relation
+            lvr,linkis_manager_service_instance si
+            WHERE l.id = lsi.label_id AND l.id = lvr.label_id AND lsi.service_instance = si.instance AND
+            (lvr.label_value_key ,lvr.label_value_content) IN
+            <foreach collection="value" index="valueKey" item="valueContent" open="(" close=")"
+                     separator=",">
+                (#{valueKey},#{valueContent})
+            </foreach>
+            GROUP BY l.id,si.instance
+            <if test="valueRelation == 'ALL'">
+                HAVING COUNT(1) = l.label_value_size and count(1) = ${value.size}
+            </if>
+            <if test="valueRelation == 'AND'">
+                HAVING l.label_value_size >= COUNT(1) and count(1) >= ${value.size}
+            </if>
+            <if test="valueRelation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+    <select id="listLabelRelationByServiceInstance"
+            parameterType="com.webank.wedatasphere.linkis.common.ServiceInstance" resultType="java.util.HashMap">
+        SELECT l.id AS 'id',l.label_key AS 'labelKey',l.label_value AS 'stringValue',
+        l.label_value_size AS 'labelValueSize',si.instance,si.name AS 'applicationName' FROM
+        linkis_manager_label l
+        JOIN linkis_manager_label_service_instance lsi
+        ON l.id = lsi.label_id
+        JOIN linkis_manager_service_instance si
+        ON si.instance=lsi.service_instance
+        WHERE (si.instance,si.`name`) IN
+        <foreach collection="nodes" item="node" separator="," open="(" close=")">
+            (#{node.instance},#{node.applicationName})
+        </foreach>
+    </select>
+
+    <select id="getLabelByKeyValue"
+            resultType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel">
+        select * from linkis_manager_label where label_key = #{labelKey} and label_value = #{stringValue}
+    </select>
+
+    <select id="getNodeByLabelKeyValue" resultType="com.webank.wedatasphere.linkis.common.ServiceInstance">
+        SELECT si.instance ,si.name as 'application_name' FROM linkis_manager_label l ,
+        linkis_manager_label_service_instance lsi ,linkis_manager_service_instance si
+        WHERE l.id = lsi.label_id AND si.instance = lsi.service_instance and
+        l.label_key = #{labelKey} and l.label_value = #{stringValue}
+    </select>
+
+    <resultMap id="persistenceLabelResultMap"
+               type="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel">
+        <result column="label_value" property="stringValue"/>
+        <result column="label_feature" property="feature"/>
+    </resultMap>
+
+    <select id="listResourceLabelByValues" resultMap="persistenceLabelResultMap">
+        SELECT l.*
+        FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lr.label_id AND l.id = lvr.label_id
+        AND (lvr.label_value_key,lvr.label_value_content) IN
+        <foreach collection="values" item="value" open="(" close=")" separator=",">
+            (#{value.key},#{value.value})
+        </foreach>
+        GROUP BY l.id,lr.resource_id HAVING COUNT(1) = l.label_value_size
+    </select>
+
+    <select id="listResourceByLaBelId"
+            resultType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource">
+        SELECT r.* FROM linkis_manager_label_resource lr, linkis_manager_linkis_resources r
+        WHERE lr.resource_id = r.id and
+        lr.label_id = #{labelId}
+    </select>
+
+    <select id="dimListResourceBykeyValueMap"
+            resultType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource">
+
+        <foreach collection="keyValueMap" index="key" item="value" separator="union all">
+            SELECT r.*,l.label_value_size
+            FROM linkis_manager_label l ,linkis_manager_label_value_relation lvr,linkis_manager_label_resource lr,linkis_manager_linkis_resources r
+            WHERE l.id = lr.label_id AND l.id = lvr.label_id AND lr.resource_id = r.id
+            AND l.label_key = #{key}
+            AND (lvr.label_value_key,lvr.label_value_content) IN
+            <foreach collection="value" index="valueKey" item="valueContent" open="(" close=")" separator=",">
+                (#{valueKey},#{valueContent})
+            </foreach>
+            GROUP BY l.id,r.id
+            <if test="valueRelation == 'ALL'">
+                HAVING COUNT(1) = l.label_value_size and count(1) = ${value.size}
+            </if>
+            <if test="valueRelation == 'AND'">
+                HAVING l.label_value_size >= COUNT(1) and count(1) >= ${value.size}
+            </if>
+            <if test="valueRelation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+    <delete id="deleteResourceByLabelIdInDirect">
+        delete from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource  where label_id = #{label_id});
+    </delete>
+
+    <delete id="deleteResourceByLabelId">
+            delete from linkis_manager_label_resource where label_id = #{label_id};
+    </delete>
+
+    <delete id="deleteResourceByLabelKeyValuesMapsInDirect">
+        delete from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource
+        where label_id = (select tmp.id from (
+        SELECT l.id,l.label_value_size
+        FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lr.label_id AND l.id = lvr.label_id
+        AND (l.label_key,lvr.label_value_key,lvr.label_value_content) IN
+        <foreach collection="labelKeyValues" index="labelKey" item="labelValues" open="(" close=")" separator=",">
+            <foreach collection="labelValues" index="valueKey" item="valueContent" open="(" close=")" separator="),(">
+                #{labelKey},#{valueKey},#{valueContent}
+            </foreach>
+        </foreach>
+        GROUP BY l.id,lr.id HAVING COUNT(1) = l.label_value_size
+        ) as tmp)
+        );
+    </delete>
+    <delete id="deleteResourceByLabelKeyValuesMaps">
+        delete from linkis_manager_label_resource where label_id = (select tmp.id from (
+        SELECT l.id,l.label_value_size
+        FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lr.label_id AND l.id = lvr.label_id
+        AND (l.label_key,lvr.label_value_key,lvr.label_value_content) IN
+        <foreach collection="labelKeyValues" index="labelKey" item="labelValues" open="(" close=")" separator=",">
+            <foreach collection="labelValues" index="valueKey" item="valueContent" open="(" close=")" separator="),(">
+                #{labelKey},#{valueKey},#{valueContent}
+            </foreach>
+        </foreach>
+        GROUP BY l.id,lr.id HAVING COUNT(1) = l.label_value_size
+        ) as tmp);
+    </delete>
+
+    <delete id="batchDeleteResourceByLabelId">
+        delete from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource
+        where label_id in
+        <foreach collection="labelIds" item="labelId" open="(" close=")" separator=",">
+            #{labelId}
+        </foreach>
+        );
+        delete from linkis_manager_label_resource where label_id in
+        <foreach collection="labelIds" item="labelId" open="(" close=");" separator=",">
+            #{labelId}
+        </foreach>
+    </delete>
+
+    <delete id="batchDeleteResourceByLabelKeyValuesMaps">
+
+        delete from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource
+        where label_id in (
+        select tmp.id from(
+        SELECT l.id,l.label_value_size
+        FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lr.label_id AND l.id = lvr.label_id
+        AND (l.label_key,lvr.label_value_key,lvr.label_value_content) IN
+        <foreach collection="labelKeyValues" index="labelKey" item="labelValues" open="(" close=")" separator=",">
+            <foreach collection="labelValues" index="valueKey" item="valueContent" open="(" close=")" separator="),(">
+                #{labelKey},#{valueKey},#{valueContent}
+            </foreach>
+        </foreach>
+        GROUP BY l.id,lr.id HAVING COUNT(1) = l.label_value_size
+        ) as tmp
+        ));
+
+        delete from linkis_manager_label_resource where label_id in
+        (
+        select tmp.id from(
+        SELECT l.id,l.label_value_size
+        FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lr.label_id AND l.id = lvr.label_id
+        AND (l.label_key,lvr.label_value_key,lvr.label_value_content) IN
+        <foreach collection="labelKeyValues" index="labelKey" item="labelValues" open="(" close=")" separator=",">
+            <foreach collection="labelValues" index="valueKey" item="valueContent" open="(" close=")" separator="),(">
+                #{labelKey},#{valueKey},#{valueContent}
+            </foreach>
+        </foreach>
+        GROUP BY l.id,lr.id HAVING COUNT(1) = l.label_value_size
+        ) as tmp
+        );
+    </delete>
+
+    <select id="listLabelByKeyValueMap" resultMap="persistenceLabelResultMap">
+        SELECT l.*
+        FROM linkis_manager_label l ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lvr.label_id
+        AND (l.label_key,lvr.label_value_key,lvr.label_value_content) IN
+        <foreach collection="keyValueMap" index="key" item="value" open="(" close=")" separator=",">
+            <foreach collection="value" index="valueKey" item="valueContent" open="(" close=")" separator="),(">
+                #{key},#{valueKey},#{valueContent}
+            </foreach>
+        </foreach>
+        GROUP BY l.id HAVING COUNT(1) = l.label_value_size
+    </select>
+
+    <select id="dimListLabelByValueList" resultMap="persistenceLabelResultMap">
+        <foreach collection="valueList" index="i" item="value" separator="union all">
+            SELECT l.*
+            FROM linkis_manager_label l ,linkis_manager_label_value_relation lvr
+            WHERE l.id = lvr.label_id
+            AND (lvr.label_value_key,lvr.label_value_content) IN
+            <foreach collection="value" index="valueKey" item="valueContent" open="(" close=")" separator=",">
+                (#{valueKey},#{valueContent})
+            </foreach>
+            GROUP BY l.id
+            <if test="valueRelation == 'ALL'">
+                HAVING COUNT(1) = l.label_value_size and count(1) = ${value.size}
+            </if>
+            <if test="valueRelation == 'AND'">
+                HAVING l.label_value_size >= COUNT(1) and count(1) >= ${value.size}
+            </if>
+            <if test="valueRelation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+    <select id="dimListLabelByKeyValueMap" resultMap="persistenceLabelResultMap">
+        <foreach collection="keyValueMap" index="key" item="value" separator="union all">
+            SELECT l.*
+            FROM linkis_manager_label l ,linkis_manager_label_value_relation lvr
+            WHERE l.id = lvr.label_id
+            AND l.label_key = #{key}
+            AND (lvr.label_value_key,lvr.label_value_content) IN
+            <foreach collection="value" index="valueKey" item="valueContent" open="(" close=")" separator=",">
+                (#{valueKey},#{valueContent})
+            </foreach>
+            GROUP BY l.id
+            <if test="valueRelation == 'ALL'">
+                HAVING COUNT(1) = l.label_value_size and count(1) = ${value.size}
+            </if>
+            <if test="valueRelation == 'AND'">
+                HAVING l.label_value_size >= COUNT(1) and count(1) >= ${value.size}
+            </if>
+            <if test="valueRelation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+    <select id="dimlistResourceLabelByKeyValueMap" resultMap="persistenceLabelResultMap">
+        <foreach collection="keyValueMap" index="key" item="value" separator="union all">
+            SELECT l.*
+            FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+            WHERE l.id = lr.label_id AND l.id = lvr.label_id
+            AND l.label_key = #{key}
+            AND (lvr.label_value_key,lvr.label_value_content) IN
+            <foreach collection="value" index="valueKey" item="valueContent" open="(" close=")" separator=",">
+                (#{valueKey},#{valueContent})
+            </foreach>
+            GROUP BY l.id,lr.resource_id
+            <if test="valueRelation == 'ALL'">
+                HAVING COUNT(1) = l.label_value_size and count(1) = ${value.size}
+            </if>
+            <if test="valueRelation == 'AND'">
+                HAVING l.label_value_size >= COUNT(1) and count(1) >= ${value.size}
+            </if>
+            <if test="valueRelation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+</mapper>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/LockManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/LockManagerMapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+
+
+<mapper namespace="com.webank.wedatasphere.linkis.manager.dao.LockManagerMapper">
+
+<!--    &lt;!&ndash; 增 &ndash;&gt;-->
+<!--    <sql id="instance_id">-->
+<!--        `id`,`instance`,`name`,`owner`,`mark`,`update_time`,`create_time`,`updator`,`creator`-->
+<!--    </sql>-->
+
+<!--    <insert id="addNodeInstance" useGeneratedKeys="true" keyProperty="id"-->
+<!--            parameterType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode">-->
+<!--        INSERT INTO  linkis_manager_service_instance(<include refid="instance_id"/>)-->
+<!--        VALUES (#{id},#{instance},#{applicationName},#{owner},#{mark},#{updateTime},#{createTime},#{updator},#{creator})-->
+<!--    </insert>-->
+
+    <!-- 删除 -->
+<!--    <delete id="removeNodeInstance">-->
+<!--        DELETE FROM  linkis_manager_service_instance where instance = #{instance} and name = #{name}-->
+<!--    </delete>-->
+
+
+    <!-- 获取 -->
+<!--    <resultMap id="PersistenceNodeInstance"-->
+<!--               type="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode">-->
+<!--        <id column="owner" property="owner"/>-->
+<!--    </resultMap>-->
+
+<!--    <select id="getNodeInstances" resultType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode">-->
+<!--        SELECT * FROM  linkis_manager_service_instance where owner = #{owner}-->
+<!--    </select>-->
+
+    <!-- 更新 -->
+<!--    <update id="updateNodeInstance"-->
+<!--            parameterType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode">-->
+<!--        UPDATE  linkis_manager_service_instance-->
+<!--        <trim prefix="set" suffixOverrides=",">-->
+<!--            <if test="instance != null">`instance` = #{instance},</if>-->
+<!--            <if test="name != null">`name` = #{applicationName},</if>-->
+<!--            <if test="owner != null">`owner` = #{owner},</if>-->
+<!--            <if test="mark != null">`mark` = #{instance},</if>-->
+<!--            <if test="update_time != null">`update_time` = #{updateTime},</if>-->
+<!--            <if test="create_time != null">`create_time` = #{createTime},</if>-->
+<!--            <if test="updator != null">`updator` = #{updator},</if>-->
+<!--            <if test="creator != null">`creator` = #{creator},</if>-->
+<!--        </trim>-->
+<!--        WHERE instance = #{instance} and name = #{name}-->
+<!--    </update>-->
+
+
+<!--    <select id="getNodeInstanceId" resultType="int">-->
+<!--        SELECT id FROM  linkis_manager_service_instance where instance = #{instance} and name = #{name}-->
+<!--    </select>-->
+
+
+
+
+</mapper>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/NodeManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/NodeManagerMapper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+
+
+<mapper namespace="com.webank.wedatasphere.linkis.manager.dao.NodeManagerMapper">
+
+    <update id="updateNodeRelation">
+        update linkis_manager_engine_em set engine_instance = #{instance} where engine_instance = #{tickedId}
+    </update>
+
+
+    <update id="updateNodeLabelRelation">
+        update linkis_manager_label_service_instance set service_instance = #{instance} where service_instance = #{tickedId}
+    </update>
+
+
+
+
+</mapper>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/NodeMetricManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/NodeMetricManagerMapper.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+
+
+<mapper namespace="com.webank.wedatasphere.linkis.manager.dao.NodeMetricManagerMapper">
+
+    <!-- 增 -->
+<!--    <sql id="addNodeMetrics">-->
+<!--        `service_instance_id`,`status`,`overload`,`heartbeat_msg`,`healthy`,`serviceInstance`,`update_time`,`create_time`-->
+<!--    </sql>-->
+
+<!--    <insert id="addNodeMetrics" useGeneratedKeys="true" keyProperty="id"-->
+<!--            parameterType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetrics">-->
+<!--        INSERT INTO  linkis_manager_service_instance_metrics(<include refid="addNodeMetrics"/>)-->
+<!--        VALUES (#{serviceInstanceId},#{status},#{overload},#{heartBeatMsg},#{healthy},#{serviceInstance},#{updateTime},#{createTime})-->
+<!--    </insert>-->
+
+    <!-- 删除 -->
+<!--    <delete id="deleteNodeMetrics">-->
+<!--        DELETE FROM  linkis_manager_service_instance_metrics where service_instance_id = #{serviceInstanceId}-->
+<!--    </delete>-->
+
+
+    <!-- 获取 -->
+<!--    <resultMap id="PersistenceNodeMetrics"-->
+<!--               type="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetrics">-->
+<!--        <id column="service_instance_id" property="serviceInstanceId"/>-->
+<!--        <id column="status" property="status"/>-->
+<!--        <id column="overLoad" property="overLoad"/>-->
+<!--        <id column="heartbeat_msg" property="heartBeatMsg"/>-->
+<!--        <id column="healthy" property="healthy"/>-->
+<!--        <id column="serviceInstance" property="serviceInstance"/>-->
+<!--        <id column="update_time" property="updateTime"/>-->
+<!--        <id column="create_time" property="createTime"/>-->
+
+<!--    </resultMap>-->
+
+<!--    <select id="getNodeMetrics" resultMap="PersistenceNodeMetrics">-->
+<!--        SELECT * FROM  linkis_manager_service_instance_metrics where service_instance_id = #{serviceInstanceId}-->
+<!--    </select>-->
+
+
+    <!-- 更新 -->
+<!--    <update id="updateNodeMetrics"-->
+<!--            parameterType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetrics">-->
+<!--        UPDATE  linkis_manager_service_instance_metrics-->
+<!--        <trim prefix="set" suffixOverrides=",">-->
+<!--            <if test="service_instance_id != null">`service_instance_id` = #{serviceInstanceId},</if>-->
+<!--            <if test="status != null">`name` = #{status},</if>-->
+<!--            <if test="overload != null">`overload` = #{overLoad},</if>-->
+<!--            <if test="heartbeat_msg != null">`heartbeat_msg` = #{heartBeatMsg},</if>-->
+<!--            <if test="healthy != null">`healthy` = #{healthy},</if>-->
+<!--            <if test="serviceInstance != null">`healthy` = #{serviceInstance},</if>-->
+<!--            <if test="update_time != null">`update_time` = #{updateTime},</if>-->
+<!--            <if test="create_time != null">`create_time` = #{createTime},</if>-->
+<!--        </trim>-->
+<!--        WHERE service_instance_id = #{serviceInstanceId}-->
+<!--    </update>-->
+
+</mapper>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/ResourceManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/dao/impl/ResourceManagerMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+
+
+<mapper namespace="com.webank.wedatasphere.linkis.manager.dao.ResourceManagerMapper">
+<!--    <sql id="resource">-->
+<!--        `id`,`max_resource`,`min_resource`,`used_resource`,`left_resource`,`expected_resource`,`locked_resource`,`resourceType`,`ticketId`,`update_time`,`create_time`,`updator`,`creator`-->
+<!--    </sql>-->
+<!--    <insert id="registerResource" useGeneratedKeys="true" keyProperty="id"-->
+<!--            parameterType="com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource">-->
+<!--        <selectKey resultType="java.lang.Integer" order="AFTER" keyProperty="id">-->
+<!--            SELECT LAST_INSERT_ID() AS id-->
+<!--        </selectKey>-->
+<!--        INSERT INTO  linkis_manager_linkis_resources(<include refid="resource"/>)-->
+<!--        VALUES (#{id},#{maxResource},#{minResource},#{usedResource},#{leftResource},#{expectedResource},#{lockedResource},#{resourceType},#{ticketId},#{updateTime},#{createTime},#{updator},#{creator})-->
+<!--    </insert>-->
+</mapper>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/entity/Tunple.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/entity/Tunple.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.entity;
+
+public class Tunple<K, V> {
+    private final K key;
+    private final V value;
+
+    public Tunple(K k, V v) {
+        this.key = k;
+        this.value = v;
+    }
+
+    public Tunple(Tunple<? extends K, ? extends V> entry) {
+        this(entry.getKey(), entry.getValue());
+    }
+
+    public K getKey() {
+        return this.key;
+    }
+
+    public V getValue() {
+        return this.value;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/NodeInstanceDuplicateException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/NodeInstanceDuplicateException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.exception;
+
+public class NodeInstanceDuplicateException  extends PersistenceErrorException {
+    public NodeInstanceDuplicateException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/NodeInstanceNotFoundException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/NodeInstanceNotFoundException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.exception;
+
+public class NodeInstanceNotFoundException extends PersistenceErrorException {
+    public NodeInstanceNotFoundException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/PersistenceErrorException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/PersistenceErrorException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException;
+
+public class PersistenceErrorException  extends ErrorException  {
+    public PersistenceErrorException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+    public PersistenceErrorException(int errCode, String desc, Throwable e){
+        super(errCode,desc);
+        this.initCause(e);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/PersistenceWarnException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/exception/PersistenceWarnException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.WarnException;
+
+public class PersistenceWarnException extends WarnException {
+    public PersistenceWarnException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public PersistenceWarnException(int errCode, String desc, Throwable e) {
+        super(errCode, desc);
+        this.initCause(e);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/LabelManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/LabelManagerPersistence.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.List;
+import java.util.Map;
+
+public interface LabelManagerPersistence {
+
+    //插入标签
+    void addLabel(PersistenceLabel persistenceLabel);
+
+    //移除标签
+    void removeLabel(int id);
+
+    void removeLabel(PersistenceLabel persistenceLabel);
+
+    //更新标签
+    void updateLabel(int id, PersistenceLabel persistenceLabel);
+
+    //查询标签
+    PersistenceLabel getLabel(int id);
+
+    List<PersistenceLabel> getLabelByServiceInstance(ServiceInstance serviceInstance);
+
+    List<PersistenceLabel> getLabelByResource(PersistenceResource persistenceResource);
+
+    /**
+     * ON DUPLICATE KEY UPDATE label_id = "xxx"
+     *
+     * @param serviceInstance
+     * @param labelIds
+     */
+    void addLabelToNode(ServiceInstance serviceInstance, List<Integer> labelIds);
+
+    List<PersistenceLabel> getLabelsByValue(Map<String, String> labelKeyValues, Label.ValueRelation valueRelation);
+
+    List<PersistenceLabel> getLabelsByValueList(List<Map<String, String>> labelKeyValues, Label.ValueRelation valueRelation);
+
+    PersistenceLabel getLabelsByKeyValue(String labelKey, Map<String, String> labelKeyValues, Label.ValueRelation valueRelation);
+
+    List<PersistenceLabel> getLabelsByKeyValueMap(Map<String, Map<String, String>> labelKeyAndValuesMap, Label.ValueRelation valueRelation);
+
+    List<PersistenceLabel> getLabelsByKey(String labelKey);
+
+    void removeNodeLabels(ServiceInstance serviceInstance, List<Integer> labelIds);
+
+    List<ServiceInstance> getNodeByLabel(int labelId);
+
+    List<ServiceInstance> getNodeByLabels(List<Integer> labelIds);
+
+    void addLabelToUser(String userName, List<Integer> labelIds);
+
+    void removeLabelFromUser(String userName, List<Integer> labelIds);
+
+    List<String> getUserByLabel(int label);
+
+    List<String> getUserByLabels(List<Integer> labels);
+
+    List<PersistenceLabel> getLabelsByUser(String userName);
+
+    Map<PersistenceLabel, List<ServiceInstance>> getNodeRelationsByLabels(List<PersistenceLabel> labelIds);
+
+    Map<ServiceInstance, List<PersistenceLabel>> getLabelRelationsByServiceInstance(List<ServiceInstance> serviceInstances);
+
+    /**
+     * 通过labelkey 和StringValue找到唯一的label，返回值可能为null
+     *
+     * @param labelKey
+     * @param stringValue
+     * @return
+     */
+    PersistenceLabel getLabelByKeyValue(String labelKey, String stringValue);
+
+    /**
+     * 通过labelkey 和StringValue找到唯一的label，并且找出他所包含的所有instance
+     *
+     * @param labelKey
+     * @param stringValue
+     * @return
+     */
+    List<ServiceInstance> getNodeByLabelKeyValue(String labelKey, String stringValue);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/LockManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/LockManagerPersistence.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLock;
+
+public interface LockManagerPersistence {
+    void lock(PersistenceLock persistenceLock,Long timeOut);
+    void unlock(PersistenceLock persistenceLock);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/ManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/ManagerPersistence.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+public interface ManagerPersistence {
+    NodeManagerPersistence getNodeManagerPersistence();
+    LabelManagerPersistence getLabelManagerPersistence();
+    LockManagerPersistence getLockManagerPersistence();
+    ResourceManagerPersistence getResourceManagerPersistence();
+    NodeMetricManagerPersistence getNodeMetricManagerPersistence();
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/NodeManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/NodeManagerPersistence.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceErrorException;
+
+import java.util.List;
+
+public interface NodeManagerPersistence {
+
+    /**
+     * 保存node
+     *
+     * @param node
+     * @throws PersistenceErrorException
+     */
+    void addNodeInstance(Node node) throws PersistenceErrorException;
+
+    void updateEngineNode(ServiceInstance serviceInstance, Node node) throws PersistenceErrorException;
+
+    /**
+     * 移除node
+     *
+     * @param node
+     * @throws PersistenceErrorException
+     */
+    void removeNodeInstance(Node node) throws PersistenceErrorException;
+
+    /**
+     * 根据 owner 获取node列表
+     *
+     * @param owner
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<Node> getNodes(String owner) throws PersistenceErrorException;
+
+
+    /**
+     * 获取所有node列表
+     *
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<Node> getAllNodes() throws PersistenceErrorException;
+
+    /**
+     * 更新node信息
+     *
+     * @param node
+     * @throws PersistenceErrorException
+     */
+    void updateNodeInstance(Node node) throws PersistenceErrorException;
+
+    /**
+     * 根据 servericeinstance 获取 Node
+     * @param serviceInstance
+     * @return
+     * @throws PersistenceErrorException
+     */
+    Node getNode(ServiceInstance serviceInstance) throws PersistenceErrorException;
+
+    /**
+     * 1. 插入Engine
+     * 2. 插入Engine和EM关系
+     *
+     * @param engineNode
+     * @throws PersistenceErrorException
+     */
+    void addEngineNode(EngineNode engineNode) throws PersistenceErrorException;
+
+    /**
+     * 1. 删除Engine和Em关系，以及清理和Engine相关的metrics信息
+     * 2. 删除Engine本身
+     *
+     * @param engineNode
+     * @throws PersistenceErrorException
+     */
+    void deleteEngineNode(EngineNode engineNode) throws PersistenceErrorException;
+
+    /**
+     * 1. 通过Engine的ServiceInstance，获取Engine的信息和EM信息
+     *
+     * @param serviceInstance
+     * @return
+     * @throws PersistenceErrorException
+     */
+    EngineNode getEngineNode(ServiceInstance serviceInstance) throws PersistenceErrorException;
+
+    /**
+     * 通过Em的ServiceInstance 获取EM下面Engine的列表
+     *
+     * @param serviceInstance
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<EngineNode> getEngineNodeByEM(ServiceInstance serviceInstance) throws PersistenceErrorException;
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/NodeMetricManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/NodeMetricManagerPersistence.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeMetrics;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceErrorException;
+
+import java.util.List;
+
+public interface NodeMetricManagerPersistence {
+
+    /**
+     * 保存节点的Metric信息
+     * @param nodeMetrics
+     * @throws PersistenceErrorException
+     */
+    void addNodeMetrics(NodeMetrics nodeMetrics) throws PersistenceErrorException;
+
+    /**
+     * 保存或更新节点的metric
+     * @param nodeMetrics
+     * @throws PersistenceErrorException
+     */
+    void addOrupdateNodeMetrics(NodeMetrics nodeMetrics) throws PersistenceErrorException;
+
+    /**
+     * 获取多个节点的 metrics列表
+     * @param nodes
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<NodeMetrics> getNodeMetrics(List<? extends Node> nodes) throws PersistenceErrorException;
+
+    /**
+     *获取节点的nodemetrics
+     * @param node
+     * @return
+     * @throws PersistenceErrorException
+     */
+
+    NodeMetrics getNodeMetrics(Node node) throws PersistenceErrorException;
+
+    /**
+     * 删除节点的metric信息
+     * @param node
+     * @throws PersistenceErrorException
+     */
+    void deleteNodeMetrics(Node node) throws PersistenceErrorException;
+
+    List<NodeMetrics> getAllNodeMetrics() throws PersistenceErrorException;
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/ResourceLabelPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/ResourceLabelPersistence.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.label.LabelKeyValue;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ResourceLabelPersistence {
+
+
+    /**
+     * 拿到的Label一定要在 Label_resource 表中有记录
+     * labelKeyValues 是由多个Label打散好放到List中，方便存在重复的Key
+     * 1. 只要labelValueSize达到要求就返回
+     * 2. 返回的Label一定要在labelResource中有记录,也就是外面还得有一层Join
+     *
+     * @return
+     */
+    List<PersistenceLabel> getResourceLabels(List<LabelKeyValue> labelKeyValues);
+
+
+    /**
+     * 拿到的Label一定要在 Label_resource 表中有记录
+     * 返回的Label一定要在labelResource中有记录,也就是外面还得有一层Join
+     *
+     * @return
+     */
+    List<PersistenceLabel> getResourceLabels(Map<String, Map<String, String>> labelKeyAndValuesMap, Label.ValueRelation valueRelation);
+
+    /**
+     * 判断ID是否存在，如果不存在则先插入，在插入关联关系
+     *
+     * @param label
+     * @param persistenceResource
+     */
+    void setResourceToLabel(PersistenceLabel label, PersistenceResource persistenceResource);
+
+
+    /**
+     * 获取Resource 通过Label
+     *
+     * @param label
+     * @return
+     */
+    List<PersistenceResource> getResourceByLabel(PersistenceLabel label);
+
+    /**
+     * 删除label和resource的关联关系
+     *
+     * @param label
+     */
+    void removeResourceByLabel(PersistenceLabel label);
+
+
+    /**
+     * @param labels
+     */
+    void removeResourceByLabels(List<PersistenceLabel> labels);
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/ResourceManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/ResourceManagerPersistence.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceErrorException;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.List;
+
+public interface ResourceManagerPersistence {
+    /**
+     * 注册资源
+     * @param persistenceResource
+     * @throws PersistenceErrorException
+     */
+    void registerResource(PersistenceResource persistenceResource)  throws PersistenceErrorException;
+
+    void registerResource(ServiceInstance serviceInstance,PersistenceResource persistenceResource)  throws PersistenceErrorException;
+
+    /**
+     * 根据标签获取资源
+     * @param label
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<PersistenceResource> getResourceByLabel(Label label) throws PersistenceErrorException;
+
+    /**
+     * 根据用户获取资源
+     * @param user
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<PersistenceResource> getResourceByUser(String user) throws PersistenceErrorException;
+
+    /**
+     * 根据serviceinstance 和资源类型获取 资源
+     * @param serviceInstance
+     * @param resourceType
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<PersistenceResource> getResourceByServiceInstance(ServiceInstance serviceInstance,String resourceType) throws PersistenceErrorException;
+
+    /**
+     *根据serviceinstance获取资源
+     * @param serviceInstance
+     * @return
+     * @throws PersistenceErrorException
+     */
+    List<PersistenceResource> getResourceByServiceInstance(ServiceInstance serviceInstance) throws PersistenceErrorException;
+
+    /**
+     * 删除实例占用的资源
+     * @param serviceInstance
+     * @throws PersistenceErrorException
+     */
+    void  deleteServiceInstanceResource(ServiceInstance serviceInstance) throws PersistenceErrorException;
+
+    /**
+     * 删除过期资源
+     * @param ticketId
+     * @throws PersistenceErrorException
+     */
+    void deleteExpiredTicketIdResource(String ticketId) throws PersistenceErrorException;
+
+    /**
+     * 更新资源 新EM时候用这个
+     * @param serviceInstance
+     * @throws PersistenceErrorException
+     */
+    void nodeResourceUpdate(ServiceInstance serviceInstance,PersistenceResource persistenceResource) throws PersistenceErrorException;
+    //resource_id 可能有多条 更新em的时候要注意  过滤出没有 ticketid 的那条，它是em，更新它就行了，更新em用这个方法
+    /**
+     * 根据ticketId 获取资源
+     * @param ticketId
+     * @return
+     */
+    PersistenceResource getNodeResourceByTicketId (String ticketId);
+
+    /**
+     * 节点资源更新，更新引擎时候用这个
+     * @param ticketId
+     * @param persistenceResource
+     */
+    void nodeResourceUpdate (String ticketId,PersistenceResource persistenceResource);
+
+    List<PersistenceLabel> getLabelsByTicketId(String ticketId);
+
+    void lockResource(List<Integer> labelIds,PersistenceResource persistenceResource);
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultLabelManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultLabelManagerPersistence.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.dao.LabelManagerMapper;
+import com.webank.wedatasphere.linkis.manager.dao.NodeManagerMapper;
+import com.webank.wedatasphere.linkis.manager.entity.Tunple;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceWarnException;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import com.webank.wedatasphere.linkis.manager.label.utils.LabelUtils;
+import com.webank.wedatasphere.linkis.manager.persistence.LabelManagerPersistence;
+import com.webank.wedatasphere.linkis.manager.util.PersistenceUtils;
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class DefaultLabelManagerPersistence implements LabelManagerPersistence {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private LabelManagerMapper labelManagerMapper;
+
+    private NodeManagerMapper nodeManagerMapper;
+
+    public LabelManagerMapper getLabelManagerMapper() {
+        return labelManagerMapper;
+    }
+
+    public void setLabelManagerMapper(LabelManagerMapper labelManagerMapper) {
+        this.labelManagerMapper = labelManagerMapper;
+    }
+
+    public NodeManagerMapper getNodeManagerMapper() {
+        return nodeManagerMapper;
+    }
+
+    public void setNodeManagerMapper(NodeManagerMapper nodeManagerMapper) {
+        this.nodeManagerMapper = nodeManagerMapper;
+    }
+
+    @Override
+    public void addLabel(PersistenceLabel persistenceLabel) {
+        labelManagerMapper.registerLabel(persistenceLabel);
+        int labelId = persistenceLabel.getId();
+
+        //此处需要修正，要拿到 label_value_key label_value_content  labelValue中有多对参数
+        Map<String, String> labelValueKeyAndContent = persistenceLabel.getValue();
+
+        labelManagerMapper.registerLabelKeyValues(labelValueKeyAndContent, labelId);
+    }
+
+    @Override
+    public void removeLabel(int id) {
+        labelManagerMapper.deleteUserById(id);
+        labelManagerMapper.deleteLabelKeyVaules(id);
+        labelManagerMapper.deleteLabel(id);
+    }
+
+    @Override
+    public void removeLabel(PersistenceLabel persistenceLabel) {
+        String labelKey = persistenceLabel.getLabelKey();
+        String labelStringValue = persistenceLabel.getStringValue();
+        labelManagerMapper.deleteByLabel(labelKey, labelStringValue);
+    }
+
+    @Override
+    public void updateLabel(int id, PersistenceLabel persistenceLabel) {
+        //1.更新label表
+        //2.删掉value
+        //3.更新labelValue
+        // TODO: 2020/10/12  updateLabel 要重写判空
+        persistenceLabel.setUpdateTime(new Date());
+        labelManagerMapper.updateLabel(id, persistenceLabel);
+        labelManagerMapper.deleteLabelKeyVaules(id);
+        labelManagerMapper.registerLabelKeyValues(persistenceLabel.getValue(),id);
+    }
+
+    @Override
+    public PersistenceLabel getLabel(int id) {
+        return labelManagerMapper.getLabel(id);
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelByServiceInstance(ServiceInstance serviceInstance) {
+        List<PersistenceLabel> persistenceLabelList = labelManagerMapper.getLabelByServiceInstance(serviceInstance.getInstance());
+        persistenceLabelList.forEach(l -> l.setValue(LabelUtils.Jackson.fromJson(l.getStringValue(), Map.class)));
+        return persistenceLabelList;
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelByResource(PersistenceResource persistenceResource) {
+        List<PersistenceLabel> persistenceLabelList = labelManagerMapper.getLabelByResource(persistenceResource);
+        return persistenceLabelList;
+    }
+
+    @Override
+    public void addLabelToNode(ServiceInstance serviceInstance, List<Integer> labelIds) {
+        labelManagerMapper.addLabelServiceInstance(serviceInstance.getInstance(), labelIds);
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelsByValue(Map<String, String> value, Label.ValueRelation valueRelation) {
+        return getLabelsByValueList(Collections.singletonList(value), valueRelation);
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelsByValueList(List<Map<String, String>> valueList, Label.ValueRelation valueRelation) {
+        if (PersistenceUtils.valueListIsEmpty(valueList)) return Collections.emptyList();
+        if (valueRelation == null) valueRelation = Label.ValueRelation.ALL;
+        return labelManagerMapper.dimListLabelByValueList(PersistenceUtils.filterEmptyValueList(valueList), valueRelation.name()).stream().map(PersistenceUtils::setValue).collect(Collectors.toList());
+    }
+
+    @Override
+    public PersistenceLabel getLabelsByKeyValue(String labelKey, Map<String, String> value, Label.ValueRelation valueRelation) {
+        List<PersistenceLabel> labelsByValueList = getLabelsByKeyValueMap(Collections.singletonMap(labelKey, value), valueRelation);
+        return labelsByValueList.isEmpty() ? null : labelsByValueList.get(0);
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelsByKeyValueMap(Map<String, Map<String, String>> keyValueMap, Label.ValueRelation valueRelation) {
+        if (PersistenceUtils.KeyValueMapIsEmpty(keyValueMap)) return Collections.emptyList();
+        if (valueRelation == null) valueRelation = Label.ValueRelation.ALL;
+        return labelManagerMapper.dimListLabelByKeyValueMap(PersistenceUtils.filterEmptyKeyValueMap(keyValueMap), valueRelation.name()).stream().map(PersistenceUtils::setValue).collect(Collectors.toList());
+    }
+
+
+    @Override
+    public List<PersistenceLabel> getLabelsByKey(String labelKey) {
+        List<PersistenceLabel> persistenceLabelList = labelManagerMapper.getLabelsByLabelKey(labelKey);
+        return persistenceLabelList;
+    }
+
+//    public List<PersistenceLabel> getLabelsByValue(Map<String, String> labelKeyValues) {
+//        //先查id再由id得到标签
+//        List<Integer> labelIds = labelManagerMapper.getLabelByLabelKeyValues(labelKeyValues);
+//        List<PersistenceLabel> persistenceLabelList = labelManagerMapper.getLabelsByLabelIds(labelIds);
+//        return persistenceLabelList;
+//    }
+
+    @Override
+    public void removeNodeLabels(ServiceInstance serviceInstance, List<Integer> labelIds) {
+        String instance = serviceInstance.getInstance();
+        if (null != labelIds && !labelIds.isEmpty()) {
+            labelManagerMapper.deleteLabelIdsAndInstance(instance, labelIds);
+        }
+    }
+
+    @Override
+    public List<ServiceInstance> getNodeByLabel(int labelId) {
+        List<PersistenceNode> persistenceNodeList = labelManagerMapper.getInstanceByLabelId(labelId);
+        List<ServiceInstance> serviceInstanceList = new ArrayList<>();
+        for (PersistenceNode persistenceNode : persistenceNodeList) {
+            ServiceInstance serviceInstance = new ServiceInstance();
+            serviceInstance.setInstance(persistenceNode.getInstance());
+            serviceInstance.setApplicationName(persistenceNode.getName());
+            serviceInstanceList.add(serviceInstance);
+        }
+        return serviceInstanceList;
+    }
+
+    @Override
+    public List<ServiceInstance> getNodeByLabels(List<Integer> labelIds) {
+        if (labelIds == null || labelIds.isEmpty()) return Collections.emptyList();
+        List<String> instances = labelManagerMapper.getInstanceIdsByLabelIds(labelIds);
+        List<PersistenceNode> persistenceNodeList = nodeManagerMapper.getNodesByInstances(instances);
+
+        List<ServiceInstance> serviceInstanceList = new ArrayList<>();
+        for (PersistenceNode persistenceNode : persistenceNodeList) {
+            ServiceInstance serviceInstance = new ServiceInstance();
+            serviceInstance.setInstance(persistenceNode.getInstance());
+            serviceInstance.setApplicationName(persistenceNode.getName());
+            serviceInstanceList.add(serviceInstance);
+        }
+        return serviceInstanceList;
+    }
+
+    @Override
+    public void addLabelToUser(String userName, List<Integer> labelIds) {
+        labelManagerMapper.addLabelsByUser(userName, labelIds);
+    }
+
+    @Override
+    public void removeLabelFromUser(String userName, List<Integer> labelIds) {
+        labelManagerMapper.deleteLabelIdsByUser(userName, labelIds);
+    }
+
+    @Override
+    public List<String> getUserByLabel(int label) {
+        List<String> userNames = labelManagerMapper.getUserNameByLabelId(label);
+        return userNames;
+    }
+
+    @Override
+    public List<String> getUserByLabels(List<Integer> labelIds) {
+        List<String> userNames = labelManagerMapper.getUserNamesByLabelIds(labelIds);
+        return userNames;
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelsByUser(String userName) {
+        List<PersistenceLabel> persistenceLabelList = labelManagerMapper.getLabelsByUser(userName);
+        //to do sure actual type
+        return persistenceLabelList;
+    }
+
+    @Override
+    public Map<PersistenceLabel, List<ServiceInstance>> getNodeRelationsByLabels(List<PersistenceLabel> persistenceLabels) {
+        //空集合过滤& 转换
+        if (PersistenceUtils.persistenceLabelListIsEmpty(persistenceLabels)) return Collections.emptyMap();
+        Map<String, Map<String, String>> keyValueMap = PersistenceUtils.filterEmptyPersistenceLabelList(persistenceLabels).stream().collect(Collectors.toMap(PersistenceLabel::getLabelKey, PersistenceLabel::getValue));
+        try {
+            String dimType = Label.ValueRelation.ALL.name();
+            List<Map<String, Object>> nodeRelationsByLabels = labelManagerMapper.dimListNodeRelationsByKeyValueMap(keyValueMap, dimType);
+            List<Tunple<PersistenceLabel, ServiceInstance>> arrays = new ArrayList<Tunple<PersistenceLabel, ServiceInstance>>();
+            for (Map<String, Object> nodeRelationsByLabel : nodeRelationsByLabels) {
+                ServiceInstance serviceInstance = new ServiceInstance();
+                PersistenceLabel persistenceLabel = new PersistenceLabel();
+                BeanUtils.populate(serviceInstance, nodeRelationsByLabel);
+                BeanUtils.populate(persistenceLabel, nodeRelationsByLabel);
+                PersistenceUtils.setValue(persistenceLabel);
+                arrays.add(new Tunple(persistenceLabel, serviceInstance));
+            }
+            return arrays.stream()
+                    .collect(Collectors.groupingBy(Tunple::getKey)).entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, f -> f.getValue().stream().map(Tunple::getValue).collect(Collectors.toList())));
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            throw new PersistenceWarnException(10000, "beanutils populate failed", e);
+        }
+    }
+
+    @Override
+    public Map<ServiceInstance, List<PersistenceLabel>> getLabelRelationsByServiceInstance(List<ServiceInstance> serviceInstances) {
+        if (CollectionUtils.isEmpty(serviceInstances)) return Collections.emptyMap();
+        try {
+            List<Map<String, Object>> nodeRelationsByLabels = labelManagerMapper.listLabelRelationByServiceInstance(serviceInstances);
+            List<Tunple<ServiceInstance, PersistenceLabel>> arrays = new ArrayList<Tunple<ServiceInstance, PersistenceLabel>>();
+            for (Map<String, Object> nodeRelationsByLabel : nodeRelationsByLabels) {
+                ServiceInstance serviceInstance = new ServiceInstance();
+                PersistenceLabel persistenceLabel = new PersistenceLabel();
+                BeanUtils.populate(serviceInstance, nodeRelationsByLabel);
+                BeanUtils.populate(persistenceLabel, nodeRelationsByLabel);
+                PersistenceUtils.setValue(persistenceLabel);
+                arrays.add(new Tunple(serviceInstance, persistenceLabel));
+            }
+            return arrays.stream()
+                    .collect(Collectors.groupingBy(Tunple::getKey)).entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, f -> f.getValue().stream().map(Tunple::getValue).collect(Collectors.toList())));
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            throw new PersistenceWarnException(10000, "beanutils populate failed", e);
+        }
+    }
+
+    @Override
+    public PersistenceLabel getLabelByKeyValue(String labelKey, String stringValue) {
+        return labelManagerMapper.getLabelByKeyValue(labelKey, stringValue);
+    }
+
+    @Override
+    public List<ServiceInstance> getNodeByLabelKeyValue(String labelKey, String stringValue) {
+        return labelManagerMapper.getNodeByLabelKeyValue(labelKey, stringValue);
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultLockManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultLockManagerPersistence.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLock;
+import com.webank.wedatasphere.linkis.manager.dao.LockManagerMapper;
+import com.webank.wedatasphere.linkis.manager.persistence.LockManagerPersistence;
+
+public class DefaultLockManagerPersistence implements LockManagerPersistence {
+
+    private LockManagerMapper lockManagerMapper;
+
+    public LockManagerMapper getLockManagerMapper() {
+        return lockManagerMapper;
+    }
+
+    public void setLockManagerMapper(LockManagerMapper lockManagerMapper) {
+        this.lockManagerMapper = lockManagerMapper;
+    }
+
+    @Override
+    public void lock(PersistenceLock persistenceLock, Long timeOut) {
+        lockManagerMapper.lock(persistenceLock.getLockObject(),timeOut);
+    }
+
+    @Override
+    public void unlock(PersistenceLock persistenceLock) {
+        lockManagerMapper.unlock(persistenceLock.getLockObject());
+    }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultManagerPersistence.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.manager.persistence.*;
+
+public class DefaultManagerPersistence implements ManagerPersistence {
+
+    private NodeManagerPersistence nodeManagerPersistence;
+    private LabelManagerPersistence labelManagerPersistence;
+    private LockManagerPersistence lockManagerPersistence;
+    private ResourceManagerPersistence resourceManagerPersistence;
+    private NodeMetricManagerPersistence nodeMetricManagerPersistence;
+    private ResourceLabelPersistence resourceLabelPersistence;
+
+    @Override
+    public NodeMetricManagerPersistence getNodeMetricManagerPersistence() {
+        return nodeMetricManagerPersistence;
+    }
+
+    public void setNodeMetricManagerPersistence(NodeMetricManagerPersistence nodeMetricManagerPersistence) {
+        this.nodeMetricManagerPersistence = nodeMetricManagerPersistence;
+    }
+
+    @Override
+    public ResourceManagerPersistence getResourceManagerPersistence() {
+        return resourceManagerPersistence;
+    }
+
+    public void setResourceManagerPersistence(ResourceManagerPersistence resourceManagerPersistence) {
+        this.resourceManagerPersistence = resourceManagerPersistence;
+    }
+
+
+
+    @Override
+    public NodeManagerPersistence getNodeManagerPersistence() {
+        return nodeManagerPersistence;
+    }
+
+    public void setNodeManagerPersistence(NodeManagerPersistence nodeManagerPersistence) {
+        this.nodeManagerPersistence = nodeManagerPersistence;
+    }
+
+    @Override
+    public LabelManagerPersistence getLabelManagerPersistence() {
+        return labelManagerPersistence;
+    }
+
+    public void setLabelManagerPersistence(LabelManagerPersistence labelManagerPersistence) {
+        this.labelManagerPersistence = labelManagerPersistence;
+    }
+
+    @Override
+    public LockManagerPersistence getLockManagerPersistence() {
+        return lockManagerPersistence;
+    }
+
+    public void setLockManagerPersistence(LockManagerPersistence lockManagerPersistence) {
+        this.lockManagerPersistence = lockManagerPersistence;
+    }
+
+    public ResourceLabelPersistence getResourceLabelPersistence() {
+        return resourceLabelPersistence;
+    }
+
+    public void setResourceLabelPersistence(ResourceLabelPersistence resourceLabelPersistence) {
+        this.resourceLabelPersistence = resourceLabelPersistence;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultNodeManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultNodeManagerPersistence.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.AMEMNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.AMEngineNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeEntity;
+import com.webank.wedatasphere.linkis.manager.dao.NodeManagerMapper;
+import com.webank.wedatasphere.linkis.manager.dao.NodeMetricManagerMapper;
+import com.webank.wedatasphere.linkis.manager.exception.NodeInstanceDuplicateException;
+import com.webank.wedatasphere.linkis.manager.exception.NodeInstanceNotFoundException;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceErrorException;
+import com.webank.wedatasphere.linkis.manager.persistence.NodeManagerPersistence;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class DefaultNodeManagerPersistence implements NodeManagerPersistence {
+
+    private NodeManagerMapper nodeManagerMapper;
+
+    private NodeMetricManagerMapper metricManagerMapper;
+
+    public NodeManagerMapper getNodeManagerMapper() {
+        return nodeManagerMapper;
+    }
+
+    public void setNodeManagerMapper(NodeManagerMapper nodeManagerMapper) {
+        this.nodeManagerMapper = nodeManagerMapper;
+    }
+
+    public NodeMetricManagerMapper getMetricManagerMapper() {
+        return metricManagerMapper;
+    }
+
+    public void setMetricManagerMapper(NodeMetricManagerMapper metricManagerMapper) {
+        this.metricManagerMapper = metricManagerMapper;
+    }
+
+    @Override
+    public void addNodeInstance(Node node) throws PersistenceErrorException {
+        PersistenceNode persistenceNode = new PersistenceNode();
+        persistenceNode.setInstance(node.getServiceInstance().getInstance());
+        persistenceNode.setName(node.getServiceInstance().getApplicationName());
+        persistenceNode.setOwner(node.getOwner());
+        persistenceNode.setMark(node.getMark());
+        persistenceNode.setCreateTime(new Date());
+        persistenceNode.setUpdateTime(new Date());
+        persistenceNode.setCreator(node.getOwner());
+        persistenceNode.setUpdator(node.getOwner());
+
+        try {
+            nodeManagerMapper.addNodeInstance(persistenceNode);
+        } catch (DuplicateKeyException e) {
+            NodeInstanceDuplicateException nodeInstanceDuplicateException = new NodeInstanceDuplicateException(41001, "Node实例已存在");
+            nodeInstanceDuplicateException.initCause(e);
+            throw nodeInstanceDuplicateException;
+        }
+
+    }
+
+    @Override
+    public void updateEngineNode(ServiceInstance serviceInstance, Node node) throws PersistenceErrorException {
+        PersistenceNode persistenceNode = new PersistenceNode();
+        persistenceNode.setInstance(node.getServiceInstance().getInstance());
+        persistenceNode.setName(node.getServiceInstance().getApplicationName());
+        persistenceNode.setOwner(node.getOwner());
+        persistenceNode.setMark(node.getMark());
+        persistenceNode.setUpdateTime(new Date());
+        persistenceNode.setCreator(node.getOwner());//rm中插入记录的时候并未给出creator，所以需要set这个值
+        persistenceNode.setUpdator(node.getOwner());
+        try {
+            nodeManagerMapper.updateNodeInstance(serviceInstance.getInstance(), persistenceNode);
+            nodeManagerMapper.updateNodeRelation(serviceInstance.getInstance(),node.getServiceInstance().getInstance());
+            nodeManagerMapper.updateNodeLabelRelation(serviceInstance.getInstance(),node.getServiceInstance().getInstance());
+        } catch (Exception e) {
+            NodeInstanceNotFoundException nodeInstanceNotFoundException = new NodeInstanceNotFoundException(41002, "Node实例不存在");
+            nodeInstanceNotFoundException.initCause(e);
+            throw nodeInstanceNotFoundException;
+        }
+    }
+
+    @Override
+    public void removeNodeInstance(Node node) throws PersistenceErrorException {
+        String instance = node.getServiceInstance().getInstance();
+        try {
+            nodeManagerMapper.removeNodeInstance(instance);
+        } catch (Exception e) {
+            NodeInstanceNotFoundException nodeInstanceNotFoundException = new NodeInstanceNotFoundException(41002, "Node实例不存在");
+            nodeInstanceNotFoundException.initCause(e);
+            throw nodeInstanceNotFoundException;
+        }
+
+    }
+
+    @Override
+    public List<Node> getNodes(String owner) throws PersistenceErrorException {
+        List<PersistenceNode> nodeInstances = nodeManagerMapper.getNodeInstancesByOwner(owner);
+        List<Node> persistenceNodeEntitys = new ArrayList<>();
+        if (!nodeInstances.isEmpty()){
+            for (PersistenceNode persistenceNode:nodeInstances){
+                PersistenceNodeEntity persistenceNodeEntity = new PersistenceNodeEntity();
+                ServiceInstance serviceInstance = new ServiceInstance();
+                serviceInstance.setApplicationName(persistenceNode.getName());
+                serviceInstance.setInstance(persistenceNode.getInstance());
+                persistenceNodeEntity.setServiceInstance(serviceInstance);
+                persistenceNodeEntity.setMark(persistenceNode.getMark());
+                persistenceNodeEntity.setOwner(persistenceNode.getOwner());
+                persistenceNodeEntity.setStartTime(persistenceNode.getCreateTime());
+                persistenceNodeEntitys.add(persistenceNodeEntity);
+            }
+        }
+        return persistenceNodeEntitys;
+    }
+
+    @Override
+    public List<Node> getAllNodes() throws PersistenceErrorException {
+        List<PersistenceNode> nodeInstances = nodeManagerMapper.getAllNodes();
+        List<Node> persistenceNodeEntitys = new ArrayList<>();
+        if (!nodeInstances.isEmpty()){
+            for (PersistenceNode persistenceNode:nodeInstances){
+                PersistenceNodeEntity persistenceNodeEntity = new PersistenceNodeEntity();
+                ServiceInstance serviceInstance = new ServiceInstance();
+                serviceInstance.setApplicationName(persistenceNode.getName());
+                serviceInstance.setInstance(persistenceNode.getInstance());
+                persistenceNodeEntity.setServiceInstance(serviceInstance);
+                persistenceNodeEntity.setMark(persistenceNode.getMark());
+                persistenceNodeEntity.setOwner(persistenceNode.getOwner());
+                persistenceNodeEntity.setStartTime(persistenceNode.getCreateTime());
+                persistenceNodeEntitys.add(persistenceNodeEntity);
+            }
+        }
+        return persistenceNodeEntitys;
+    }
+
+    @Override
+    public void updateNodeInstance(Node node) throws PersistenceErrorException {
+
+        if (null != node) {
+            PersistenceNode persistenceNode = new PersistenceNode();
+            persistenceNode.setInstance(node.getServiceInstance().getInstance());
+            persistenceNode.setName(node.getServiceInstance().getApplicationName());
+            persistenceNode.setOwner(node.getOwner());
+            persistenceNode.setMark(node.getMark());
+            persistenceNode.setCreateTime(new Date());
+            persistenceNode.setUpdateTime(new Date());
+            persistenceNode.setCreator(node.getOwner());
+            persistenceNode.setUpdator(node.getOwner());
+            nodeManagerMapper.updateNodeInstanceOverload(persistenceNode);
+        }
+    }
+
+    @Override
+    public Node getNode(ServiceInstance serviceInstance) throws PersistenceErrorException {
+        String instance = serviceInstance.getInstance();
+        PersistenceNode nodeInstances = nodeManagerMapper.getNodeInstance(instance);
+        PersistenceNodeEntity persistenceNodeEntity = new PersistenceNodeEntity();
+        persistenceNodeEntity.setServiceInstance(serviceInstance);
+        persistenceNodeEntity.setOwner(nodeInstances.getOwner());
+        persistenceNodeEntity.setMark(nodeInstances.getMark());
+        persistenceNodeEntity.setStartTime(nodeInstances.getCreateTime());
+        return persistenceNodeEntity;
+    }
+
+    @Override
+    public void addEngineNode(EngineNode engineNode) throws PersistenceErrorException {
+        //插入engine
+        addNodeInstance(engineNode);
+        //插入关联关系，todo 异常后续统一处理
+        String engineNodeInstance = engineNode.getServiceInstance().getInstance();
+        String emNodeInstance = engineNode.getEMNode().getServiceInstance().getInstance();
+        nodeManagerMapper.addEngineNode(engineNodeInstance,emNodeInstance);
+    }
+
+    @Override
+    public void deleteEngineNode(EngineNode engineNode) throws PersistenceErrorException {
+        String engineNodeInstance = engineNode.getServiceInstance().getInstance();
+        String emNodeInstance = engineNode.getEMNode().getServiceInstance().getInstance();
+        //清理 engine和em 的关系表
+        nodeManagerMapper.deleteEngineNode(engineNodeInstance,emNodeInstance);
+        //清理 metric信息
+        metricManagerMapper.deleteNodeMetricsByInstance(engineNodeInstance);
+        //metricManagerMapper.deleteNodeMetrics(emNodeId);
+        //清除 引擎
+        nodeManagerMapper.removeNodeInstance(engineNode.getServiceInstance().getInstance());
+    }
+
+    @Override
+    public EngineNode getEngineNode(ServiceInstance serviceInstance) throws PersistenceErrorException {
+        //给定引擎的 serviceinstance 查到 emNode
+        PersistenceNode emNode = nodeManagerMapper.getEMNodeInstanceByEngineNode(serviceInstance.getInstance());
+        if (emNode == null) return null;
+        String emInstance = emNode.getInstance();
+        String emName = emNode.getName();
+        ServiceInstance emServiceInstance = new ServiceInstance();
+        emServiceInstance.setApplicationName(emName);
+        emServiceInstance.setInstance(emInstance);
+        AMEMNode amemNode = new AMEMNode();
+        amemNode.setMark(emNode.getMark());
+        amemNode.setOwner(emNode.getOwner());
+        amemNode.setServiceInstance(emServiceInstance);
+        amemNode.setStartTime(emNode.getCreateTime());
+
+        AMEngineNode amEngineNode = new AMEngineNode();
+        amEngineNode.setServiceInstance(serviceInstance);
+        PersistenceNode engineNode = nodeManagerMapper.getNodeInstance(serviceInstance.getInstance());
+        amEngineNode.setOwner(engineNode.getOwner());
+        amEngineNode.setMark(engineNode.getMark());
+        amEngineNode.setStartTime(engineNode.getCreateTime());
+        amEngineNode.setEMNode(amemNode);
+        return amEngineNode;
+    }
+
+    @Override
+    public List<EngineNode> getEngineNodeByEM(ServiceInstance serviceInstance) throws PersistenceErrorException {
+        //给定EM的 serviceinstance
+         PersistenceNode emNode = nodeManagerMapper.getNodeInstance(serviceInstance.getInstance());
+
+        List<PersistenceNode> engineNodeList = nodeManagerMapper.getNodeInstances(serviceInstance.getInstance());
+        List<EngineNode> amEngineNodeList =new ArrayList<>();
+        for (PersistenceNode engineNode : engineNodeList){
+            AMEMNode amEmNode = new AMEMNode();
+            amEmNode.setServiceInstance(serviceInstance);
+            amEmNode.setOwner(emNode.getOwner());
+            amEmNode.setMark(emNode.getMark());
+            amEmNode.setStartTime(emNode.getCreateTime());
+
+            AMEngineNode amEngineNode = new AMEngineNode();
+            ServiceInstance engineServiceInstance = new ServiceInstance();
+            engineServiceInstance.setInstance(engineNode.getInstance());
+            engineServiceInstance.setApplicationName(engineNode.getName());
+            amEngineNode.setServiceInstance(engineServiceInstance);
+            amEngineNode.setOwner(engineNode.getOwner());
+            amEngineNode.setMark(engineNode.getMark());
+            amEngineNode.setStartTime(engineNode.getCreateTime());
+            amEngineNode.setEMNode(amEmNode);
+
+            amEngineNodeList.add(amEngineNode);
+        }
+        return amEngineNodeList;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultNodeMetricManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultNodeMetricManagerPersistence.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeMetrics;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetrics;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceNodeMetricsEntity;
+import com.webank.wedatasphere.linkis.manager.dao.NodeManagerMapper;
+import com.webank.wedatasphere.linkis.manager.dao.NodeMetricManagerMapper;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceErrorException;
+import com.webank.wedatasphere.linkis.manager.persistence.NodeMetricManagerPersistence;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class DefaultNodeMetricManagerPersistence implements NodeMetricManagerPersistence {
+
+    private NodeManagerMapper nodeManagerMapper;
+
+    private NodeMetricManagerMapper nodeMetricManagerMapper;
+
+    public NodeManagerMapper getNodeManagerMapper() {
+        return nodeManagerMapper;
+    }
+
+    public void setNodeManagerMapper(NodeManagerMapper nodeManagerMapper) {
+        this.nodeManagerMapper = nodeManagerMapper;
+    }
+
+    public NodeMetricManagerMapper getNodeMetricManagerMapper() {
+        return nodeMetricManagerMapper;
+    }
+
+    public void setNodeMetricManagerMapper(NodeMetricManagerMapper nodeMetricManagerMapper) {
+        this.nodeMetricManagerMapper = nodeMetricManagerMapper;
+    }
+
+    @Override
+    public void addNodeMetrics(NodeMetrics nodeMetrics) throws PersistenceErrorException {
+        //直接插入 NodeMetric即可
+        PersistenceNodeMetrics persistenceNodeMetrics = new PersistenceNodeMetrics();
+        persistenceNodeMetrics.setInstance(nodeMetrics.getServiceInstance().getInstance());
+        persistenceNodeMetrics.setHealthy(nodeMetrics.getHealthy());
+        persistenceNodeMetrics.setHeartBeatMsg(nodeMetrics.getHeartBeatMsg());
+        persistenceNodeMetrics.setOverLoad(nodeMetrics.getOverLoad());
+        persistenceNodeMetrics.setStatus(nodeMetrics.getStatus());
+        persistenceNodeMetrics.setCreateTime(new Date());
+        persistenceNodeMetrics.setUpdateTime(new Date());
+        //todo 异常信息后面统一处理
+        nodeMetricManagerMapper.addNodeMetrics(persistenceNodeMetrics);
+    }
+
+    @Override
+    public void addOrupdateNodeMetrics(NodeMetrics nodeMetrics) throws PersistenceErrorException {
+        PersistenceNodeMetrics persistenceNodeMetrics = new PersistenceNodeMetrics();
+        String instance = nodeMetrics.getServiceInstance().getInstance();
+        //todo 异常信息后面统一处理
+        int isInstanceIdExist = nodeMetricManagerMapper.checkInstanceExist(instance);
+        //是否存在
+        if (isInstanceIdExist == 0) {
+            persistenceNodeMetrics.setInstance(nodeMetrics.getServiceInstance().getInstance());
+            persistenceNodeMetrics.setHealthy(nodeMetrics.getHealthy());
+            persistenceNodeMetrics.setHeartBeatMsg(nodeMetrics.getHeartBeatMsg());
+            persistenceNodeMetrics.setOverLoad(nodeMetrics.getOverLoad());
+            persistenceNodeMetrics.setStatus(nodeMetrics.getStatus());
+            persistenceNodeMetrics.setCreateTime(new Date());
+            persistenceNodeMetrics.setUpdateTime(new Date());
+            //todo 异常信息后面统一处理
+            nodeMetricManagerMapper.addNodeMetrics(persistenceNodeMetrics);
+        } else if (isInstanceIdExist == 1) {
+            persistenceNodeMetrics.setInstance(nodeMetrics.getServiceInstance().getInstance());
+            persistenceNodeMetrics.setHealthy(nodeMetrics.getHealthy());
+            persistenceNodeMetrics.setHeartBeatMsg(nodeMetrics.getHeartBeatMsg());
+            persistenceNodeMetrics.setOverLoad(nodeMetrics.getOverLoad());
+            persistenceNodeMetrics.setStatus(nodeMetrics.getStatus());
+            persistenceNodeMetrics.setCreateTime(new Date());
+            persistenceNodeMetrics.setUpdateTime(new Date());
+            nodeMetricManagerMapper.updateNodeMetrics(persistenceNodeMetrics, instance);
+        } else {
+            //其他情况都不处理，打印个告警日志
+        }
+    }
+
+    @Override
+    public List<NodeMetrics> getNodeMetrics(List<? extends Node> nodes) throws PersistenceErrorException {
+        if (nodes == null || nodes.isEmpty()) return Collections.emptyList();
+        List<NodeMetrics> nodeMetricsList = new ArrayList<>();
+        List<String> instances = new ArrayList<>();
+        for (Node node : nodes) {
+            String instance = node.getServiceInstance().getInstance();
+            instances.add(instance);
+        }
+
+        //根据  id 查 metric 信息
+        List<PersistenceNodeMetrics> persistenceNodeMetricsList = nodeMetricManagerMapper.getNodeMetricsByInstances(instances);
+
+        for (PersistenceNodeMetrics persistenceNodeMetric : persistenceNodeMetricsList) {
+            for (Node node : nodes) {
+                if (persistenceNodeMetric.getInstance().equals(node.getServiceInstance().getInstance())) {
+                    persistenceNodeMetric.setServiceInstance(node.getServiceInstance());
+                    nodeMetricsList.add(persistenceNodeMetric);
+                }
+            }
+        }
+
+
+        return nodeMetricsList;
+    }
+
+    @Override
+    public NodeMetrics getNodeMetrics(Node node) throws PersistenceErrorException {
+        PersistenceNodeMetrics persistenceNodeMetrics = nodeMetricManagerMapper.getNodeMetricsByInstance(node.getServiceInstance().getInstance());
+        if (persistenceNodeMetrics == null) return null;
+        persistenceNodeMetrics.setServiceInstance(node.getServiceInstance());
+        return persistenceNodeMetrics;
+    }
+
+
+    @Override
+    public void deleteNodeMetrics(Node node) throws PersistenceErrorException {
+        String instance = node.getServiceInstance().getInstance();
+        nodeMetricManagerMapper.deleteNodeMetrics(instance);
+    }
+
+    @Override
+    public List<NodeMetrics> getAllNodeMetrics() throws PersistenceErrorException {
+        List<PersistenceNodeMetricsEntity> allNodeMetrics = nodeMetricManagerMapper.getAllNodeMetrics();
+        List<NodeMetrics> persistenceNodeMetricsList = new ArrayList<>();
+        for (PersistenceNodeMetricsEntity persistenceNodeMetricsEntity : allNodeMetrics) {
+            PersistenceNodeMetrics persistenceNodeMetrics = new PersistenceNodeMetrics();
+            ServiceInstance serviceInstance = new ServiceInstance();
+            serviceInstance.setApplicationName(persistenceNodeMetricsEntity.getName());
+            serviceInstance.setInstance(persistenceNodeMetricsEntity.getInstance());
+            persistenceNodeMetrics.setServiceInstance(serviceInstance);
+            persistenceNodeMetrics.setInstance(persistenceNodeMetricsEntity.getHealthy());
+            persistenceNodeMetrics.setHeartBeatMsg(persistenceNodeMetricsEntity.getHeartBeatMsg());
+            persistenceNodeMetrics.setOverLoad(persistenceNodeMetricsEntity.getOverLoad());
+            persistenceNodeMetrics.setStatus(persistenceNodeMetricsEntity.getStatus());
+            persistenceNodeMetrics.setCreateTime(persistenceNodeMetricsEntity.getCreateTime());
+            persistenceNodeMetrics.setUpdateTime(persistenceNodeMetricsEntity.getUpdateTime());
+            persistenceNodeMetricsList.add(persistenceNodeMetrics);
+        }
+        return persistenceNodeMetricsList;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultResourceLabelPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultResourceLabelPersistence.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.label.LabelKeyValue;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.dao.LabelManagerMapper;
+import com.webank.wedatasphere.linkis.manager.dao.ResourceManagerMapper;
+import com.webank.wedatasphere.linkis.manager.entity.Tunple;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import com.webank.wedatasphere.linkis.manager.persistence.ResourceLabelPersistence;
+import com.webank.wedatasphere.linkis.manager.util.PersistenceUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class DefaultResourceLabelPersistence implements ResourceLabelPersistence {
+
+    private LabelManagerMapper labelManagerMapper;
+
+    private ResourceManagerMapper resourceManagerMapper;
+
+    public LabelManagerMapper getLabelManagerMapper() {
+        return labelManagerMapper;
+    }
+
+    public void setLabelManagerMapper(LabelManagerMapper labelManagerMapper) {
+        this.labelManagerMapper = labelManagerMapper;
+    }
+
+    public void setResourceManagerMapper(ResourceManagerMapper resourceManagerMapper) {
+        this.resourceManagerMapper = resourceManagerMapper;
+    }
+
+    /**
+     * 拿到的Label一定要在 Label_resource 表中有记录
+     * labelKeyValues 是由多个Label打散好放到List中，方便存在重复的Key
+     * 1. 只要labelValueSize达到要求就返回
+     * 2. 返回的Label一定要在labelResource中有记录,也就是外面还得有一层Join
+     *
+     * @return
+     */
+    @Override
+    public List<PersistenceLabel> getResourceLabels(List<LabelKeyValue> labelKeyValues) {
+        if (CollectionUtils.isEmpty(labelKeyValues)) return Collections.emptyList();
+        return labelManagerMapper.listResourceLabelByValues(labelKeyValues).stream()
+                .map(PersistenceUtils::setValue).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<PersistenceLabel> getResourceLabels(Map<String, Map<String, String>> labelKeyAndValuesMap, Label.ValueRelation valueRelation) {
+        if (PersistenceUtils.KeyValueMapIsEmpty(labelKeyAndValuesMap)) return Collections.emptyList();
+        return labelManagerMapper.dimlistResourceLabelByKeyValueMap(PersistenceUtils.filterEmptyKeyValueMap(labelKeyAndValuesMap), valueRelation.name()).stream()
+                .map(PersistenceUtils::setValue).collect(Collectors.toList());
+    }
+
+    @Override
+    public void setResourceToLabel(PersistenceLabel label, PersistenceResource persistenceResource) {
+        if (label == null || persistenceResource == null) return;
+        //label id 不为空，则直接通过label_id 查询，否则通过 value_key and value_content 查询
+        Integer labelId = label.getId();
+        // TODO: 2020/8/31 id 的包装类
+        if (labelId <= 0) {
+            if (MapUtils.isEmpty(label.getValue())) return;
+            List<PersistenceLabel> resourceLabels = labelManagerMapper.listLabelByKeyValueMap(Collections.singletonMap(label.getLabelKey(), label.getValue()));
+            labelId = resourceLabels.stream().findFirst().orElseGet(new Supplier<PersistenceLabel>() {
+                @Override
+                public PersistenceLabel get() {
+                    labelManagerMapper.registerLabel(label);
+                    return label;
+                }
+            }).getId();
+            label.setId(labelId);
+        }
+        //找到label对应的persistenceResourceId，不存在就插入，存在就更新
+        // TODO: 2020/9/8 多resource的判断，persistenceResource 有id的话，直接update这个
+        List <PersistenceResource> resourceByLabels = labelManagerMapper.listResourceByLaBelId(labelId);
+        if (CollectionUtils.isNotEmpty(resourceByLabels)) {
+            //删除
+            this.removeResourceByLabel(label);
+        }
+        //插入resource和relation记录
+        persistenceResource.setCreator(System.getProperty("user.name"));
+        persistenceResource.setUpdator(System.getProperty("user.name"));
+        resourceManagerMapper.registerResource(persistenceResource);
+        labelManagerMapper.addLabelsAndResource(persistenceResource.getId(), Collections.singletonList(labelId));
+    }
+
+    @Override
+    public List<PersistenceResource> getResourceByLabel(PersistenceLabel label) {
+        //label id 不为空，则直接通过label_id 查询，否则通过 value_key and value_content 查询
+        if (label == null) return Collections.emptyList();
+        if (label.getId() != null && label.getId() > 0) {
+            return labelManagerMapper.listResourceByLaBelId(label.getId());
+        } else {
+            Map<String, String> value = label.getValue();
+            if (MapUtils.isEmpty(value)) return Collections.emptyList();
+            String dimType = Label.ValueRelation.ALL.name();
+            return labelManagerMapper.dimListResourceBykeyValueMap(Collections.singletonMap(label.getLabelKey(), value), dimType);
+        }
+    }
+
+    @Override
+    public void removeResourceByLabel(PersistenceLabel label) {
+        //label id 不为空，则直接通过label_id 查询，否则通过 value_key and value_content 查询
+        if (label.getId() != null) {
+            labelManagerMapper.deleteResourceByLabelId(label.getId());
+            labelManagerMapper.deleteResourceByLabelIdInDirect(label.getId());
+        } else {
+            Map<String, String> value = label.getValue();
+            labelManagerMapper.deleteResourceByLabelKeyValuesMaps(Collections.singletonMap(label.getLabelKey(), value));
+            labelManagerMapper.deleteResourceByLabelKeyValuesMapsInDirect(Collections.singletonMap(label.getLabelKey(), value));
+        }
+    }
+
+    @Override
+    public void removeResourceByLabels(List<PersistenceLabel> labels) {
+        //label id 不为空，则直接通过label_id 查询，否则通过 value_key and value_content 查询
+        List<PersistenceLabel> notBlankIds = labels.stream().filter(l -> l.getId() != null).collect(Collectors.toList());
+        if (CollectionUtils.isNotEmpty(notBlankIds)) {
+            List<Integer> ids = notBlankIds.stream().map(PersistenceLabel::getId).collect(Collectors.toList());
+            labelManagerMapper.batchDeleteResourceByLabelId(ids);
+            labelManagerMapper.batchDeleteResourceByLabelIdInDirect(ids);
+        }
+        List<PersistenceLabel> blankIds = labels.stream().filter(l -> l.getId() == null).collect(Collectors.toList());
+        if (CollectionUtils.isNotEmpty(blankIds)) {
+            Map<String, Map<String, String>> keyValueMaps = blankIds.stream()
+                    .map(PersistenceUtils::entryToTunple)
+                    .collect(Collectors.toMap(Tunple::getKey, Tunple::getValue));
+            labelManagerMapper.batchDeleteResourceByLabelKeyValuesMaps(keyValueMaps);
+        }
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultResourceManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/persistence/impl/DefaultResourceManagerPersistence.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.persistence.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.dao.LabelManagerMapper;
+import com.webank.wedatasphere.linkis.manager.dao.NodeManagerMapper;
+import com.webank.wedatasphere.linkis.manager.dao.ResourceManagerMapper;
+import com.webank.wedatasphere.linkis.manager.exception.PersistenceErrorException;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import com.webank.wedatasphere.linkis.manager.persistence.ResourceManagerPersistence;
+
+import java.util.List;
+
+public class DefaultResourceManagerPersistence implements ResourceManagerPersistence {
+
+    private ResourceManagerMapper resourceManagerMapper;
+
+    private NodeManagerMapper nodeManagerMapper;
+
+    private LabelManagerMapper labelManagerMapper;
+
+    public ResourceManagerMapper getResourceManagerMapper() {
+        return resourceManagerMapper;
+    }
+
+    public void setResourceManagerMapper(ResourceManagerMapper resourceManagerMapper) {
+        this.resourceManagerMapper = resourceManagerMapper;
+    }
+
+    public NodeManagerMapper getNodeManagerMapper() {
+        return nodeManagerMapper;
+    }
+
+    public void setNodeManagerMapper(NodeManagerMapper nodeManagerMapper) {
+        this.nodeManagerMapper = nodeManagerMapper;
+    }
+
+    public LabelManagerMapper getLabelManagerMapper() {
+        return labelManagerMapper;
+    }
+
+    public void setLabelManagerMapper(LabelManagerMapper labelManagerMapper) {
+        this.labelManagerMapper = labelManagerMapper;
+    }
+
+    @Override
+    public void registerResource(PersistenceResource persistenceResource) throws PersistenceErrorException {
+        // 直接注册
+        resourceManagerMapper.registerResource(persistenceResource);
+    }
+
+    @Override
+    public void registerResource(ServiceInstance serviceInstance, PersistenceResource persistenceResource) throws PersistenceErrorException {
+        //保存资源
+        resourceManagerMapper.registerResource(persistenceResource);
+        //保存标签与资源的关系表
+        int resourceId = persistenceResource.getId();
+
+        //int instanceId = nodeManagerMapper.getNodeInstanceId(serviceInstance.getInstance(), serviceInstance.getApplicationName());
+        List<Integer> labelIds = labelManagerMapper.getLabelIdsByInstance(serviceInstance.getInstance());
+
+        labelManagerMapper.addLabelsAndResource(resourceId,labelIds);
+
+    }
+
+
+    @Override
+    public List<PersistenceResource> getResourceByLabel(Label label) throws PersistenceErrorException {
+        String labelKey = label.getLabelKey();
+        String stringValue = label.getStringValue();
+        List<PersistenceResource> persistenceResourceList = labelManagerMapper.getResourcesByLabel(labelKey,stringValue);
+        return persistenceResourceList;
+    }
+
+    @Override
+    public List<PersistenceResource> getResourceByUser(String user) throws PersistenceErrorException {
+        List<PersistenceResource> persistenceResourceList = resourceManagerMapper.getResourceByUserName(user);
+        return persistenceResourceList;
+    }
+
+    @Override
+    public List<PersistenceResource> getResourceByServiceInstance(ServiceInstance serviceInstance, String resourceType) throws PersistenceErrorException {
+        List<PersistenceResource> persistenceResourceList = resourceManagerMapper.getResourceByInstanceAndResourceType(serviceInstance.getInstance(), resourceType);
+        return persistenceResourceList;
+    }
+
+    @Override
+    public List<PersistenceResource> getResourceByServiceInstance(ServiceInstance serviceInstance) throws PersistenceErrorException {
+        List<PersistenceResource> persistenceResourceList = resourceManagerMapper.getResourceByServiceInstance(serviceInstance.getInstance());
+        return persistenceResourceList;
+    }
+
+    @Override
+    public void deleteServiceInstanceResource(ServiceInstance serviceInstance) throws PersistenceErrorException {
+        //移除资源
+        resourceManagerMapper.deleteResourceByInstance(serviceInstance.getInstance());
+        //移除关系
+        resourceManagerMapper.deleteResourceAndLabelId(serviceInstance.getInstance());
+    }
+
+    @Override
+    public void deleteExpiredTicketIdResource(String ticketId) throws PersistenceErrorException {
+        //关联表-标签资源表 删除
+        labelManagerMapper.deleteLabelResourceByByTicketId(ticketId);
+        //删除资源表
+        resourceManagerMapper.deleteResourceByTicketId(ticketId);
+    }
+
+    @Override
+    public void nodeResourceUpdate(ServiceInstance serviceInstance,PersistenceResource persistenceResource) throws PersistenceErrorException {
+        int resourceId = resourceManagerMapper.getNodeResourceUpdateResourceId(serviceInstance.getInstance());
+        resourceManagerMapper.nodeResourceUpdateByResourceId(resourceId,persistenceResource);
+    }
+
+    @Override
+    public PersistenceResource getNodeResourceByTicketId(String ticketId) {
+        PersistenceResource persistenceResource = resourceManagerMapper.getNodeResourceByTicketId(ticketId);
+        return persistenceResource;
+    }
+
+    @Override
+    public void nodeResourceUpdate(String ticketId, PersistenceResource persistenceResource) {
+        resourceManagerMapper.nodeResourceUpdate(ticketId,persistenceResource);
+    }
+
+    @Override
+    public List<PersistenceLabel> getLabelsByTicketId(String ticketId) {
+        List<PersistenceLabel> persistenceLabelList = resourceManagerMapper.getLabelsByTicketId(ticketId);
+        return persistenceLabelList;
+    }
+
+    @Override
+    public void lockResource(List<Integer> labelIds, PersistenceResource persistenceResource) {
+        resourceManagerMapper.registerResource(persistenceResource);
+        int resourceId = persistenceResource.getId();
+        labelManagerMapper.addLabelsAndResource(resourceId,labelIds);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/util/PersistenceUtils.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/com/webank/wedatasphere/linkis/manager/util/PersistenceUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.util;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.entity.Tunple;
+import com.webank.wedatasphere.linkis.manager.label.utils.LabelUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PersistenceUtils {
+
+    public static PersistenceLabel setValue(PersistenceLabel persistenceLabel) {
+        persistenceLabel.setValue(LabelUtils.Jackson.fromJson(persistenceLabel.getStringValue(), Map.class));
+        return persistenceLabel;
+    }
+
+    public static Tunple<String, Map<String, String>> entryToTunple(PersistenceLabel label) {
+        return new Tunple<>(label.getLabelKey(), label.getValue());
+    }
+
+    public static boolean valueListIsEmpty(List<Map<String, String>> valueList) {
+        return CollectionUtils.isEmpty(valueList)
+                || CollectionUtils.isEmpty(valueList.stream().filter(MapUtils::isNotEmpty).collect(Collectors.toList()));
+    }
+
+    public static List<Map<String, String>> filterEmptyValueList(List<Map<String, String>> valueList) {
+        return valueList.stream().filter(MapUtils::isNotEmpty).collect(Collectors.toList());
+    }
+
+    public static boolean KeyValueMapIsEmpty(Map<String, Map<String, String>> keyValueMap) {
+        return MapUtils.isEmpty(keyValueMap)
+                || MapUtils.isEmpty(keyValueMap.entrySet().stream().filter(e -> MapUtils.isNotEmpty(e.getValue())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    public static Map<String, Map<String, String>> filterEmptyKeyValueMap(Map<String, Map<String, String>> keyValueMap) {
+        return keyValueMap.entrySet().stream().filter(e -> MapUtils.isNotEmpty(e.getValue())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public static boolean persistenceLabelListIsEmpty(List<PersistenceLabel> persistenceLabelList) {
+        return CollectionUtils.isEmpty(persistenceLabelList) || CollectionUtils.isEmpty(persistenceLabelList.stream().filter(l -> MapUtils.isNotEmpty(l.getValue())).collect(Collectors.toList()));
+    }
+
+    public static List<PersistenceLabel> filterEmptyPersistenceLabelList(List<PersistenceLabel> persistenceLabelList) {
+        return persistenceLabelList.stream().filter(e -> MapUtils.isNotEmpty(e.getValue())).collect(Collectors.toList());
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/java/PersistenceTest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/java/PersistenceTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.label.LabelKeyValue;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel;
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource;
+import com.webank.wedatasphere.linkis.manager.dao.LabelManagerMapper;
+import com.webank.wedatasphere.linkis.manager.entity.Tunple;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import com.webank.wedatasphere.linkis.manager.persistence.ResourceLabelPersistence;
+import org.apache.commons.beanutils.BeanUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * created by v_wbjftang on 2020/8/25
+ */
+public class PersistenceTest {
+
+    AnnotationConfigApplicationContext context = null;
+
+    LabelManagerMapper labelManagerMapper = null;
+
+    ResourceLabelPersistence resourceLabelPersistence = null;
+
+    @Before
+    public void before() {
+        context = new AnnotationConfigApplicationContext(Scan.class);
+        labelManagerMapper = context.getBean(LabelManagerMapper.class);
+        resourceLabelPersistence = context.getBean(ResourceLabelPersistence.class);
+    }
+
+    @Test
+    public void test01() throws InvocationTargetException, IllegalAccessException {
+
+        PersistenceLabel persistenceLabel1 = new PersistenceLabel();
+        persistenceLabel1.setLabelKey("engineType");
+        persistenceLabel1.setValue(Collections.singletonMap("runType", "spark"));
+        System.out.println(persistenceLabel1.getStringValue());
+        PersistenceLabel persistenceLabel2 = new PersistenceLabel();
+        persistenceLabel2.setLabelKey("engineType");
+        persistenceLabel2.setValue(Collections.singletonMap("runType", "hive"));
+        System.out.println(persistenceLabel2.getStringValue());
+        List<PersistenceLabel> persistenceLabels = Arrays.asList(persistenceLabel1);
+        List<Map<String, Object>> nodeRelationsByLabels = labelManagerMapper.dimListNodeRelationsByKeyValueMap(Collections.singletonMap(persistenceLabel1.getLabelKey(),persistenceLabel1.getValue()), Label.ValueRelation.ALL.name());
+        List<Tunple<PersistenceLabel, ServiceInstance>> arrays = new ArrayList<Tunple<PersistenceLabel, ServiceInstance>>();
+        for (Map<String, Object> nodeRelationsByLabel : nodeRelationsByLabels) {
+            ServiceInstance serviceInstance = new ServiceInstance();
+            PersistenceLabel persistenceLabel = new PersistenceLabel();
+            BeanUtils.populate(serviceInstance, nodeRelationsByLabel);
+            BeanUtils.populate(persistenceLabel, nodeRelationsByLabel);
+            arrays.add(new Tunple(persistenceLabel, serviceInstance));
+        }
+        Map<PersistenceLabel, List<ServiceInstance>> collect = arrays.stream()
+                .collect(Collectors.groupingBy(Tunple::getKey)).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, f -> f.getValue().stream().map(Tunple::getValue).collect(Collectors.toList())));
+        System.out.println(collect);
+    }
+
+
+    @Test
+    public void test02() throws InvocationTargetException, IllegalAccessException {
+
+        List<ServiceInstance> list = Arrays.asList(ServiceInstance.apply("aaa", "localhost:8088"), ServiceInstance.apply("bbb", "localhost:8089"));
+        List<Map<String, Object>> nodeRelationsByLabels = labelManagerMapper.listLabelRelationByServiceInstance(list);
+        List<Tunple<ServiceInstance, PersistenceLabel>> arrays = new ArrayList<>();
+        for (Map<String, Object> nodeRelationsByLabel : nodeRelationsByLabels) {
+            ServiceInstance serviceInstance = new ServiceInstance();
+            PersistenceLabel persistenceLabel = new PersistenceLabel();
+            BeanUtils.populate(serviceInstance, nodeRelationsByLabel);
+            BeanUtils.populate(persistenceLabel, nodeRelationsByLabel);
+            arrays.add(new Tunple(serviceInstance, persistenceLabel));
+        }
+        Map<ServiceInstance, List<PersistenceLabel>> collect = arrays.stream()
+                .collect(Collectors.groupingBy(Tunple::getKey)).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, f -> f.getValue().stream().map(Tunple::getValue).collect(Collectors.toList())));
+        System.out.println(collect);
+    }
+
+
+    @Test
+    public void test03() throws InvocationTargetException, IllegalAccessException {
+
+        List<ServiceInstance> nodeByLabelKeyValue = labelManagerMapper.getNodeByLabelKeyValue("serverAlias", "em");
+        System.out.println(nodeByLabelKeyValue);
+    }
+
+
+    @Test
+    public void testListResourceLabelByValueList() throws InvocationTargetException, IllegalAccessException {
+        /*SELECT l.*,lvr.*
+                FROM linkis_manager_label l ,linkis_manager_label_resource lr ,linkis_manager_label_value_relation lvr
+        WHERE l.id = lr.label_id AND l.id = lvr.label_id
+        AND (lvr.label_value_key,lvr.label_value_content) IN (('alias','em'),('key2','value2'),("instance","localhost:9000"),("serviceName","sparkEngine"))
+        GROUP BY l.id HAVING COUNT(1) = l.label_value_size;*/
+        ArrayList<LabelKeyValue> labelKeyValues = new ArrayList<>();
+        labelKeyValues.add(new LabelKeyValue("alias", "em"));
+        labelKeyValues.add(new LabelKeyValue("key2", "value2"));
+        List<PersistenceLabel> persistenceLabels = labelManagerMapper.listResourceLabelByValues(labelKeyValues);
+        System.out.println(persistenceLabels);
+    }
+
+    @Test
+    public void testListResourceLabelByKeyValuesMaps() throws InvocationTargetException, IllegalAccessException {
+        HashMap<String, Map<String, String>> labelKeyValues = new HashMap<>();
+        HashMap<String, String> key1 = new HashMap<>();
+        key1.put("instance", "johnnwang:9026");
+        key1.put("serviceName", "linkis-engineManager");
+        labelKeyValues.put("emInstance", key1);
+        HashMap<String, String> key2 = new HashMap<>();
+        key2.put("instance", "localhost:9000");
+        key2.put("serviceName", "sparkEngine");
+        labelKeyValues.put("engineInstance", key2);
+        List<PersistenceLabel> persistenceLabels = labelManagerMapper.dimlistResourceLabelByKeyValueMap(labelKeyValues, Label.ValueRelation.ALL.name());
+        System.out.println(persistenceLabels);
+    }
+
+    @Test
+    public void testGetResourceByLaBelId() {
+        List<PersistenceResource> persistenceResources = labelManagerMapper.listResourceByLaBelId(1);
+        System.out.println(persistenceResources);
+    }
+
+    @Test
+    public void testGetResourceByKeyValuesMaps() {
+        HashMap<String, Map<String, String>> labelKeyValues = new HashMap<>();
+        HashMap<String, String> key1 = new HashMap<>();
+        key1.put("alias", "em");
+        key1.put("key2", "value2");
+        labelKeyValues.put("serverAlias", key1);
+        HashMap<String, String> key2 = new HashMap<>();
+        key2.put("instance", "localhost:9000");
+        key2.put("serviceName", "sparkEngine");
+        labelKeyValues.put("engineInstance", key2);
+        List<PersistenceLabel> persistenceLabels = labelManagerMapper.dimlistResourceLabelByKeyValueMap(labelKeyValues, Label.ValueRelation.ALL.name());
+        System.out.println(persistenceLabels);
+    }
+
+    @Test
+    public void testDeleteResourceByLabelId() {
+        labelManagerMapper.deleteResourceByLabelId(1);
+    }
+
+    @Test
+    public void testDeleteResourceByLabelKeyValuesMaps() {
+        HashMap<String, Map<String, String>> labelKeyValues = new HashMap<>();
+        HashMap<String, String> key1 = new HashMap<>();
+        key1.put("alias", "em");
+        key1.put("key2", "value2");
+        labelKeyValues.put("serverAlias", key1);
+        labelManagerMapper.deleteResourceByLabelKeyValuesMaps(labelKeyValues);
+        labelManagerMapper.deleteResourceByLabelKeyValuesMapsInDirect(labelKeyValues);
+    }
+
+    @Test
+    public void testBatchDeleteResourceByLabelId() {
+        labelManagerMapper.batchDeleteResourceByLabelId(Arrays.asList(3, 4));
+        labelManagerMapper.batchDeleteResourceByLabelIdInDirect(Arrays.asList(3, 4));
+    }
+
+    @Test
+    public void testBatchDeleteResourceByLabelKeyValuesMaps() {
+        HashMap<String, Map<String, String>> labelKeyValues = new HashMap<>();
+        HashMap<String, String> key1 = new HashMap<>();
+        key1.put("alias", "em");
+        key1.put("key2", "value2");
+        labelKeyValues.put("serverAlias", key1);
+        HashMap<String, String> key2 = new HashMap<>();
+        key2.put("instance", "localhost:9000");
+        key2.put("serviceName", "sparkEngine");
+        labelKeyValues.put("engineInstance", key2);
+        labelManagerMapper.batchDeleteResourceByLabelKeyValuesMaps(labelKeyValues);
+    }
+
+    @Test
+    public void testSetResource01() {
+        HashMap<String, Map<String, String>> labelKeyValues = new HashMap<>();
+        HashMap<String, String> key1 = new HashMap<>();
+        key1.put("alias", "em");
+        key1.put("key2", "value2");
+        labelKeyValues.put("serverAlias", key1);
+        HashMap<String, String> key2 = new HashMap<>();
+        key2.put("instance", "localhost:9000");
+        key2.put("serviceName", "sparkEngine");
+        labelKeyValues.put("engineInstance", key2);
+        PersistenceResource persistenceResource = new PersistenceResource();
+        persistenceResource.setMaxResource("100");
+        PersistenceLabel persistenceLabel = new PersistenceLabel();
+        persistenceLabel.setId(3);
+        resourceLabelPersistence.setResourceToLabel(persistenceLabel, persistenceResource);
+    }
+
+    @Test
+    public void testSetResource02() {
+        HashMap<String, Map<String, String>> labelKeyValues = new HashMap<>();
+        HashMap<String, String> key1 = new HashMap<>();
+        key1.put("alias", "em");
+        key1.put("key2", "value2");
+        labelKeyValues.put("serverAlias", key1);
+        HashMap<String, String> key2 = new HashMap<>();
+        key2.put("instance", "localhost:9000");
+        key2.put("serviceName", "sparkEngine");
+        labelKeyValues.put("engineInstance", key2);
+        PersistenceResource persistenceResource = new PersistenceResource();
+        persistenceResource.setMaxResource("300");
+        PersistenceLabel persistenceLabel = new PersistenceLabel();
+        persistenceLabel.setValue(key1);
+        persistenceLabel.setLabelKey("serverAlias");
+        resourceLabelPersistence.setResourceToLabel(persistenceLabel, persistenceResource);
+    }
+
+    @Test
+    public void testdimListLabelByValueList() throws InvocationTargetException, IllegalAccessException {
+        HashMap<String, String> stringStringHashMap = new HashMap<>();
+        stringStringHashMap.put("type", "spark");
+        //stringStringHashMap.put("version","2.4.3");
+        stringStringHashMap.put("aaa", "bbb");
+        List<PersistenceLabel> persistenceLabels = labelManagerMapper.dimListLabelByValueList(Arrays.asList(stringStringHashMap), Label.ValueRelation.OR.name());
+        System.out.println(persistenceLabels.size());
+    }
+
+    @Test
+    public void testdimListLabelsByKeyValueMap() throws InvocationTargetException, IllegalAccessException {
+        HashMap<String, String> stringStringHashMap = new HashMap<>();
+        stringStringHashMap.put("type", "spark");
+        //stringStringHashMap.put("version","2.4.3");
+        stringStringHashMap.put("aaa", "bbb");
+        List<PersistenceLabel> persistenceLabels = labelManagerMapper.dimListLabelByKeyValueMap(Collections.singletonMap("combined_xx_xx", stringStringHashMap), Label.ValueRelation.AND.name());
+        System.out.println(persistenceLabels.size());
+    }
+
+
+    @Test
+    public void testListLabelByKeyValueMap() throws InvocationTargetException, IllegalAccessException {
+        HashMap<String, String> stringStringHashMap = new HashMap<>();
+        stringStringHashMap.put("type", "spark");
+        stringStringHashMap.put("version", "2.4.3");
+        stringStringHashMap.put("aaa", "bbb");
+        stringStringHashMap.put("ccc", "ddd");
+        stringStringHashMap.put("eee", "fff");
+        List<PersistenceLabel> persistenceLabels = labelManagerMapper.listLabelByKeyValueMap(Collections.singletonMap("combined_xx_xx", stringStringHashMap));
+        System.out.println(persistenceLabels.size());
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/java/Scan.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/java/Scan.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.*;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * Created by v_wbjftang on 2020/2/13.
+ */
+@ComponentScan(value = "com.webank.wedatasphere", excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,value = DataWorkCloudApplication.class))
+@Configuration
+@EnableAspectJAutoProxy
+public class Scan {
+    @Autowired
+    private DataSource dataSource;
+
+    @Bean
+    public JdbcTemplate getJdbcTemplate() {
+        return new JdbcTemplate(dataSource);
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/resources/linkis.properties
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/resources/linkis.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2019 WeBank
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+wds.linkis.test.mode=true
+wds.linkis.server.mybatis.datasource.url=
+wds.linkis.server.mybatis.datasource.username=
+wds.linkis.server.mybatis.datasource.password=
+wds.linkis.log.clear=true
+wds.linkis.server.version=v1
+##mybatis
+wds.linkis.server.mybatis.mapperLocations=classpath*:com\\webank\\wedatasphere\\linkis\\manager\\dao\\impl\\*.xml
+wds.linkis.server.mybatis.BasePackage=com.webank.wedatasphere.linkis.manager.dao

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/resources/manager.sql
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/test/resources/manager.sql
@@ -1,0 +1,164 @@
+-- 0.实例表：engine/EM,每个enginemanager有一个唯一标签记录它的资源，engine会继承这个em的标签
+-- 1.所有 linkis_manager 开头分模块
+-- 2.错误码统一,
+-- 3.配置文件保持唯一
+-- 4.微服务名字唯一
+-- 5.启动/停止脚本 传参提供类名即可
+
+-- 针对 entrance 作为EM的情况,instance可以插入多条记录,unique key 一定是 instance，ip和端口 ,name 作为类型
+CREATE TABLE `linkis_manager_service_instance`(
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `instance` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `owner` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `mark` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  `updator` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `creator` varchar(255) COLLATE utf8_bin DEFAULT NULL,  
+  unique key instance(`instance`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+-- select * from linkis_manager_service_instance_metrics where service_instance_id in (select id from linkis_manager_service_instance where instance={instance} and name=#{name})
+
+-- select * from linkis_manager_service_instance_metrics where service_instance_id in  (select id from linkis_manager_service_instance where instance=#{} )
+
+-- metric表 service_instance_metrics: service_instance_id status{运行状态，负载情况}  
+CREATE TABLE `linkis_manager_service_instance_metrics` (
+  `instance` varchar(16) NOT NULL,
+  `instance_status` int(11) DEFAULT NULL,
+  `overload` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `heartbeat_msg` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `healthy_status` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(), 
+  PRIMARY KEY (`instance`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+
+CREATE TABLE `linkis_manager_metrics_history` (
+  `instance_status` int(20) DEFAULT NULL,
+  `overload` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `heartbeat_msg` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `healthy_status` int(20) COLLATE utf8_bin DEFAULT NULL,
+  `create_time` datetime DEFAULT now(),
+  `creator` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `ticketID` varchar(255) COLLATE utf8_bin DEFAULT NULL,# 通过时间戳做id类似于yarn的appid
+  `serviceName` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `instance` varchar(255) COLLATE utf8_bin DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+-- 一个 EM可能有多个 engine 
+
+-- 引擎与EM关系表
+CREATE TABLE `linkis_manager_engine_em` (
+  `id` int(20) NOT NULL AUTO_INCREMENT,
+  `engine_instance` varchar(16) DEFAULT NULL,
+  `em_instance` varchar(16) DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+-- 标签表：
+CREATE TABLE `linkis_manager_label` (
+  `id` int(20) NOT NULL AUTO_INCREMENT,
+  `label_key` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `label_value` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `label_feature` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `label_value_size` int(20) DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  unique key label_key_value(`label_key`, `label_value`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+/**
+key  content
+把三次查询合成一个查询
+AMap---list<int> 交集labelIDs
+
+BMap---list<int> 交集labelIDs
+
+CMap---list<int> 交集labelIDs
+*/
+-- 标签值-关系表
+CREATE TABLE `linkis_manager_label_value_relation` (
+  `label_value_key` varchar(255) COLLATE utf8_bin  NOT NULL, 
+  `label_value_content` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `label_id` int(20) DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+   unique key label_value_key_label_id(`label_value_key`, `label_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+CREATE TABLE `linkis_manager_lable_user` (
+  `id` int(20) NOT NULL AUTO_INCREMENT,
+  `username` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `label_id` int(20) DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+
+-- 标签/实例关系表
+CREATE TABLE `linkis_manager_label_service_instance` (
+  `id` int(20) NOT NULL AUTO_INCREMENT,
+  `label_id` int(20) DEFAULT NULL,
+  `service_instance` varchar(16) DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+-- select * from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource A join linkis_manager_lable_user B on A.label_id=B.label_id AND B.username=#{userName})
+-- select * from linkis_manager_linkis_resources where resourceType=#{resourceType} and id in (select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id = B.label_id and B.service_instance_id=#{instanceId})
+
+-- select * from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B join on A.label_id = B.label_id and B.service_instance_id=#{instanceId})
+
+-- delete from linkis_manager_label_resource where label_id in (select label_id from linkis_manager_label_service_instance where service_instance_id = #{instanceId})
+
+-- delete from linkis_manager_linkis_resources where id in (select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id=B.label_id and B.service_instance_id==#{instanceId} )
+
+-- 标签资源表
+-- label_resource:
+CREATE TABLE `linkis_manager_label_resource` (
+  `id` int(20) NOT NULL AUTO_INCREMENT,
+  `label_id` int(20) DEFAULT NULL,
+  `resource_id` int(20) DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+-- delete from linkis_manager_label_resource where resource_id in (select id from linkis_manager_linkis_resources where ticketId=#{ticketId})
+-- select id from linkis_manager_linkis_resources where ticketId is null and id in ( select resource_id from linkis_manager_label_resource A join linkis_manager_label_service_instance B on A.label_id=B.label_id and B.service_instance_id=#{instanceId})
+-- 资源表
+CREATE TABLE `linkis_manager_linkis_resources` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `max_resource` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `min_resource` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `used_resource` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `left_resource` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `expected_resource` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `locked_resource` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `resourceType` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `ticketId` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(),
+  `updator` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `creator` varchar(255) COLLATE utf8_bin DEFAULT NULL,  
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+--  锁表 lock
+CREATE TABLE `linkis_manager_lock` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `lock_object` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `time_out`  longtext     DEFAULT NULL,
+  `update_time` datetime DEFAULT now(),
+  `create_time` datetime DEFAULT now(), 
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
### What is the purpose of the change
Related issues: #581 
Persistence Module provides the data persistence layer for Linkis Manager Service. It's designed to be flexible and extensible to support a variety of storages and databases, such as MySQL, HBase, etc. 

### Brief change log

1. Add CRUD of application instance information(EngineConn and EngineConn Manager) for Application Manager module;
2. Add CRUD of resource usage information for Resource Manager module;
3. Add CRUD of label information for Label Manager module;