### PR TITLE
IOEngine adapts to the Linkis1.0's new architecture, Implement the IO…

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineplugin-io_file</artifactId>
+    <properties>
+        <io_file.version>1</io_file.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-computation-engineconn</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-storage</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>**/application.yml</exclude>
+                    <exclude>**/bootstrap.yml</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/assembly/distribution.xml
@@ -1,0 +1,70 @@
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-engineplugin-io_file</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>io_file</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>/dist/v${io_file.version}/lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>linkis-engineconn.properties</include>
+                <include>log4j2-engineconn.xml</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>/dist/v${io_file.version}/conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}/target</directory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*doc.jar</exclude>
+            </excludes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>/plugin/${io_file.version}</outputDirectory>
+        </fileSet>
+
+    </fileSets>
+
+</assembly>
+

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/resources/linkis-engineconn.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2019 WeBank
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+wds.linkis.server.version=v1
+
+wds.linkis.engineconn.debug.enable=true
+
+#wds.linkis.keytab.enable=true
+
+wds.linkis.engineconn.plugin.default.clazz=com.webank.wedatasphere.linkis.manager.engineplugin.io.IoEngineConnPlugin
+
+wds.linkis.engineconn.io.version=1
+
+#wds.linkis.engine.io.opts=" -Dfile.encoding=UTF-8  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=49100 "
+
+wds.linkis.engineconn.support.parallelism=true
+

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/resources/log4j2-engineconn.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/resources/log4j2-engineconn.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<configuration status="error" monitorInterval="30">
+    <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+        </Console>
+        <RollingFile name="RollingFile" fileName="log/linkis.log"
+                     filePattern="log/$${date:yyyy-MM}/linkis-log-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-40t] %c{1.} (%L) [%M] - %msg%xEx%n"/>
+            <SizeBasedTriggeringPolicy size="100MB"/>
+            <DefaultRolloverStrategy max="20"/>
+        </RollingFile>
+        <Send name="Send" >
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+        </Send>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <!-- <appender-ref ref="RollingFile"/>
+             <appender-ref ref="Console"/>-->
+        </root>
+    </loggers>
+</configuration>
+

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/IoEngineConnPlugin.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/IoEngineConnPlugin.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.EngineConnPlugin
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.creation.EngineConnFactory
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.EngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.{EngineResourceFactory, GenericEngineResourceFactory}
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.builder.IoProcessEngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.conf.IOEngineConnConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.factory.IoEngineConnFactory
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineRunTypeLabel, EngineType, EngineTypeLabel, RunType}
+
+class IoEngineConnPlugin extends EngineConnPlugin {
+
+  private val EP_CONTEXT_CONSTRUCTOR_LOCK = new Object()
+
+  private var engineResourceFactory: EngineResourceFactory = _
+
+  private var engineLaunchBuilder: EngineConnLaunchBuilder = _
+
+  private var engineFactory: EngineConnFactory = _
+
+  private val defaultLabels: util.List[Label[_]] = new util.ArrayList[Label[_]]()
+
+  override def init(params: util.Map[String, Any]): Unit = {
+    /*val engineTypeLabel = new EngineTypeLabel()
+    engineTypeLabel.setEngineType(EngineType.IO_ENGINE.toString)
+    engineTypeLabel.setVersion(IOEngineConnConfiguration.DEFAULT_VERSION.getValue)
+    this.defaultLabels.add(engineTypeLabel)
+    val runTypeLabel = new EngineRunTypeLabel()
+    runTypeLabel.setRunType(RunType.IO.toString)*/
+  }
+
+  override def getEngineResourceFactory: EngineResourceFactory = EP_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+    if (null == engineResourceFactory) {
+      engineResourceFactory = new GenericEngineResourceFactory
+    }
+    engineResourceFactory
+  }
+
+  override def getEngineConnLaunchBuilder: EngineConnLaunchBuilder = EP_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+    if (null == engineLaunchBuilder) {
+      engineLaunchBuilder = new IoProcessEngineConnLaunchBuilder
+    }
+    engineLaunchBuilder
+  }
+
+  override def getEngineConnFactory: EngineConnFactory = EP_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+    if (null == engineFactory) {
+      engineFactory = new IoEngineConnFactory
+    }
+    engineFactory
+  }
+
+  override def getDefaultLabels: util.List[Label[_]] = this.defaultLabels
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/builder/IoProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/builder/IoProcessEngineConnLaunchBuilder.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.builder
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.JavaProcessEngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.conf.IOEngineConnConfiguration
+
+class IoProcessEngineConnLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
+
+  override protected def getExtractJavaOpts: String = IOEngineConnConfiguration.EXTRA_JAVA_OTS.getValue
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/conf/IOEngineConnConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/conf/IOEngineConnConfiguration.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.conf
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+
+object IOEngineConnConfiguration {
+
+  val EXTRA_JAVA_OTS = CommonVars[String]("wds.linkis.engine.io.opts", " -Dfile.encoding=UTF-8 ")
+
+  val IO_FS_MAX = CommonVars[Int]("wds.linkis.storage.io.fs.num", 5)
+
+  val IO_FS_CLEAR_TIME = CommonVars[Long]("wds.linkis.storage.io.fs.clear.time", 1000L)
+
+  val IO_FS_ID_LIMIT = CommonVars[Long]("wds.linkis.storage.io.fs.id.limit", Long.MaxValue/3*2)
+
+  val OUTPUT_LIMIT = CommonVars[Int]("wds.linkis.engineconn.io.output.limit", Int.MaxValue)
+
+  val DEFAULT_VERSION = CommonVars[String]("wds.linkis.engineconn.io.version", "*")
+
+  val IO_FILE_CONCURRENT_LIMIT = CommonVars[Int]("wds.linkis.engineconn.io_file.concurrent.limit", 100)
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/domain/FSInfo.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/domain/FSInfo.scala
@@ -21,7 +21,6 @@ import com.webank.wedatasphere.linkis.storage.utils.StorageConfiguration
 
 /**
   * FS信息记录，包括Entrance的ID信息
-  * Created by johnnwang on 2018/10/31.
   */
 class FSInfo(val id: Long, val fs: Fs, var lastAccessTime: Long = System.currentTimeMillis()) {
   def timeout = System.currentTimeMillis() - lastAccessTime > (StorageConfiguration.IO_FS_EXPIRE_TIME.getValue + 60 * 1000)

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/domain/FSInfo.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/domain/FSInfo.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.domain
+
+import com.webank.wedatasphere.linkis.common.io.Fs
+import com.webank.wedatasphere.linkis.storage.utils.StorageConfiguration
+
+/**
+  * FS信息记录，包括Entrance的ID信息
+  * Created by johnnwang on 2018/10/31.
+  */
+class FSInfo(val id: Long, val fs: Fs, var lastAccessTime: Long = System.currentTimeMillis()) {
+  def timeout = System.currentTimeMillis() - lastAccessTime > (StorageConfiguration.IO_FS_EXPIRE_TIME.getValue + 60 * 1000)
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/executor/IoEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/executor/IoEngineConnExecutor.scala
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.executor
+
+import java.util
+import java.util.concurrent.atomic.AtomicLong
+
+import com.webank.wedatasphere.linkis.common.io.{Fs, FsPath}
+import com.webank.wedatasphere.linkis.common.utils.{Logging, OverloadUtils, Utils}
+import com.webank.wedatasphere.linkis.engineconn.computation.executor.execute.{ConcurrentComputationExecutor, EngineExecutionContext}
+import com.webank.wedatasphere.linkis.engineconn.core.EngineConnObject
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{CommonNodeResource, LoadResource, NodeResource}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EngineConnPluginConf
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.conf.IOEngineConnConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.domain.FSInfo
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.service.FsProxyService
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.utils.{IOHelp, ReflectionUtils}
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.protocol.engine.JobProgressInfo
+import com.webank.wedatasphere.linkis.scheduler.executer.{AliasOutputExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
+import com.webank.wedatasphere.linkis.storage.FSFactory
+import com.webank.wedatasphere.linkis.storage.domain.{MethodEntity, MethodEntitySerializer}
+import com.webank.wedatasphere.linkis.storage.exception.StorageErrorException
+import com.webank.wedatasphere.linkis.storage.fs.FileSystem
+import com.webank.wedatasphere.linkis.storage.utils.StorageUtils
+import org.apache.commons.io.IOUtils
+import org.json4s.DefaultFormats
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+class IoEngineConnExecutor(val id: Int, val outputLimit: Int) extends ConcurrentComputationExecutor(outputLimit) with Logging {
+
+  implicit val formats = DefaultFormats
+
+  val fsIdCount = new AtomicLong()
+
+  val FS_ID_LIMIT = IOEngineConnConfiguration.IO_FS_ID_LIMIT.getValue
+  //TODO 去掉ArrayBuffer:其中key为用户，value为用户申请到的FS数组
+  private val userFSInfos = new util.HashMap[String, ArrayBuffer[FSInfo]]()
+
+  private val fsProxyService = new FsProxyService
+
+  private var initialized: Boolean = _
+
+  var executorLabels: util.List[Label[_]] = new util.ArrayList[Label[_]](2)
+
+  private val namePrefix: String = "IoEngineConnExecutor_"
+
+  override def init(): Unit = {
+    if (!initialized) {
+      super.init
+      info("Ready to start IoEngine!")
+      cleanupThread.start()
+      initialized = true
+    }
+  }
+
+  /*
+  * 定时清理空闲的FS
+  */
+  private val cleanupThread = new Thread("IOEngineExecutor-Cleanup-Scanner") {
+    setDaemon(true)
+    var continue = true
+
+    override def run(): Unit = {
+      while (continue) {
+        var clearCount = 0
+        userFSInfos.asScala.filter(_._2.exists(_.timeout)).foreach { case (_, list) =>
+          list synchronized list.filter(_.timeout).foreach {
+            s =>
+              s.fs.close()
+              list -= s
+              clearCount = clearCount + 1
+          }
+        }
+        info(s"Finished to clear userFs, clear count: $clearCount")
+        Utils.tryQuietly(Thread.sleep(IOEngineConnConfiguration.IO_FS_CLEAR_TIME.getValue))
+      }
+    }
+  }
+
+  // todo ①use concurrent lock; ② when task num up to limit , status change to busy, otherwise idle.
+    override def executeLine(engineExecutionContext: EngineExecutionContext, code: String): ExecuteResponse = {
+      val method = MethodEntitySerializer.deserializer(code)
+      val methodName = method.methodName
+      val jobID = engineExecutionContext.getJobId.get
+      info(s"jobID($jobID):creator ${method.creatorUser} proxy user: ${method.proxyUser} to execute a method: ${method.methodName}.,fsId=${method.id}")
+      val executeResponse = methodName match {
+        case "init" =>
+          val fsId: Long = if (!existsUserFS(method)) {
+            createUserFS(method)
+          } else {
+            method.id
+          }
+          info(s"jobID($jobID),user(${method.proxyUser}) execute init and fsID($fsId)")
+          AliasOutputExecuteResponse(fsId.toString, StorageUtils.serializerStringToResult(fsId.toString))
+        case "close" => closeUserFS(method); SuccessExecuteResponse()
+        case "read" =>
+          val fs = getUserFS(method)
+          AliasOutputExecuteResponse(method.id.toString, IOHelp.read(fs, method))
+        case "available" =>
+          val fs = getUserFS(method)
+          if (method.params == null || method.params.length != 2) throw new StorageErrorException(53003, "Unsupported parameter calls")
+          val dest = MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String],classOf[FsPath])
+          val position = if (method.params(1).toString.toInt < 0) 0 else method.params(1).toString.toInt
+          val inputStream = fs.read(dest)
+          Utils.tryFinally(AliasOutputExecuteResponse(method.id.toString, StorageUtils.serializerStringToResult((inputStream.available() - position).toString)))(IOUtils.closeQuietly(inputStream))
+        case "write" =>
+          val fs = getUserFS(method)
+          IOHelp.write(fs, method)
+          SuccessExecuteResponse()
+        case "renameTo" =>
+          val fs = getUserFS(method)
+          if (method.params == null || method.params.length != 2) throw new StorageErrorException(53003, "Unsupported parameter calls")
+          fs.renameTo(MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String],classOf[FsPath]),MethodEntitySerializer.deserializerToJavaObject(method.params(1).asInstanceOf[String],classOf[FsPath]))
+          SuccessExecuteResponse()
+        case "list" =>
+          if (method.params == null || method.params.length != 1) throw new StorageErrorException(53003, "Unsupported parameter calls")
+          val fs = getUserFS(method)
+          val dest = MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String],classOf[FsPath])
+          AliasOutputExecuteResponse(method.id.toString,StorageUtils.serializerStringToResult(MethodEntitySerializer.serializerJavaObject(fs.list(dest))))
+        case "listPathWithError" =>
+          if (method.params == null || method.params.length != 1) throw new StorageErrorException(53003, "Unsupported parameter calls")
+          val fs = getUserFS(method).asInstanceOf[FileSystem]
+          val dest = MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String], classOf[FsPath])
+          AliasOutputExecuteResponse(method.id.toString, StorageUtils.serializerStringToResult(MethodEntitySerializer.serializerJavaObject(fs.listPathWithError(dest))))
+        case "get" | "create" | "isOwner" =>
+          invokeMethod(method, classOf[String], jobID)
+        case _ =>
+          invokeMethod(method, classOf[FsPath], jobID)
+      }
+      info(s"jobID($jobID):creator ${method.creatorUser} proxy user: ${method.proxyUser} finished to  execute a method: ${method.methodName}.,fsId=${method.id}")
+      executeResponse
+    }
+
+  override def executeCompletely(engineExecutorContext: EngineExecutionContext, code: String, completedLine: String): ExecuteResponse = null
+
+  override def progress(): Float = 1.0f
+
+  override def getProgressInfo: Array[JobProgressInfo] = null
+
+  override def supportCallBackLogs(): Boolean = false
+
+  override def requestExpectedResource(expectedResource: NodeResource): NodeResource = null
+
+  override def getCurrentNodeResource(): NodeResource = {
+    val properties = EngineConnObject.getEngineCreationContext.getOptions
+    if (properties.containsKey(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key)) {
+      val settingClientMemory = properties.get(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key)
+      if (!settingClientMemory.toLowerCase().endsWith("g")) {
+        properties.put(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key, settingClientMemory + "g")
+      }
+    }
+    val resource = new CommonNodeResource
+    val usedResource = new LoadResource(OverloadUtils.getProcessMaxMemory, 1)
+    resource.setUsedResource(usedResource)
+    resource
+  }
+
+  override def getExecutorLabels(): util.List[Label[_]] = executorLabels
+
+  override def setExecutorLabels(labels: util.List[Label[_]]): Unit = {
+    if (null != labels && !labels.isEmpty) {
+      executorLabels.clear()
+      executorLabels.addAll(labels)
+    }
+  }
+
+  override def getId(): String = namePrefix + id
+
+  def getFSId():Long ={
+    if (fsIdCount.get() == FS_ID_LIMIT){
+      fsIdCount.getAndSet(0)
+    } else {
+      fsIdCount.getAndIncrement()
+    }
+  }
+
+  private def existsUserFS(methodEntity: MethodEntity): Boolean = {
+    val proxyUser = methodEntity.proxyUser
+    if(!userFSInfos.containsKey(proxyUser)) return false
+    userFSInfos.get(proxyUser).synchronized {
+      val userFsInfo = userFSInfos.get(proxyUser).find(fsInfo => fsInfo != null && fsInfo.id == methodEntity.id)
+      userFsInfo.foreach(_.lastAccessTime = System.currentTimeMillis())
+      userFsInfo.isDefined
+    }
+  }
+
+  protected def getUserFS(methodEntity: MethodEntity): Fs = {
+    val fsType = methodEntity.fsType
+    val proxyUser = methodEntity.proxyUser
+    if(!userFSInfos.containsKey(proxyUser)) {
+      throw new StorageErrorException(53001,s"not exist storage $fsType, please init first.")
+    }
+    userFSInfos.get(proxyUser) synchronized {
+      val userFsInfo = userFSInfos.get(proxyUser).find(fsInfo => fsInfo != null && fsInfo.id == methodEntity.id)
+        .getOrElse(throw new StorageErrorException(53001,s"not exist storage $fsType, please init first."))
+      userFsInfo.lastAccessTime = System.currentTimeMillis()
+      userFsInfo.fs
+    }
+  }
+
+  private def createUserFS(methodEntity: MethodEntity): Long = {
+    info(s"Creator ${methodEntity.creatorUser}准备为用户${methodEntity.proxyUser}初始化FS：$methodEntity")
+    var fsId = methodEntity.id
+    val properties = methodEntity.params(0).asInstanceOf[Map[String, String]]
+    val proxyUser = methodEntity.proxyUser
+    if(!fsProxyService.canProxyUser(methodEntity.creatorUser,proxyUser,methodEntity.fsType)){
+      throw new StorageErrorException(52002,s"FS Can not proxy to：$proxyUser")
+    }
+    if(! userFSInfos.containsKey(proxyUser)) {
+      userFSInfos synchronized {
+        if(!userFSInfos.containsKey(proxyUser)) {
+          userFSInfos.put(proxyUser, ArrayBuffer[FSInfo]())
+        }
+      }
+    }
+    val userFsInfo = userFSInfos.get(proxyUser)
+    userFsInfo synchronized {
+      if(! userFsInfo.exists(fsInfo => fsInfo != null && fsInfo.id == methodEntity.id)) {
+        val fs = FSFactory.getFs(methodEntity.fsType)
+        fs.init(properties.asJava)
+        fsId = getFSId()
+        userFsInfo +=  new FSInfo(fsId, fs)
+      }
+    }
+    info(s"Creator ${methodEntity.creatorUser}为用户${methodEntity.proxyUser}初始化结束 fsId=$fsId")
+    fsId
+  }
+
+  private def closeUserFS(methodEntity: MethodEntity): Unit = {
+    info(s"Creator ${methodEntity.creatorUser}为用户${methodEntity.proxyUser} close FS：$methodEntity")
+    val proxyUser = methodEntity.proxyUser
+    if(!userFSInfos.containsKey(proxyUser)) return
+    val userFsInfo = userFSInfos.get(proxyUser)
+    userFsInfo synchronized {
+      val fsInfo = userFsInfo.find(fsInfo => fsInfo != null && fsInfo.id == methodEntity.id)
+      if (fsInfo.isDefined){
+        Utils.tryFinally(fsInfo.get.fs.close()){
+          userFsInfo -= fsInfo.get
+          if(userFsInfo.isEmpty) {
+            info(s"Prepare to clear userFsInfo:$methodEntity")
+            userFSInfos.remove(proxyUser)
+          }
+        }
+      }
+    }
+  }
+
+  private def invokeMethod[T](method:MethodEntity,methodParamType: Class[T],jobID:String):AliasOutputExecuteResponse={
+    val fs = getUserFS(method)
+    val methodName = method.methodName
+    val parameterSize = if(method.params == null) 0 else method.params.length
+    val realMethod = fs.getClass.getMethods.filter(_.getName == methodName).find(_.getGenericParameterTypes.length == parameterSize)
+    if (realMethod.isEmpty) throw new StorageErrorException(53003, s"not exists method $methodName in fs ${fs.getClass.getSimpleName}.")
+    if(parameterSize > 0) method.params(0) = MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String], methodParamType)
+    val res = MethodEntitySerializer.serializerJavaObject(ReflectionUtils.invoke(fs, realMethod.get, method.params))
+    if("exists" == methodName) {
+      info(s"jobID($jobID),user(${method.proxyUser}) execute exists get res($res) and input code($method)")
+    }
+
+    AliasOutputExecuteResponse(method.id.toString, StorageUtils.serializerStringToResult(res))
+  }
+
+  override def getConcurrentLimit(): Int = IOEngineConnConfiguration.IO_FILE_CONCURRENT_LIMIT.getValue
+
+  override def killTask(taskID: String): Unit = {
+    warn(s"Kill job : ${taskID}")
+    super.killTask(taskID)
+  }
+
+  override def killAll(): Unit = {
+
+  }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/factory/IoEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/factory/IoEngineConnFactory.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.factory
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.{DefaultEngineConn, EngineConn}
+import com.webank.wedatasphere.linkis.engineconn.core.executor.ExecutorManager
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.creation.SingleExecutorEngineConnFactory
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.conf.IOEngineConnConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.io.executor.IoEngineConnExecutor
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineRunTypeLabel, EngineType, EngineTypeLabel, RunType}
+import org.apache.commons.lang.StringUtils
+
+class IoEngineConnFactory extends SingleExecutorEngineConnFactory with Logging {
+
+  private var engineCreationContext: EngineCreationContext = _
+
+  override def createEngineConn(engineCreationContext: EngineCreationContext): EngineConn = {
+    val engineConn = new DefaultEngineConn(engineCreationContext)
+    engineConn.setEngineType(EngineType.IO_ENGINE_FILE.toString)
+    engineConn
+  }
+
+  override def createExecutor(engineCreationContext: EngineCreationContext, engineConn: EngineConn): Executor = {
+    this.engineCreationContext = engineCreationContext
+
+    val id = ExecutorManager.getInstance().generateId()
+
+    val executor = new IoEngineConnExecutor(id, IOEngineConnConfiguration.OUTPUT_LIMIT.getValue)
+
+    val runTypeLabel = getDefaultEngineRunTypeLabel()
+    executor.getExecutorLabels().add(runTypeLabel)
+    executor
+  }
+
+  private def engineVersionMatch(initalLabel: EngineTypeLabel, engineCreationLabel: EngineTypeLabel): Boolean = {
+    if (StringUtils.isBlank(initalLabel.getVersion)) {
+      true
+    } else if (initalLabel.getVersion.equals("*") || initalLabel.getVersion.equalsIgnoreCase(engineCreationLabel.getVersion)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  override def getDefaultEngineRunTypeLabel(): EngineRunTypeLabel = {
+    val runTypeLabel = new EngineRunTypeLabel
+    runTypeLabel.setRunType(RunType.IO_FILE.toString)
+    runTypeLabel
+  }
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/service/FsProxyService.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/service/FsProxyService.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.service
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.storage.utils.{StorageConfiguration, StorageUtils}
+
+class FsProxyService extends Logging{
+
+  def canProxyUser(creatorUser:String, proxyUser:String, fsType:String): Boolean = creatorUser match {
+    case StorageConfiguration.STORAGE_ROOT_USER.getValue => true
+    case StorageConfiguration.LOCAL_ROOT_USER.getValue => StorageUtils.FILE == fsType
+    case StorageConfiguration.HDFS_ROOT_USER.getValue => StorageUtils.HDFS == fsType
+    case _ => creatorUser.equals(proxyUser)
+  }
+  /*  if(creatorUser.equals(proxyUser)){
+     return true
+    }
+    if(creatorUser == StorageConfiguration.STORAGE_ROOT_USER.getValue ) return t
+    if(StorageUtils.FILE == fsType && creatorUser == StorageConfiguration.LOCAL_ROOT_USER.getValue){
+      return true
+    }
+    if(StorageUtils.HDFS == fsType && creatorUser == StorageConfiguration.HDFS_ROOT_USER.getValue){
+      return true
+    }
+    info(s"$creatorUser Failed to proxy user:$proxyUser of FsType:$fsType")
+     true*/
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/utils/IOHelp.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/utils/IOHelp.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.utils
+
+import com.webank.wedatasphere.linkis.common.io.{Fs, FsPath}
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.storage.domain.{MethodEntity, MethodEntitySerializer}
+import com.webank.wedatasphere.linkis.storage.exception.StorageErrorException
+import com.webank.wedatasphere.linkis.storage.resultset.io.{IOMetaData, IORecord}
+import com.webank.wedatasphere.linkis.storage.resultset.{ResultSetFactory, ResultSetReader, ResultSetWriter}
+import com.webank.wedatasphere.linkis.storage.utils.{StorageConfiguration, StorageUtils}
+import org.apache.commons.io.IOUtils
+
+object IOHelp {
+
+  private val maxPageSize = StorageConfiguration.IO_PROXY_READ_FETCH_SIZE.getValue.toLong
+
+  /**
+    * 读出内容后，通过将bytes数组转换为base64加密的字符串
+    * 现在ujes之前不能直接传输bytes，所以通过base64保真
+    * @param fs
+    * @param method
+    * @return
+    */
+  def read(fs: Fs, method: MethodEntity): String = {
+    if (method.params == null || method.params.isEmpty) throw new StorageErrorException(53002,"read方法参数不能为空")
+    val dest = MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String],classOf[FsPath])
+    val inputStream = fs.read(dest)
+    val resultSet = ResultSetFactory.getInstance.getResultSetByType(ResultSetFactory.IO_TYPE)
+    val writer = ResultSetWriter.getResultSetWriter(resultSet, Long.MaxValue, null)
+    Utils.tryFinally {
+      if (method.params.length == 1) {
+        val bytes = IOUtils.toByteArray(inputStream)
+        val ioMetaData = new IOMetaData(0, bytes.length)
+        val ioRecord = new IORecord(bytes)
+        writer.addMetaData(ioMetaData)
+        writer.addRecord(ioRecord)
+        writer.toString()
+      } else if (method.params.length == 3) {
+        val position = if (method.params(1).toString.toInt < 0) 0 else method.params(1).toString.toInt
+        val fetchSize = if (method.params(2).toString.toInt > maxPageSize) maxPageSize.toInt else method.params(2).toString.toInt
+        if (position > 0) inputStream.skip(position)
+        val bytes = new Array[Byte](fetchSize)
+        val len = StorageUtils.readBytes(inputStream,bytes,fetchSize)
+        val ioMetaData = new IOMetaData(0, len)
+        val ioRecord = new IORecord(bytes.slice(0, len))
+        writer.addMetaData(ioMetaData)
+        writer.addRecord(ioRecord)
+        writer.toString()
+      } else throw new StorageErrorException(53003, "不支持的参数调用")
+    }(IOUtils.closeQuietly(inputStream))
+  }
+
+  /**
+    * 将穿过来的base64加密的内容转换为bytes数组写入文件
+    * @param fs
+    * @param method
+    */
+  def write(fs: Fs, method: MethodEntity): Unit = {
+    if (method.params == null || method.params.isEmpty) throw new StorageErrorException(53003, "不支持的参数调用")
+    val dest = MethodEntitySerializer.deserializerToJavaObject(method.params(0).asInstanceOf[String],classOf[FsPath])
+    val overwrite = method.params(1).asInstanceOf[Boolean]
+    val outputStream = fs.write(dest, overwrite)
+    val content = method.params(2).asInstanceOf[String]
+    Utils.tryFinally {
+      val resultSet = ResultSetFactory.getInstance.getResultSetByType(ResultSetFactory.IO_TYPE)
+      val reader = ResultSetReader.getResultSetReader(resultSet, content)
+      while (reader.hasNext) {
+        IOUtils.write(reader.getRecord.asInstanceOf[IORecord].value, outputStream)
+      }
+    }(IOUtils.closeQuietly(outputStream))
+  }
+
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/utils/ReflectionUtils.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/io_file/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/io/utils/ReflectionUtils.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.io.utils
+
+import java.lang.reflect.{Method}
+
+object ReflectionUtils {
+
+  @throws[Throwable]
+  def invoke(any: Any, method: Method, args: Array[AnyRef]): Unit = {
+    try {
+      method.invoke(any, args)
+    } catch {
+      case t: Throwable =>
+        throw t.getCause
+    }
+  }
+
+}


### PR DESCRIPTION
**What is the purpose of the change**
Related issues: [#594 ](https://github.com/WeBankFinTech/Linkis/issues/594)
IOEngine adapts to the Linkis1.0's new architecture, Implement the IOEngineConn.

**Brief change log**
1. Implement the IO EngineConn plugin;
2. Implement the IO EngineConn factory;
3. Implement the IO EngineConn executor.