### PR TITLE
Add a new module EngineConnPlugin for the Linkis1.0 architecture to simplify the user's implementation of a new Linkis underlying computation storage engine.

### DIFF
--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/pom.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+<!--        <relativePath>../../../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-plugin-cache</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/EngineConnPluginCache.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/EngineConnPluginCache.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+
+
+public interface EngineConnPluginCache {
+    /**
+     * Put into cache
+     * @param pluginInfo hold the label and resource version
+     * @param pluginInstance plugin instance
+     */
+    void put(EngineConnPluginInfo pluginInfo, EngineConnPluginInstance pluginInstance) throws Exception;
+
+    /**
+     * Get from the cache, if not exist invoke the getter
+     * @param pluginInfo hold the label and resource version
+     * @param getter getter
+     */
+    EngineConnPluginInstance get(EngineConnPluginInfo pluginInfo, PluginGetter getter) throws Exception;
+
+    /**
+     * Remove from the cache
+     * @param pluginInfo info
+     * @return the previous plugin instance
+     */
+    EngineConnPluginInstance remove(EngineConnPluginInfo pluginInfo) throws Exception;
+
+    @FunctionalInterface
+    interface PluginGetter {
+        /**
+         * Call method
+         * @param pluginInfo plugin info
+         * @return instance
+         */
+        EngineConnPluginInstance call(EngineConnPluginInfo pluginInfo) throws Exception;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/GuavaEngineConnPluginCache.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/GuavaEngineConnPluginCache.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache;
+
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalListener;
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.config.EngineConnPluginCacheConfig;
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh.*;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.concurrent.*;
+
+
+public class GuavaEngineConnPluginCache implements RefreshableEngineConnPluginCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GuavaEngineConnPluginCache.class);
+
+    private Cache<String, EngineConnPluginInstance> pluginCache;
+
+    private PluginCacheRefresher refresher;
+    /**
+     * Refresh container
+     */
+    private RefreshPluginCacheContainer refreshContainer;
+
+    public GuavaEngineConnPluginCache(){
+        this(null);
+    }
+
+    public GuavaEngineConnPluginCache(PluginCacheRefresher refresher){
+        this.refreshContainer = new DefaultRefreshPluginCacheContainer(this);
+        this.refresher = refresher;
+        this.pluginCache = constructCache(EngineConnPluginCacheConfig.PLUGIN_CACHE_SIZE.getValue(),
+                EngineConnPluginCacheConfig.PLUGIN_CACHE_EXPIRE_TIME_SECONDS.getValue(),
+                removalNotification -> {
+                    String cacheKey = removalNotification.getKey();
+                    LOG.info("Remove cache of engine conn plugin:[ " + cacheKey + " ], cause: " + removalNotification.getCause());
+                    if(!RemovalCause.REPLACED.equals(removalNotification.getCause())){
+                        //Ignore replace condition
+                        this.refreshContainer.removeRefreshOperation(removalNotification.getValue().info());
+                    }
+                });
+        if(null != refresher){
+            this.refreshContainer.start(refresher);
+        }
+    }
+
+    private Cache<String, EngineConnPluginInstance> constructCache(int cacheSize,
+                                                                   long expireTimeInSeconds,
+                                                                   RemovalListener<String, EngineConnPluginInstance> removeListener){
+        CacheBuilder<String, EngineConnPluginInstance> cacheBuilder = CacheBuilder.newBuilder()
+                .maximumSize(cacheSize)
+                .removalListener(removeListener);
+        if(expireTimeInSeconds > 0){
+            cacheBuilder.expireAfterAccess(expireTimeInSeconds, TimeUnit.SECONDS);
+        }
+        return cacheBuilder.build();
+    }
+    @Override
+    public void addRefreshListener(RefreshListener refreshListener) {
+        refreshContainer.addRefreshListener(refreshListener);
+    }
+
+    @Override
+    public synchronized void setRefresher(PluginCacheRefresher refresher) {
+        if(null != refresher) {
+            if (null != this.refresher) {
+                refreshContainer.stop();
+            }
+            this.refreshContainer.start(refresher);
+            this.refresher = refresher;
+        }
+    }
+
+    @Override
+    public void refresh(EngineConnPluginInfo pluginInfo, EngineConnPluginInstance pluginInstance) throws Exception {
+        //The same as the put method
+        put(pluginInfo, pluginInstance);
+    }
+
+    @Override
+    public void put(EngineConnPluginInfo pluginInfo, EngineConnPluginInstance pluginInstance) throws Exception{
+        this.pluginCache.put(pluginInfo.toString(), pluginInstance);
+        //Be care of that: put method doesn't add refresh operation
+    }
+
+    @Override
+    public EngineConnPluginInstance get(EngineConnPluginInfo pluginInfo, PluginGetter caller) throws Exception{
+        return this.pluginCache.get(pluginInfo.toString(), () -> {
+            EngineConnPluginInstance instance =  caller.call(pluginInfo);
+            if(null != refresher){
+                refreshContainer.addRefreshOperation(pluginInfo, new RefreshPluginCacheOperation(info -> {
+                    try {
+                        //Use the getter method of plugin
+                        return caller.call(info);
+                    } catch (Exception e) {
+                        LOG.error("Refresh cache of plugin: [" + info.toString() + "] failed, message: [" + e.getMessage() + "]", e);
+                        return null;
+                    }
+                }));
+            }
+            return instance;
+        });
+    }
+
+    @Override
+    public EngineConnPluginInstance remove(EngineConnPluginInfo pluginInfo) throws Exception{
+        final EngineConnPluginInstance instance = pluginCache.getIfPresent(pluginInfo.toString());
+        pluginCache.invalidate(pluginInfo.toString());
+        return instance;
+    }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/config/EngineConnPluginCacheConfig.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/config/EngineConnPluginCacheConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache.config;
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars;
+
+
+public class EngineConnPluginCacheConfig {
+
+    public static final CommonVars<Integer> PLUGIN_CACHE_SIZE = CommonVars.apply("linkis.engineConn.plugin.cache.size", 1000);
+
+    public static final CommonVars<Long> PLUGIN_CACHE_EXPIRE_TIME_SECONDS = CommonVars.apply("linkis.engineConn.plugin.cache.expire-in-seconds", 30 * 60 * 60 * 1000L);
+
+    public static final CommonVars<Integer> PLUGIN_CACHE_REFRESH_WORKERS = CommonVars.apply("linkis.engineConn.plugin.cache.refresh.workers", 5);
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/DefaultRefreshPluginCacheContainer.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/DefaultRefreshPluginCacheContainer.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.config.EngineConnPluginCacheConfig;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class DefaultRefreshPluginCacheContainer implements RefreshPluginCacheContainer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultRefreshPluginCacheContainer.class);
+
+    private static final String REFRESH_SCHEDULE_THREAD = "Refresh-plugin-cache-scheduler-";
+
+    private static final String REFRESH_WORKER_THREAD = "Refresh-plugin-cache-worker-";
+
+    private ConcurrentHashMap<String, RefreshPluginCacheOperation> pluginRefreshOps = new ConcurrentHashMap<>();
+
+    /**
+     * Refresh listeners
+     */
+    private List<RefreshableEngineConnPluginCache.RefreshListener> refreshListeners = new ArrayList<>();
+
+    /**
+     * Delay queue for refreshing cache
+     */
+    private DelayQueue<RefreshPluginCacheOperation> refreshDelayQueue = new DelayQueue<>();
+
+    private PluginCacheRefresher refresher;
+
+    private volatile boolean isRunning = false;
+
+    private ExecutorService scheduleService;
+
+    private ExecutorService workService;
+
+    private RefreshableEngineConnPluginCache pluginCache;
+
+    public DefaultRefreshPluginCacheContainer(RefreshableEngineConnPluginCache pluginCache){
+        this.pluginCache = pluginCache;
+    }
+
+    @Override
+    public synchronized void start(PluginCacheRefresher refresher) {
+        if(!isRunning){
+            LOG.info("Starting container of refreshing plugin cache...");
+            checkRefresher(refresher);
+            this.refresher = refresher;
+            startExecutors();
+            this.isRunning = true;
+            //Start consumer thread
+            startConsumer();
+        }else{
+            LOG.trace("This container has been started");
+        }
+    }
+
+    @Override
+    public synchronized void stop() {
+        LOG.info("Stopping container of refreshing plugin cache...");
+        stopExecutors();
+        isRunning = false;
+        LOG.info("Success to stop container of refreshing plugin cache");
+    }
+
+    @Override
+    public void addRefreshOperation(EngineConnPluginInfo cacheKey, RefreshPluginCacheOperation operation) {
+        if(null != refresher){
+            operation.setTimeUnit(refresher.timeUnit());
+            operation.setDuration(refresher.interval());
+            operation.setPluginInfo(cacheKey);
+            operation.nextTime();
+            this.pluginRefreshOps.computeIfAbsent(cacheKey.toString(), (key) ->{
+                this.refreshDelayQueue.put(operation);
+                return operation;
+            });
+        }
+    }
+
+    @Override
+    public void removeRefreshOperation(EngineConnPluginInfo cacheKey) {
+        RefreshPluginCacheOperation operation = this.pluginRefreshOps.remove(cacheKey.toString());
+        if(null != operation){
+            LOG.trace("Remove refresh-cache operation in queue for plugin:[ " + cacheKey + " ]");
+            this.refreshDelayQueue.remove(operation);
+        }
+    }
+
+    @Override
+    public void addRefreshListener(RefreshableEngineConnPluginCache.RefreshListener refreshListener) {
+        this.refreshListeners.add(refreshListener);
+    }
+
+    /**
+     * Start executors
+     */
+    private void startExecutors(){
+        LOG.info("Start executors: [ schedule, worker ] in container");
+        this.scheduleService = Executors.newSingleThreadExecutor(new RefreshThreadFactory(REFRESH_SCHEDULE_THREAD));
+        // OOM ?
+        this.workService = Executors.newFixedThreadPool(EngineConnPluginCacheConfig.PLUGIN_CACHE_REFRESH_WORKERS.getValue(),
+                new RefreshThreadFactory(REFRESH_WORKER_THREAD));
+    }
+
+    /**
+     * Stop executors
+     */
+    private void stopExecutors(){
+        LOG.info("Stop executors: [ schedule, worker ] in container");
+        if(null != this.scheduleService){
+            this.scheduleService.shutdownNow();
+            this.scheduleService = null;
+        }
+        if(null != this.workService){
+            this.workService.shutdownNow();
+            this.workService = null;
+        }
+    }
+
+    /**
+     * Invoke refresh listener
+     */
+    private void onRefresh(EngineConnPluginInfo pluginInfo){
+        refreshListeners.forEach(refreshListener -> refreshListener.onRefresh(pluginInfo));
+    }
+
+    private void checkRefresher(PluginCacheRefresher refresher){
+        long interval = refresher.interval();
+        if(interval <= 0){
+            throw new IllegalArgumentException("interval value [" + interval + "]of refresher cannot be <= 0 ");
+        }
+    }
+
+    private void startConsumer(){
+        this.scheduleService.submit(() -> {
+            while(isRunning) {
+                try {
+                    RefreshPluginCacheOperation operation = refreshDelayQueue.take();
+                    String cacheKey = operation.cacheStringKey();
+                    //Avoid concurrent operation
+                    if (operation == pluginRefreshOps.get(cacheKey)) {
+                        try{
+                            try {
+                                //Invoke Refresh operation
+                                Future<EngineConnPluginInstance> future = workService.submit(() -> operation.getOperation().apply(operation.pluginInfo()));
+                                EngineConnPluginInstance newPluginInstance = future.get(12, TimeUnit.HOURS);
+                                if(null != newPluginInstance){
+                                    //Refresh the cache;
+                                    this.pluginCache.refresh(newPluginInstance.info(), newPluginInstance);
+                                    //Also update plugin info into refresh operation
+                                    operation.setPluginInfo(newPluginInstance.info());
+                                    onRefresh(newPluginInstance.info());
+                                }
+                            }catch(Exception e){
+                                LOG.info("Unable to refresh plugin: [ " + pluginCache.toString() +" ]", e);
+                                //Ignore
+                            }
+                        }finally {
+                            //Update the trigger time
+                            operation.nextTime();
+                            operation.setDuration(refresher.interval());
+                            operation.setTimeUnit(refresher.timeUnit());
+                            //Re-into the delay queue
+                            this.refreshDelayQueue.add(operation);
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    LOG.info("Error in consuming delay queue of refresh-plugin-cache operation, message:[" + e.getMessage() + "]", e);
+                    //Just wait a seconds
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ex) {
+                        //Ignore
+                    }
+                }
+            }
+        });
+    }
+    static class RefreshThreadFactory implements ThreadFactory {
+        private static final AtomicInteger poolNumber = new AtomicInteger(1);
+        private final ThreadGroup group;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        RefreshThreadFactory(String namePrefix) {
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() :
+                    Thread.currentThread().getThreadGroup();
+            this.namePrefix =  namePrefix +
+                    poolNumber.getAndIncrement() +
+                    "-thread-";
+        }
+
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(group, r,
+                    namePrefix + threadNumber.getAndIncrement(),
+                    0);
+            if (t.isDaemon())
+                t.setDaemon(false);
+            if (t.getPriority() != Thread.NORM_PRIORITY)
+                t.setPriority(Thread.NORM_PRIORITY);
+            return t;
+        }
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/PluginCacheRefresher.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/PluginCacheRefresher.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh;
+
+import java.util.concurrent.TimeUnit;
+
+
+public interface PluginCacheRefresher {
+
+    long interval();
+
+    TimeUnit timeUnit();
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/RefreshPluginCacheContainer.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/RefreshPluginCacheContainer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+
+
+public interface RefreshPluginCacheContainer {
+
+    /**
+     * Start container
+     * @param refresher
+     */
+    void start(PluginCacheRefresher refresher);
+
+    /**
+     * Stop container
+     */
+    void stop();
+
+    /**
+     * Add operation to container
+     * @param operation operation
+     */
+    void addRefreshOperation(EngineConnPluginInfo cacheKey, RefreshPluginCacheOperation operation);
+
+    /**
+     * Remove operation from container
+     * @param cacheKey cache key
+     */
+    void removeRefreshOperation(EngineConnPluginInfo cacheKey);
+
+    /**
+     * Add the refreshListener
+     * @param refreshListener listener
+     */
+    void addRefreshListener(RefreshableEngineConnPluginCache.RefreshListener refreshListener);
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/RefreshPluginCacheOperation.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/RefreshPluginCacheOperation.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+
+public class RefreshPluginCacheOperation implements Delayed {
+    private AtomicLong triggerTime = new AtomicLong(0);
+
+    private TimeUnit timeUnit = TimeUnit.SECONDS;
+
+    private long duration = 0L;
+
+    private EngineConnPluginInfo pluginInfo;
+
+    private Function<EngineConnPluginInfo, EngineConnPluginInstance> operation;
+
+    public RefreshPluginCacheOperation(Function<EngineConnPluginInfo, EngineConnPluginInstance> operation){
+        this.operation = operation;
+        this.triggerTime.set(System.currentTimeMillis());
+    }
+
+    void setDuration(long duration){
+        this.duration = duration;
+    }
+
+    void setTimeUnit(TimeUnit timeUnit){
+        if(null != timeUnit) {
+            this.timeUnit = timeUnit;
+        }
+    }
+
+
+    String cacheStringKey(){
+        return this.pluginInfo != null ? this.pluginInfo.toString() : null;
+    }
+
+    EngineConnPluginInfo pluginInfo(){
+        return this.pluginInfo;
+    }
+
+    void setPluginInfo(EngineConnPluginInfo pluginInfo){
+        this.pluginInfo = pluginInfo;
+    }
+    public Function<EngineConnPluginInfo, EngineConnPluginInstance> getOperation(){
+        return operation;
+    }
+    public void nextTime(){
+        this.triggerTime.addAndGet(TimeUnit.MILLISECONDS.convert(duration, timeUnit));
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return unit.convert(this.triggerTime.get() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        if(o instanceof RefreshPluginCacheOperation){
+            return (int)(this.triggerTime.get() - ((RefreshPluginCacheOperation)o).triggerTime.get());
+        }
+        return -1;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/RefreshableEngineConnPluginCache.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/cache/refresh/RefreshableEngineConnPluginCache.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.EngineConnPluginCache;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+
+
+public interface RefreshableEngineConnPluginCache extends EngineConnPluginCache {
+
+    /**
+     * Add the refreshListener
+     * @param refreshListener listener
+     */
+    void addRefreshListener(RefreshListener refreshListener);
+
+    /**
+     * Set refresher
+     * @param refresher
+     */
+    void setRefresher(PluginCacheRefresher refresher);
+
+    /**
+     * Refresh method
+     * @param pluginInfo
+     * @param pluginInstance
+     * @throws Exception
+     */
+    void refresh(EngineConnPluginInfo pluginInfo, EngineConnPluginInstance pluginInstance) throws Exception;
+
+    interface RefreshListener{
+
+        /**
+         * On refresh
+         * @param enginePluginInfo plugin info
+         */
+        void onRefresh(EngineConnPluginInfo enginePluginInfo);
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/pom.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!--<relativePath>../../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-plugin-core</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-protocol</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-executor-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-label-common</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/EngineConnPlugin.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/EngineConnPlugin.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.creation.EngineConnFactory
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.EngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.EngineResourceFactory
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait EngineConnPlugin {
+
+   def init(params: util.Map[String, Any])
+
+   def getEngineResourceFactory: EngineResourceFactory
+
+  def getEngineConnLaunchBuilder: EngineConnLaunchBuilder
+
+  def getEngineConnFactory: EngineConnFactory
+
+  def getDefaultLabels: util.List[Label[_]]
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/conf/EngineConnPluginConf.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/conf/EngineConnPluginConf.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{ByteType, CommonVars}
+
+
+object EngineConnPluginConf {
+
+  val JAVA_ENGINE_REQUEST_MEMORY = CommonVars[ByteType]("wds.linkis.engineconn.java.driver.memory", new ByteType("1g"))
+
+  val JAVA_ENGINE_REQUEST_CORES = CommonVars[Int]("wds.linkis.engineconn.java.driver.cores", 2)
+
+  val JAVA_ENGINE_REQUEST_INSTANCE = CommonVars[Int]("wds.linkis.engineconn.java.driver.instannce", 1)
+
+  val ENGINECONN_TYPE_NAME = CommonVars[String]("wds.linkis.engineconn.type.name", "python")
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/conf/EnvConfiguration.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/conf/EnvConfiguration.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{ByteType, CommonVars, Configuration}
+
+
+object EnvConfiguration {
+
+  val HIVE_CONF_DIR = CommonVars[String]("hive.config.dir", CommonVars[String]("HIVE_CONF_DIR", "/appcom/config/hive-config").getValue)
+
+  val HADOOP_LIB_NATIVE = CommonVars[String]("linkis.hadoop.lib.native", "/appcom/Install/hadoop/lib/native")
+
+  val HADOOP_CONF_DIR = CommonVars[String]("hadoop.config.dir", CommonVars[String]("HADOOP_CONF_DIR", "/appcom/config/hadoop-config").getValue)
+
+  val ENGINE_CONN_JARS = CommonVars("wds.linkis.engineConn.jars", "", "engineConn额外的Jars")
+
+  val ENGINE_CONN_CLASSPATH_FILES = CommonVars("wds.linkis.engineConn.files", "", "engineConn额外的配置文件")
+
+  val ENGINE_CONN_DEFAULT_JAVA_OPTS = CommonVars[String]("wds.linkis.engineConn.javaOpts.default", s"-XX:+UseG1GC -XX:MaxPermSize=250m -XX:PermSize=128m " +
+    s"-Xloggc:%s -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Dwds.linkis.configuration=linkis-engineconn.properties -Dwds.linkis.gateway.url=${Configuration.getGateWayURL()}")
+
+  val ENGINE_CONN_MEMORY = CommonVars("wds.linkis.engineConn.memory", new ByteType("2g"), "Specify the memory size of the java client(指定java进程的内存大小)")
+
+  val ENGINE_CONN_JAVA_EXTRA_OPTS = CommonVars("wds.linkis.engineConn.java.extraOpts", "",
+    "Specify the option parameter of the java process (please modify it carefully!!!)")
+
+  val ENGINE_CONN_JAVA_EXTRA_CLASSPATH = CommonVars("wds.linkis.engineConn.extra.classpath", "", "Specify the full path of the java classpath")
+
+  val ENGINE_CONN_MAX_RETRIES = CommonVars("wds.linkis.engineconn.retries.max", 3)
+
+  val ENGINE_CONN_DEBUG_ENABLE = CommonVars("wds.linkis.engineconn.debug.enable", false)
+
+  val LOG4J2_XML_FILE = CommonVars[String]("wds.linkis.engineconn.log4j2.xml.file", "log4j2-engineconn.xml")
+
+  val LINKIS_PUBLIC_MODULE_PATH = CommonVars("wds.linkis.public_module.path", Configuration.LINKIS_HOME.getValue + "/lib/linkis-commons/public-module")
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/creation/EngineConnFactory.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/creation/EngineConnFactory.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.creation
+
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineRunTypeLabel
+import org.reflections.Reflections
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConverters._
+
+
+trait EngineConnFactory {
+
+  def createEngineConn(engineCreationContext: EngineCreationContext): EngineConn
+
+}
+
+/**
+  * For only one kind of executor, like hive, python ...
+  */
+trait SingleExecutorEngineConnFactory extends EngineConnFactory {
+
+  def createExecutor(engineCreationContext: EngineCreationContext, engineConn: EngineConn): Executor
+
+  def getDefaultEngineRunTypeLabel(): EngineRunTypeLabel
+}
+
+/**
+  * For many kinds of executor, such as spark with spark-sql and spark-shell and pyspark
+  */
+trait MultiExecutorEngineConnFactory extends EngineConnFactory with Logging {
+
+  def getExecutorFactories: Array[ExecutorFactory] = {
+    val executorFactories = new ArrayBuffer[ExecutorFactory]
+    Utils.tryCatch {
+      val reflections = new Reflections("com.webank.wedatasphere.linkis", classOf[ExecutorFactory])
+      val allSubClass = reflections.getSubTypesOf(classOf[ExecutorFactory])
+      allSubClass.asScala.foreach(l => {
+        executorFactories += l.newInstance
+      })
+    } {
+      t: Throwable =>
+        error(t.getMessage)
+    }
+    executorFactories.toArray
+  }
+
+  def getDefaultExecutorFactory: ExecutorFactory = {
+    var defaultExecutorFactory: ExecutorFactory = null
+    getExecutorFactories.foreach(f => {
+      if (null == defaultExecutorFactory) {
+        defaultExecutorFactory = f
+      } else if (f.getOrder < defaultExecutorFactory.getOrder) {
+          defaultExecutorFactory = f
+        }
+    })
+    defaultExecutorFactory
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/creation/ExecutorFactory.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/creation/ExecutorFactory.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.creation
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.{EngineConnPluginErrorCode, EngineConnPluginErrorException}
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineRunTypeLabel
+import com.webank.wedatasphere.linkis.protocol.UserWithCreator
+
+
+trait ExecutorFactory extends Logging {
+
+  /**
+   * Order of executors, the smallest one is the default
+   * @return
+   */
+  def getOrder: Int
+
+  def canCreate(labels: Array[Label[_]]): Boolean = {
+    val runTypeLabel = getDefaultEngineRunTypeLabel()
+    if (null == runTypeLabel) {
+      error("DefaultEngineRunTypeLabel must not be null!")
+      throw new EngineConnPluginErrorException(EngineConnPluginErrorCode.INVALID_RUNTYPE, "DefaultEngineRunTypeLabel cannot be null.")
+    }
+      labels.find(_.isInstanceOf[EngineRunTypeLabel]).foreach {
+        case label: EngineRunTypeLabel =>
+          info(s"executor runType is ${runTypeLabel.getRunType} input runType is ${label.getRunType}")
+          if (runTypeLabel.getRunType.equalsIgnoreCase(label.getRunType)) {
+            return true
+          }
+        case _ =>
+          error(s"runType label not exists")
+      }
+    false
+  }
+
+  /**
+   *
+   * @param engineCreationContext
+   * @param engineConn
+   * @param labels
+   * @return
+   */
+  def createExecutor(engineCreationContext: EngineCreationContext, engineConn: EngineConn, labels: Array[Label[_]]): Executor
+
+  def getDefaultEngineRunTypeLabel(): EngineRunTypeLabel
+}
+
+object ExecutorFactory extends Logging {
+
+  def parseUserWithCreator(labels: Array[Label[_]]): UserWithCreator = {
+    labels.foreach(l => l match {
+      case label: UserWithCreator =>
+        return UserWithCreator(label.user, label.creator)
+      case _ =>
+    })
+    null
+  }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/creation/JavaProcessEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/creation/JavaProcessEngineConnFactory.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.creation
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.{DefaultEngineConn, EngineConn}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EngineConnPluginConf
+
+
+abstract class JavaProcessEngineConnFactory extends EngineConnFactory with Logging {
+
+  override def createEngineConn(engineCreationContext: EngineCreationContext): EngineConn = {
+    val engineConn = new DefaultEngineConn(engineCreationContext)
+    engineConn.setEngineType(EngineConnPluginConf.ENGINECONN_TYPE_NAME.getValue)
+    engineConn
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/exception/EngineConnBuildFailedException.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/exception/EngineConnBuildFailedException.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+
+
+class EngineConnBuildFailedException(errCode: Int, desc: String) extends ErrorException(errCode, desc) {
+
+  def this(errCode: Int, desc: String, cause: Throwable) = {
+    this(errCode, desc)
+    initCause(cause)
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/exception/EngineConnPluginErrorCode.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/exception/EngineConnPluginErrorCode.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.exception
+
+
+object EngineConnPluginErrorCode {
+
+  def INVALID_RUNTYPE = 70101
+
+  def INVALID_LABELS = 70102
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/exception/EngineConnPluginErrorException.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/exception/EngineConnPluginErrorException.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+
+
+class EngineConnPluginErrorException(code: Int, msg: String) extends ErrorException(code, msg) {
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/EngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/EngineConnLaunchBuilder.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, EngineConnLaunchRequest}
+
+
+trait EngineConnLaunchBuilder {
+
+  def buildEngineConn(engineConnBuildRequest: EngineConnBuildRequest): EngineConnLaunchRequest
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/entity/EngineConnBuildRequest.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/entity/EngineConnBuildRequest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+trait EngineConnBuildRequest extends RequestProtocol {
+  val ticketId: String
+  val labels: util.List[Label[_]]
+  val engineResource: NodeResource
+  val engineConnCreationDesc: EngineConnCreationDesc
+}
+
+
+case class EngineConnBuildRequestImpl(ticketId: String,
+                                      labels: util.List[Label[_]],
+                                      engineResource: NodeResource,
+                                      engineConnCreationDesc: EngineConnCreationDesc) extends EngineConnBuildRequest
+
+
+trait RicherEngineConnBuildRequest extends EngineConnBuildRequest {
+
+  def getBmlResources: Array[BmlResource]
+
+  def getStartupConfigs: util.Map[String, Object]
+
+}
+
+
+
+
+
+

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/entity/EngineConnCreationDesc.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/entity/EngineConnCreationDesc.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity
+
+import java.util
+
+
+trait EngineConnCreationDesc {
+
+  val createService: String
+
+  val description: String
+
+  val properties: util.Map[String, String]
+
+}
+
+case class EngineConnCreationDescImpl(createService: String, description: String, properties: util.Map[String, String]) extends EngineConnCreationDesc

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/entity/EngineConnLaunchRequest.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/entity/EngineConnLaunchRequest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+trait EngineConnLaunchRequest extends RequestProtocol {
+
+  val ticketId: String
+
+  val user: String
+
+  val labels: util.List[Label[_]]
+
+  val nodeResource: NodeResource
+
+  val creationDesc: EngineConnCreationDesc
+
+  val engineConnManagerHooks: util.List[String]
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/EngineConnResourceGenerator.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/EngineConnResourceGenerator.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+
+
+trait EngineConnResourceGenerator {
+
+  def getEngineConnBMLResources(engineTypeLabel: EngineTypeLabel): EngineConnResource
+
+}
+
+trait EngineConnResource {
+
+  def getConfBmlResource: BmlResource
+
+  def getLibBmlResource: BmlResource
+
+  def getOtherBmlResources: Array[BmlResource]
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/Environment.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/Environment.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process
+
+
+object Environment extends Enumeration {
+
+  type Environment = Value
+  val USER, ECM_HOME, PWD, PATH, SHELL, JAVA_HOME, CLASSPATH,
+      HADOOP_HOME, HADOOP_CONF_DIR, HIVE_CONF_DIR, LOG_DIRS, TEMP_DIRS,
+      ECM_HOST, ECM_PORT, RANDOM_PORT, SERVICE_DISCOVERY = Value
+
+  def variable(environment: Environment): String = LaunchConstants.EXPANSION_MARKER_LEFT + environment + LaunchConstants.EXPANSION_MARKER_RIGHT
+
+}
+
+object LaunchConstants {
+
+  val CLASS_PATH_SEPARATOR = "<<CPS>>"
+  val EXPANSION_MARKER_LEFT = "<<L"
+  val EXPANSION_MARKER_RIGHT = "R>>"
+  val LOG_DIRS_KEY = "LOG_DIRS"
+  val TICKET_ID_KEY = "TICKET_ID"
+  val ENGINE_CONN_CONF_DIR_NAME = "conf"
+  val ENGINE_CONN_LIB_DIR_NAME = "lib"
+
+  def addPathToClassPath(env: java.util.Map[String, String], value: String): Unit = {
+    val v = if(env.containsKey(Environment.CLASSPATH.toString)) {
+      env.get(Environment.CLASSPATH.toString) + CLASS_PATH_SEPARATOR + value
+    } else value
+    env.put(Environment.CLASSPATH.toString, v)
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process
+
+
+import java.io.File
+import java.nio.file.Paths
+import java.util
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EnvConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EnvConfiguration.LINKIS_PUBLIC_MODULE_PATH
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnBuildFailedException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, RicherEngineConnBuildRequest}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.Environment.{variable, _}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.LaunchConstants._
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang.time.DateFormatUtils
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+
+abstract class JavaProcessEngineConnLaunchBuilder extends ProcessEngineConnLaunchBuilder with Logging {
+
+  private var engineConnResourceGenerator: EngineConnResourceGenerator = _
+
+  def setEngineConnResourceGenerator(engineConnResourceGenerator: EngineConnResourceGenerator): Unit =
+    this.engineConnResourceGenerator = engineConnResourceGenerator
+
+  protected def getGcLogDir(engineConnBuildRequest: EngineConnBuildRequest): String = variable(LOG_DIRS) + "/" +
+    engineConnBuildRequest.ticketId + "/gc.log" + DateFormatUtils.format(System.currentTimeMillis, "yyyyMMdd-HH_mm")
+
+  protected def getLogDir(engineConnBuildRequest: EngineConnBuildRequest): String = s" -Dlogging.file=${EnvConfiguration.LOG4J2_XML_FILE.getValue} -D$LOG_DIRS_KEY=${variable(LOG_DIRS)}" +
+    s" -D$TICKET_ID_KEY=${engineConnBuildRequest.ticketId}"
+
+  override protected def getCommands(implicit engineConnBuildRequest: EngineConnBuildRequest): Array[String] = {
+    val commandLine: ArrayBuffer[String] = ArrayBuffer[String]()
+    commandLine += (variable(JAVA_HOME) + "/bin/java")
+    commandLine += "-server"
+    val engineConnMemory = EnvConfiguration.ENGINE_CONN_MEMORY.getValue(engineConnBuildRequest.engineConnCreationDesc.properties).toString
+    commandLine += ("-Xmx" + engineConnMemory)
+    commandLine += ("-Xms" + engineConnMemory)
+    val javaOPTS = getExtractJavaOpts
+    if (StringUtils.isNotEmpty(EnvConfiguration.ENGINE_CONN_DEFAULT_JAVA_OPTS.getValue))
+      EnvConfiguration.ENGINE_CONN_DEFAULT_JAVA_OPTS.getValue.format(getGcLogDir(engineConnBuildRequest)).split("\\s+").foreach(commandLine += _)
+    if (StringUtils.isNotEmpty(javaOPTS)) javaOPTS.split("\\s+").foreach(commandLine += _)
+    getLogDir(engineConnBuildRequest).trim.split(" ").foreach(commandLine += _)
+    commandLine += ("-Djava.io.tmpdir=" + variable(TEMP_DIRS))
+    if (EnvConfiguration.ENGINE_CONN_DEBUG_ENABLE.getValue) {
+      commandLine += s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${variable(RANDOM_PORT)}"
+    }
+    commandLine += "-cp"
+    commandLine += variable(CLASSPATH)
+    commandLine += getMainClass
+    commandLine ++= Seq("1>", s"${variable(LOG_DIRS)}/stdout", "2>", s"${variable(LOG_DIRS)}/stderr")
+    commandLine.toArray
+  }
+
+  protected def getMainClass: String = "com.webank.wedatasphere.linkis.engineconn.launch.EngineConnServer"
+
+  override protected def getEnvironment(implicit engineConnBuildRequest: EngineConnBuildRequest): util.Map[String, String] = {
+    info("Setting up the launch environment for engineconn.")
+    val environment = new util.HashMap[String, String]
+    if(ifAddHiveConfigPath) {
+      addPathToClassPath(environment, variable(HADOOP_CONF_DIR))
+      addPathToClassPath(environment, variable(HIVE_CONF_DIR))
+    }
+//    addPathToClassPath(environment, variable(PWD))
+    // first, add engineconn conf dirs.
+    addPathToClassPath(environment, Seq(variable(PWD), ENGINE_CONN_CONF_DIR_NAME))
+    // second, add engineconn libs.
+    addPathToClassPath(environment, Seq(variable(PWD), ENGINE_CONN_LIB_DIR_NAME + "/*"))
+    // then, add public modules.
+    if (!isAddSparkConfig) {
+      addPathToClassPath(environment, Seq(LINKIS_PUBLIC_MODULE_PATH.getValue + "/*"))
+    }
+    // finally, add the suitable properties key to classpath
+    engineConnBuildRequest.engineConnCreationDesc.properties.foreach { case (key, value) =>
+      if (key.startsWith("engineconn.classpath") || key.startsWith("wds.linkis.engineconn.classpath")) {
+        addPathToClassPath(environment, Seq(variable(PWD), new File(value).getName))
+      }
+    }
+    getExtraClassPathFile.foreach { file: String =>
+      addPathToClassPath(environment, Seq(variable(PWD), new File(file).getName))
+    }
+    engineConnBuildRequest match {
+      case richer: RicherEngineConnBuildRequest =>
+        def addFiles(files: String): Unit = if (StringUtils.isNotBlank(files)) {
+          files.split(",").foreach(file => addPathToClassPath(environment, Seq(variable(PWD), new File(file).getName)))
+        }
+
+        val configs: util.Map[String, String] = richer.getStartupConfigs.filter(_._2.isInstanceOf[String]).map { case (k, v: String) => k -> v }
+        val jars: String = EnvConfiguration.ENGINE_CONN_JARS.getValue(configs)
+        addFiles(jars)
+        val files: String = EnvConfiguration.ENGINE_CONN_CLASSPATH_FILES.getValue(configs)
+        addFiles(files)
+      case _ =>
+    }
+    environment
+  }
+
+  override protected def getNecessaryEnvironment(implicit engineConnBuildRequest: EngineConnBuildRequest): Array[String] =
+    if(!ifAddHiveConfigPath) Array.empty else Array(HADOOP_CONF_DIR.toString, HIVE_CONF_DIR.toString)
+
+  protected def getExtractJavaOpts: String = EnvConfiguration.ENGINE_CONN_JAVA_EXTRA_OPTS.getValue
+
+  protected def getExtraClassPathFile: Array[String] = EnvConfiguration.ENGINE_CONN_JAVA_EXTRA_CLASSPATH.getValue.split(",")
+
+  protected def ifAddHiveConfigPath: Boolean = false
+
+  protected def isAddSparkConfig: Boolean = false
+
+  override protected def getBmlResources(implicit engineConnBuildRequest: EngineConnBuildRequest): util.List[BmlResource] = {
+    val engineType = engineConnBuildRequest.labels.find(_.isInstanceOf[EngineTypeLabel])
+      .map{ case engineTypeLabel: EngineTypeLabel => engineTypeLabel}.getOrElse(throw new EngineConnBuildFailedException(20000, "EngineTypeLabel is not exists."))
+    val engineConnResource = engineConnResourceGenerator.getEngineConnBMLResources(engineType)
+    Array(engineConnResource.getConfBmlResource, engineConnResource.getLibBmlResource) ++: engineConnResource.getOtherBmlResources.toList
+  }
+
+  private implicit def buildPath(paths: Seq[String]): String = Paths.get(paths.head, paths.tail: _*).toFile.getPath
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/ProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/ProcessEngineConnLaunchBuilder.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EnvConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnBuildFailedException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.EngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity._
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.UserCreatorLabel
+
+import scala.collection.JavaConversions._
+
+
+trait ProcessEngineConnLaunchBuilder extends EngineConnLaunchBuilder {
+
+  protected def getCommands(implicit engineConnBuildRequest: EngineConnBuildRequest): Array[String]
+
+  protected def getMaxRetries(implicit engineConnBuildRequest: EngineConnBuildRequest): Int = EnvConfiguration.ENGINE_CONN_MAX_RETRIES.getValue
+
+  protected def getEnvironment(implicit engineConnBuildRequest: EngineConnBuildRequest): util.Map[String, String]
+
+  protected def getNecessaryEnvironment(implicit engineConnBuildRequest: EngineConnBuildRequest): Array[String]
+
+  protected def getBmlResources(implicit engineConnBuildRequest: EngineConnBuildRequest): util.List[BmlResource]
+
+  protected def getEngineConnManagerHooks(implicit engineConnBuildRequest: EngineConnBuildRequest): util.List[String] = new util.ArrayList[String]
+
+  override def buildEngineConn(engineConnBuildRequest: EngineConnBuildRequest): EngineConnLaunchRequest = {
+    implicit val engineConnBuildRequestImplicit: EngineConnBuildRequest = engineConnBuildRequest
+    val bmlResources = new util.ArrayList[BmlResource]
+    engineConnBuildRequest match {
+      case richer: RicherEngineConnBuildRequest => bmlResources.addAll(util.Arrays.asList(richer.getBmlResources: _*))
+      case _ =>
+    }
+    bmlResources.addAll(getBmlResources)
+    val environment = getEnvironment
+    engineConnBuildRequest.labels.find(_.isInstanceOf[UserCreatorLabel]).map {
+      case label: UserCreatorLabel =>
+        CommonProcessEngineConnLaunchRequest(engineConnBuildRequest.ticketId, getEngineStartUser(label),
+          engineConnBuildRequest.labels, engineConnBuildRequest.engineResource, bmlResources, environment, getNecessaryEnvironment,
+          engineConnBuildRequest.engineConnCreationDesc, getEngineConnManagerHooks, getCommands, getMaxRetries)
+    }.getOrElse(throw new EngineConnBuildFailedException(20000, "UserCreatorLabel is not exists."))
+  }
+
+  protected def getEngineStartUser(label: UserCreatorLabel): String = {
+    label.getUser
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/ProcessEngineConnLaunchRequest.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/ProcessEngineConnLaunchRequest.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnCreationDesc, EngineConnLaunchRequest}
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait ProcessEngineConnLaunchRequest extends EngineConnLaunchRequest {
+
+  val bmlResources: util.List[BmlResource]
+
+  val environment: util.Map[String, String]
+
+  val necessaryEnvironments: Array[String]
+
+  val commands: Array[String]
+
+  val maxRetries: Int
+
+}
+
+case class CommonProcessEngineConnLaunchRequest(ticketId: String,
+                                                 user: String,
+                                                 labels: util.List[Label[_]],
+                                                 nodeResource: NodeResource,
+                                                 bmlResources: util.List[BmlResource],
+                                                 environment: util.Map[String, String],
+                                                 necessaryEnvironments: Array[String],
+                                                 creationDesc:  EngineConnCreationDesc,
+                                                 engineConnManagerHooks: util.List[String],
+                                                 commands: Array[String],
+                                                 maxRetries: Int = 1
+                                               ) extends ProcessEngineConnLaunchRequest

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/conf/PluginLoaderConstant.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/conf/PluginLoaderConstant.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.conf
+
+
+object PluginLoaderConstant {
+
+  val PLUGIN_ILLEGAL_PARAMETER = 70061
+
+  val PLUGIN_FAIL_TO_LOAD_RES = 70064
+
+  val PLUGIN_FAIL_TO_LOAD = 70062
+
+  val PLUGIN_NOT_FOUND = 70063
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/entity/EngineConnPluginInfo.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/entity/EngineConnPluginInfo.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity
+
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+
+
+case class EngineConnPluginInfo(typeLabel: EngineTypeLabel,
+                                var resourceUpdateTime: Long = -1L,
+                                var resourceId: String,
+                                var resourceVersion: String,
+                                var classLoader: ClassLoader){
+
+  override def toString: String = {
+    if (Option(typeLabel).isDefined){
+      typeLabel.toString
+    }else{
+      null
+    }
+//    super.toString()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case info: EngineConnPluginInfo => typeLabel.equals(info.typeLabel)
+      case _ => super.equals(obj)
+    }
+  }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/entity/EngineConnPluginInstance.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/entity/EngineConnPluginInstance.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.EngineConnPlugin
+
+
+case class EngineConnPluginInstance(info: EngineConnPluginInfo, plugin: EngineConnPlugin)

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/exception/EngineConnPluginLoadException.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/exception/EngineConnPluginLoadException.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.conf.PluginLoaderConstant
+
+
+class EngineConnPluginLoadException(desc: String, t: Throwable) extends ErrorException(PluginLoaderConstant.PLUGIN_FAIL_TO_LOAD, desc) {
+  super.initCause(t)
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/exception/EngineConnPluginLoadResourceException.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/exception/EngineConnPluginLoadResourceException.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.conf.PluginLoaderConstant
+
+
+class EngineConnPluginLoadResourceException(desc: String, t: Throwable) extends ErrorException(PluginLoaderConstant.PLUGIN_FAIL_TO_LOAD_RES, desc) {
+  super.initCause(t)
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/exception/EngineConnPluginNotFoundException.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/loader/exception/EngineConnPluginNotFoundException.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.conf.PluginLoaderConstant
+
+
+class EngineConnPluginNotFoundException(desc: String, t: Throwable) extends ErrorException(PluginLoaderConstant.PLUGIN_NOT_FOUND, desc) {
+  super.initCause(t)
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/AbstractEngineResourceFactory.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/AbstractEngineResourceFactory.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.resource
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{NodeResource, Resource}
+import com.webank.wedatasphere.linkis.manager.common.utils.ResourceUtils
+
+
+trait AbstractEngineResourceFactory extends EngineResourceFactory {
+
+  protected def getRequestResource(properties: java.util.Map[String, String]): Resource
+
+  override def createEngineResource(engineResourceRequest: EngineResourceRequest): NodeResource = {
+    val user = engineResourceRequest.user
+    val engineResource = new UserNodeResource
+    val resource = getRequestResource(engineResourceRequest.properties)
+    engineResource.setUser(user)
+    engineResource.setMinResource(resource)
+    engineResource.setResourceType(ResourceUtils.getResourceTypeByResource(resource))
+    engineResource.setMaxResource(engineResource.getMinResource)
+    engineResource
+  }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/EngineResourceFactory.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/EngineResourceFactory.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.resource
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+
+
+trait EngineResourceFactory {
+
+  def createEngineResource(engineResourceRequest: EngineResourceRequest): NodeResource
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/EngineResourceRequest.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/EngineResourceRequest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.resource
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+trait EngineResourceRequest extends RequestProtocol {
+  val user: String
+  val labels: util.List[Label[_]]
+  val properties: util.Map[String, String]
+}
+
+trait TimeoutResourceRequest {
+  val timeout: Long
+}
+
+case class NormalEngineResourceRequest(user: String,
+                                       labels: util.List[Label[_]],
+                                       properties: util.Map[String, String]) extends EngineResourceRequest
+
+case class TimeoutEngineResourceRequest(timeout: Long,
+                                        user: String,
+                                        labels: util.List[Label[_]],
+                                        properties: util.Map[String, String]) extends EngineResourceRequest with TimeoutResourceRequest

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/GenericEngineResourceFactory.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/GenericEngineResourceFactory.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.resource
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{LoadInstanceResource, Resource}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EngineConnPluginConf
+
+
+class GenericEngineResourceFactory extends AbstractEngineResourceFactory with Logging {
+
+  override protected def getRequestResource(properties: util.Map[String, String]): Resource = {
+    if (properties.containsKey(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key)) {
+      val settingClientMemory = properties.get(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key)
+      if (!settingClientMemory.toLowerCase().endsWith("g")) {
+        properties.put(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key, settingClientMemory + "g")
+      }
+    }
+
+
+    new LoadInstanceResource(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.getValue(properties).toLong,
+      EngineConnPluginConf.JAVA_ENGINE_REQUEST_CORES.getValue(properties), EngineConnPluginConf.JAVA_ENGINE_REQUEST_INSTANCE.getValue)
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/UserNodeResource.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/resource/UserNodeResource.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.common.resource
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{NodeResource, Resource, ResourceType}
+
+
+class UserNodeResource extends NodeResource {
+
+  private var user: String = _
+  private var resourceType: ResourceType = _
+  private var minResource: Resource = _
+  private var maxResource: Resource = _
+  private var expectedResource: Resource = _
+  private var usedResource: Resource = _
+  private var lockedResource: Resource = _
+  private var leftResource: Resource = _
+
+  def getUser = user
+
+  def setUser(user: String) = this.user = user
+
+  override def getResourceType: ResourceType = resourceType
+
+  override def setResourceType(resourceType: ResourceType): Unit = this.resourceType = resourceType
+
+  override def getMinResource: Resource = minResource
+
+  override def setMinResource(resource: Resource): Unit = this.minResource = resource
+
+  override def getMaxResource: Resource = maxResource
+
+  override def setMaxResource(resource: Resource): Unit = this.maxResource = resource
+
+  override def getExpectedResource: Resource = expectedResource
+
+  override def setExpectedResource(resource: Resource): Unit = this.expectedResource = resource
+
+  override def setUsedResource(usedResource: Resource): Unit = this.usedResource = usedResource
+
+  override def getUsedResource: Resource = this.usedResource
+
+  override def setLockedResource(lockedResource: Resource): Unit = this.lockedResource = lockedResource
+
+  override def getLockedResource: Resource = this.lockedResource
+
+  override def setLeftResource(leftResource: Resource): Unit = this.leftResource = leftResource
+
+  override def getLeftResource: Resource = this.leftResource
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/pom.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!--<relativePath>../../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-plugin-loader</artifactId>
+
+    <properties>
+        <commons.lang3.version>3.4</commons.lang3.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-cache</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-bml-client</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                    <artifactId>linkis-storage</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                </configuration>
+            </plugin>
+
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/classloader/EngineConnPluginClassLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/classloader/EngineConnPluginClassLoader.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.classloader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+public class EngineConnPluginClassLoader extends URLClassLoader{
+
+    private static final Logger logger = LoggerFactory.getLogger(EngineConnPluginClassLoader.class);
+
+    /**
+     * Reverse order
+     */
+    private boolean reverseOrder = false;
+    /**
+     * To combine other class loader
+     */
+    private List<ClassLoader> extendedLoaders = new ArrayList<>();
+
+
+    public EngineConnPluginClassLoader(URL[] urls, ClassLoader parent){
+        super(urls, parent);
+    }
+    public EngineConnPluginClassLoader(URL[] urls, ClassLoader parent, List<ClassLoader> extendedLoaders, boolean reverseOrder) {
+        super(urls, parent);
+        this.extendedLoaders = extendedLoaders;
+        this.reverseOrder = reverseOrder;
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        if(!extendedLoaders.isEmpty()){
+            for(ClassLoader extend : extendedLoaders){
+                try {
+                    return extend.loadClass(name);
+                }catch(ClassNotFoundException e){
+                    //ignore
+                }
+            }
+        }
+        return super.findClass(name);
+    }
+
+
+    /**
+     * Change the order to load class (if you need)
+     * @param name
+     * @param resolve
+     * @return
+     * @throws ClassNotFoundException
+     */
+    private Class<?> loadClassReverse(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)){
+            //First, check if the class has already been loaded
+            Class<?> c = findLoadedClass(name);
+            if(c == null){
+                long t0 = System.nanoTime();
+                try {
+                    //invoke findClass in this class
+                    c = findClass(name);
+                }catch(ClassNotFoundException e){
+                    // ClassNotFoundException thrown if class not found
+                }
+                if(c == null){
+                    return super.loadClass(name, resolve);
+                }
+                //For compatibility with higher versions > java 1.8.0_141
+//                sun.misc.PerfCounter.getFindClasses().addElapsedTimeFrom(t0);
+//                sun.misc.PerfCounter.getFindClasses().increment();
+            }
+            if(resolve){
+                resolveClass(c);
+            }
+            return c;
+        }
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if(reverseOrder){
+            return loadClassReverse(name, resolve);
+        }
+        return super.loadClass(name, resolve);
+    }
+
+    /**
+     * Construct method
+     * @param urls classpath urls
+     * @param parent parent classloader
+     * @return
+     */
+    public static EngineConnPluginClassLoader custom(URL[] urls, ClassLoader parent){
+        return custom(urls, parent, Collections.emptyList(), false);
+    }
+
+    /**
+     * Close the classloader
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException {
+        super.close();
+    }
+
+    public static EngineConnPluginClassLoader custom(URL[] urls, ClassLoader parent, List<ClassLoader> extendedLoaders){
+        return custom(urls, parent, extendedLoaders, false);
+    }
+    public static EngineConnPluginClassLoader custom(URL[] urls, ClassLoader parent, List<ClassLoader> extendedLoaders, boolean reverseOrder){
+        return AccessController.doPrivileged((PrivilegedAction<EngineConnPluginClassLoader>)()-> new EngineConnPluginClassLoader(urls, parent, Collections.emptyList(), reverseOrder));
+    }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/CacheablesEngineConnPluginLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/CacheablesEngineConnPluginLoader.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.GuavaEngineConnPluginCache;
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.EngineConnPluginCache;
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh.PluginCacheRefresher;
+import com.webank.wedatasphere.linkis.manager.engineplugin.cache.refresh.RefreshableEngineConnPluginCache;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.config.EngineConnPluginLoaderConf;
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+
+public abstract class CacheablesEngineConnPluginLoader implements EngineConnPluginsLoader {
+
+    protected EngineConnPluginCache pluginCache;
+
+    private static final Logger LOG = LoggerFactory.getLogger(CacheablesEngineConnPluginLoader.class);
+
+    public CacheablesEngineConnPluginLoader(){
+        //Init cache
+        RefreshableEngineConnPluginCache refreshablePluginCache = new GuavaEngineConnPluginCache();
+        refreshablePluginCache.addRefreshListener(enginePluginInfo -> LOG.trace("Refresh engine conn plugin: [name: " + enginePluginInfo.typeLabel().getEngineType() +
+                ", version: " + enginePluginInfo.typeLabel().getVersion() +
+                ", resource_id: " + enginePluginInfo.resourceId() + ", resource_version: " + enginePluginInfo.resourceVersion() +
+                ", resource_update_time: " + enginePluginInfo.resourceUpdateTime() + "]"));
+        refreshablePluginCache.setRefresher(new PluginCacheRefresher() {
+            @Override
+            public long interval() {
+                return Long.parseLong(EngineConnPluginLoaderConf.ENGINE_PLUGIN_LOADER_CACHE_REFRESH_INTERVAL().getValue());
+            }
+
+            @Override
+            public TimeUnit timeUnit() {
+                return TimeUnit.SECONDS;
+            }
+        });
+        this.pluginCache = refreshablePluginCache;
+    }
+
+    @Override
+    public EngineConnPluginInstance getEngineConnPlugin(EngineTypeLabel engineTypeLabel) throws Exception {
+        //Construct plugin info
+        EngineConnPluginInfo pluginInfo = new EngineConnPluginInfo(engineTypeLabel,
+                -1L, null, null, null);
+        return pluginCache.get(pluginInfo, this::loadEngineConnPluginInternal);
+    }
+
+    @Override
+    public EngineConnPluginInstance loadEngineConnPlugin(EngineTypeLabel engineTypeLabel) throws Exception {
+        //Construct plugin info
+        EngineConnPluginInfo pluginInfo = new EngineConnPluginInfo(engineTypeLabel,
+                -1L, null, null, null);
+        EngineConnPluginInstance pluginInstance = loadEngineConnPluginInternal(pluginInfo);
+        //Update the cache
+        pluginCache.put(pluginInstance.info(), pluginInstance);
+        return pluginInstance;
+    }
+
+    /**
+     * Internal method
+     * @param  enginePluginInfo plugin info
+     * @return plugin
+     */
+    protected abstract EngineConnPluginInstance loadEngineConnPluginInternal(EngineConnPluginInfo enginePluginInfo) throws Exception;
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/DefaultEngineConnPluginLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/DefaultEngineConnPluginLoader.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders;
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.EngineConnPlugin;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception.EngineConnPluginLoadException;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception.EngineConnPluginNotFoundException;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.classloader.EngineConnPluginClassLoader;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.config.EngineConnPluginLoaderConf;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.resource.LocalEngineConnPluginResourceLoader;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.resource.PluginResource;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils.EngineConnPluginUtils;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils.ExceptionHelper;
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+
+
+public class DefaultEngineConnPluginLoader extends CacheablesEngineConnPluginLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultEngineConnPluginLoader.class);
+
+    private final List<EngineConnPluginsResourceLoader> resourceLoaders = new ArrayList<>();
+
+    private String rootStorePath;
+
+    private String pluginPropsName;
+
+    private static final String PLUGIN_DIR = "plugin";
+
+    public DefaultEngineConnPluginLoader() throws ErrorException {
+        //Check store path (is necessary)
+        String storePath = EngineConnPluginLoaderConf.ENGINE_PLUGIN_STORE_PATH().getValue();
+        if (StringUtils.isBlank(storePath)) {
+            ExceptionHelper.dealErrorException(70061, "You should defined ["
+                    + EngineConnPluginLoaderConf.ENGINE_PLUGIN_STORE_PATH().key() + "] in properties file", null);
+        }
+        //The path can be uri
+        try {
+            URI storeUri = new URI(storePath);
+            if(null != storeUri.getScheme()){
+                File storeDir = new File(storeUri);
+                storePath = storeDir.getAbsolutePath();
+            }
+        } catch (URISyntaxException e) {
+            //Ignore
+        } catch (IllegalArgumentException e){
+            ExceptionHelper.dealErrorException(70061, "The value:[" + storePath +"] of ["
+                    + EngineConnPluginLoaderConf.ENGINE_PLUGIN_STORE_PATH().key() + "] is incorrect", e);
+        }
+        this.rootStorePath = storePath;
+        this.pluginPropsName = EngineConnPluginLoaderConf.ENGINE_PLUGIN_PROPERTIES_NAME().getValue();
+        //Prepare inner loaders
+//        resourceLoaders.add(new BmlEngineConnPluginResourceLoader());
+        resourceLoaders.add(new LocalEngineConnPluginResourceLoader());
+    }
+
+    @Override
+    protected EngineConnPluginInstance loadEngineConnPluginInternal(EngineConnPluginInfo enginePluginInfo) throws Exception {
+        //Build save path
+        String savePath = rootStorePath;
+        EngineTypeLabel typeLabel = enginePluginInfo.typeLabel();
+        if (!savePath.endsWith(String.valueOf(IOUtils.DIR_SEPARATOR))) {
+            savePath += IOUtils.DIR_SEPARATOR;
+        }
+        savePath += IOUtils.DIR_SEPARATOR + typeLabel.getEngineType() + IOUtils.DIR_SEPARATOR + PLUGIN_DIR + IOUtils.DIR_SEPARATOR;
+        if (StringUtils.isNoneBlank(typeLabel.getVersion())) {
+            savePath += typeLabel.getVersion() + IOUtils.DIR_SEPARATOR;
+        }
+        //Try to fetch resourceId from configuration
+      /*  if (StringUtils.isBlank(enginePluginInfo.resourceId())) {
+            String identify = EngineConnPluginLoaderConf.ENGINE_PLUGIN_RESOURCE_ID_NAME_PREFIX() + typeLabel.getEngineType() + "-" + typeLabel.getVersion();
+            String resourceIdInConf = BDPConfiguration.get(identify);
+            if (StringUtils.isNotBlank(resourceIdInConf)) {
+                LOG.info("Fetch resourceId:[" + resourceIdInConf + "] from properties:[" + identify + "]");
+                enginePluginInfo.resourceId_$eq(resourceIdInConf);
+            }
+        }*/
+        EngineConnPlugin enginePlugin = null;
+        //Load the resource of engine plugin
+        PluginResource pluginResource = null;
+        for (int i = 0; i < resourceLoaders.size(); i++) {
+            PluginResource resource = resourceLoaders.get(i).loadEngineConnPluginResource(enginePluginInfo, savePath);
+            if (null != resource) {
+                if (null == pluginResource) {
+                    pluginResource = resource;
+                } else {
+                    //Merge plugin resource
+                    pluginResource.merge(pluginResource);
+                }
+            }
+        }
+        if (null != pluginResource &&
+                null != pluginResource.getUrls() && pluginResource.getUrls().length > 0) {
+            //Load engine plugin properties file
+            Map<String, Object> props = readFromProperties(savePath + pluginPropsName);
+            //Build engine classloader
+            ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+            EngineConnPluginClassLoader enginePluginClassLoader = new EngineConnPluginClassLoader(pluginResource.getUrls(), currentClassLoader);
+            //Load the engine plugin object
+            enginePlugin = loadEngineConnPlugin(enginePluginClassLoader, props);
+            if(null != enginePlugin){
+                //Need to init engine plugin ?
+                LOG.info("Init engine conn plugin:[name: " + typeLabel.getEngineType() +
+                        ", version: " + typeLabel.getVersion() + "], invoke method init() ");
+                initEngineConnPlugin(enginePlugin, props);
+                //New another plugin info
+                EngineConnPluginInfo newPluginInfo = new EngineConnPluginInfo(typeLabel, pluginResource.getUpdateTime(),
+                        pluginResource.getId(), pluginResource.getVersion(), enginePluginClassLoader);
+                return new EngineConnPluginInstance(newPluginInfo, enginePlugin);
+            }
+         }
+        throw new EngineConnPluginNotFoundException("No plugin found, please check your configuration", null);
+    }
+
+    /**
+     * Init plugin
+     * @param plugin plugin instance
+     * @param props parameters
+     */
+    private void initEngineConnPlugin(EngineConnPlugin plugin, Map<String, Object> props) throws EngineConnPluginLoadException {
+        try {
+            //Only one method
+            plugin.init(props);
+        }catch(Exception e){
+            throw new EngineConnPluginLoadException("Failed to init engine conn plugin instance", e);
+        }
+    }
+
+    private EngineConnPlugin loadEngineConnPlugin(EngineConnPluginClassLoader enginePluginClassLoader, Map<String, Object> props) throws EngineConnPluginLoadException {
+        //First try to load from spi
+        EngineConnPlugin enginePlugin = EngineConnPluginUtils.loadSubEngineConnPluginInSpi(enginePluginClassLoader);
+        if(null == enginePlugin){
+            //Second, try to find plugin class
+            String pluginClass = EngineConnPluginUtils.getEngineConnPluginClass(enginePluginClassLoader);
+            //Not contain plugin class
+            if(StringUtils.isNotBlank(pluginClass)){
+                Class<? extends EngineConnPlugin> enginePluginClass = loadEngineConnPluginClass(pluginClass, enginePluginClassLoader);
+                return loadEngineConnPlugin(enginePluginClass, enginePluginClassLoader, props);
+            }
+        }
+        return null;
+    }
+
+    private EngineConnPlugin loadEngineConnPlugin(Class<? extends EngineConnPlugin> pluginClass, EngineConnPluginClassLoader enginePluginClassLoader, Map<String, Object> props) throws EngineConnPluginLoadException {
+        ClassLoader storeClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(enginePluginClassLoader);
+        try{
+            final Constructor<?>[] constructors = pluginClass.getConstructors();
+            if(constructors.length == 0){
+                throw new EngineConnPluginLoadException("No public constructor in pluginClass [" + pluginClass.getName() + "]", null);
+            }
+            //Choose the first one
+            Constructor<?> constructor = constructors[0];
+            Class<?>[] parameters = constructor.getParameterTypes();
+            try {
+                if (constructor.getParameterCount() == 0) {
+                    return (EngineConnPlugin)constructor.newInstance();
+                }else if (constructor.getParameterCount() == 1 && parameters[0] == Map.class){
+                    return (EngineConnPlugin)constructor.newInstance(props);
+                }else{
+                    throw new EngineConnPluginLoadException("Illegal arguments in constructor of pluginClass [" + pluginClass.getName() + "]", null);
+                }
+            }catch(Exception e){
+                if(e instanceof EngineConnPluginLoadException){
+                    throw (EngineConnPluginLoadException) e;
+                }
+                throw new EngineConnPluginLoadException("Unable to construct pluginClass [" + pluginClass.getName() + "]", null);
+            }
+        }finally{
+            Thread.currentThread().setContextClassLoader(storeClassLoader);
+        }
+    }
+
+    private Class<? extends EngineConnPlugin> loadEngineConnPluginClass(String pluginClass, EngineConnPluginClassLoader classLoader) throws EngineConnPluginLoadException {
+        try {
+            return classLoader.loadClass(pluginClass).asSubclass(EngineConnPlugin.class);
+        } catch (ClassNotFoundException e) {
+            throw new EngineConnPluginLoadException("Unable to load class:[" + pluginClass + "]", e);
+        }
+    }
+
+    @SuppressWarnings(value = {"unchecked", "rawtypes"})
+    private Map<String, Object> readFromProperties(String propertiesFile) {
+        Map<String, Object> map = new HashMap<>();
+        Properties properties = new Properties();
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(propertiesFile));
+            properties.load(reader);
+            map = new HashMap<String, Object>((Map) properties);
+        }catch(IOException e){
+            //Just warn
+        }
+        return map;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/EngineConnPluginsLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/EngineConnPluginsLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInstance;
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel;
+
+
+public interface EngineConnPluginsLoader {
+
+
+    /**
+     * Get plugin( will get from the cache first )
+     * @param engineTypeLabel engine type label
+     * @return enginePlugin and classloader (you must not to hold the instance, avoid OOM)
+     */
+    EngineConnPluginInstance getEngineConnPlugin(EngineTypeLabel engineTypeLabel) throws Exception;
+    /**
+     * Load plugin without caching ( will force to update the cache )
+     * @param engineTypeLabel engine type label
+     * @return enginePlugin and classloader (you must not to hold the instance, avoid OOM)
+     */
+    EngineConnPluginInstance loadEngineConnPlugin(EngineTypeLabel engineTypeLabel) throws Exception;
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/EngineConnPluginsResourceLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/EngineConnPluginsResourceLoader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception.EngineConnPluginLoadResourceException;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.resource.PluginResource;
+
+
+public interface EngineConnPluginsResourceLoader {
+
+
+    /**
+     *
+     * @param pluginInfo plugin info
+     * @param savePath save Path
+     * @return resource of plugin
+     */
+    PluginResource loadEngineConnPluginResource(EngineConnPluginInfo pluginInfo,
+                                                String savePath) throws EngineConnPluginLoadResourceException;
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/resource/BmlEngineConnPluginResourceLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/resource/BmlEngineConnPluginResourceLoader.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.resource;
+
+import com.webank.wedatasphere.linkis.bml.client.BmlClient;
+import com.webank.wedatasphere.linkis.bml.client.BmlClientFactory;
+import com.webank.wedatasphere.linkis.bml.protocol.BmlDownloadResponse;
+import com.webank.wedatasphere.linkis.bml.protocol.Version;
+import com.webank.wedatasphere.linkis.common.io.FsPath;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.exception.EngineConnPluginLoadResourceException;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.config.EngineConnPluginLoaderConf;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.EngineConnPluginsResourceLoader;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils.EngineConnPluginUtils;
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+
+
+public class BmlEngineConnPluginResourceLoader implements EngineConnPluginsResourceLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BmlEngineConnPluginResourceLoader.class);
+
+    private static final String LOAD_LOCK_FILE = ".lock-dir";
+    /**
+     * BML client user
+     */
+    private String clientUser;
+
+    /**
+     * BML client entity
+     */
+    private BmlClient bmlClient;
+
+    private String downloadTmpDir;
+
+    public BmlEngineConnPluginResourceLoader(){
+        this(EngineConnPluginLoaderConf
+                .ENGINE_PLUGIN_LOADER_DEFAULT_USER().getValue(), null);
+    }
+
+    public BmlEngineConnPluginResourceLoader(String clientUser, Map<String, Object> clientProps){
+        this.clientUser = clientUser;
+        this.bmlClient = BmlClientFactory.createBmlClient(clientUser, clientProps);
+        this.downloadTmpDir = EngineConnPluginLoaderConf.DOWNLOAD_TEMP_DIR_PREFIX().getValue();
+    }
+
+    @Override
+    public PluginResource loadEngineConnPluginResource(EngineConnPluginInfo pluginInfo, String savePath)
+        throws EngineConnPluginLoadResourceException {
+        String resourceId = getResourceIdFromStorage(pluginInfo.typeLabel());
+        resourceId = StringUtils.isBlank(resourceId)? pluginInfo.resourceId() : resourceId;
+        EngineTypeLabel typeLabel = pluginInfo.typeLabel();
+        if(StringUtils.isNotBlank(resourceId)) {
+            String resourceVersion = pluginInfo.resourceVersion();
+            String maxVersion = "";
+            if (StringUtils.isNotBlank(resourceVersion)) {
+                List<Version> versions = this.bmlClient.getVersions(this.clientUser, resourceId).resourceVersions().versions();
+                maxVersion = versions.stream().map(Version::version).max(Comparator.naturalOrder()).orElse(null);
+                if(null == maxVersion){
+                    LOG.trace("Unable to find the versions of resourceId:[" + resourceId +"] for engine conn plugin:[name: " + typeLabel.getEngineType() +
+                            ", version: " + typeLabel.getVersion() + "] in BML");
+                    return null;
+                }
+                //Has the same version
+                if(maxVersion.equals(resourceVersion)){
+                    LOG.trace("The version:[" + versions + "] of resourceId:[" + resourceId +"] for engine conn plugin:[name: " + typeLabel.getEngineType() +
+                            ", version: " + typeLabel.getVersion() + "] must be latest");
+                    return null;
+                }
+                LOG.trace("Start to download resource of engine conn plugin:[name: " + typeLabel.getEngineType() +
+                        ", version: " + typeLabel.getVersion() + "]");
+                //Try to download
+                downloadResource(typeLabel, resourceId, maxVersion, savePath);
+                //Bml doesn't need to provide urls
+                return new PluginResource(resourceId, maxVersion, -1L, null);
+            }
+        }
+        //Don't need to load resource
+        return null;
+    }
+
+    private void downloadResource(EngineTypeLabel typeLabel, String resourceId,
+                                     String version, String savePath) throws EngineConnPluginLoadResourceException {
+        //Use FsPath instead ?
+        File savePos = FileUtils.getFile(savePath);
+        if(!savePos.exists() || savePos.isDirectory()) {
+            File parentFile = savePos.getParentFile();
+            if(null == parentFile){
+                throw new EngineConnPluginLoadResourceException("Unable to build temp directory for downloading," +
+                        " reason:[The parent directory of savePath doesn't exist], savePath:[" + savePath + "]", null);
+            }
+            if(!parentFile.exists() || !parentFile.canWrite()){
+                throw new EngineConnPluginLoadResourceException("Have no write permission to directory:[" + parentFile.getAbsolutePath() + "]", null);
+            }
+            String tmpPath = parentFile.getAbsolutePath();
+            if (!tmpPath.endsWith(String.valueOf(IOUtils.DIR_SEPARATOR))) {
+                tmpPath += IOUtils.DIR_SEPARATOR;
+            }
+            //TODO maybe has the same name directory?
+            tmpPath += (downloadTmpDir + System.currentTimeMillis() + "-" + Thread.currentThread().getId());
+            File tmpFile = FileUtils.getFile(tmpPath);
+            try {
+                BmlDownloadResponse downloadResponse = this.bmlClient
+                        .downloadResource(this.clientUser, resourceId, version, EngineConnPluginUtils.FILE_SCHEMA
+                                + (FsPath.WINDOWS ? IOUtils.DIR_SEPARATOR_UNIX + FilenameUtils.normalize(tmpPath, true)
+                                : FilenameUtils.normalize(tmpPath, true)), true);
+                if (null == downloadResponse || !downloadResponse.isSuccess()) {
+                    throw new EngineConnPluginLoadResourceException("Fail to download resources of engine conn plugin:[name: " + typeLabel.getEngineType() +
+                            ", version: " + typeLabel.getVersion() + "]", null);
+                } else {
+                    LOG.info("Success to download resource of plugin:[name: " + typeLabel.getEngineType() +
+                            ", version: " + typeLabel.getVersion() + "], start to load temp resource directory");
+                    //Load tmp directory
+                    loadTempResourceFile(tmpFile, savePos);
+                }
+            }finally{
+                //Ensure that the temporary directory will be deleted completely
+                if(tmpFile.exists()){
+                    try {
+                        FileUtils.forceDelete(tmpFile);
+                    } catch (IOException e) {
+                        //Ignore
+                        LOG.warn("Delete temp file fail:[" + tmpFile.getAbsolutePath() +
+                                "], message:[" + e.getMessage() + "]", e);
+                    }
+                }
+            }
+        }
+        LOG.error("Unable to download from BML to savePath:[" + savePath + "], is not a directory");
+    }
+
+    private void loadTempResourceFile(File tempFile, File saveDir) throws EngineConnPluginLoadResourceException {
+        if(saveDir.exists()) {
+            LOG.info("Clean out-of-date files in saving directory:[" + saveDir.getAbsolutePath() + "]");
+            try {
+                FileUtils.cleanDirectory(saveDir);
+            } catch (IOException e) {
+                throw new EngineConnPluginLoadResourceException("Fail to clean out-of-date save directory:[" + saveDir.getAbsolutePath() + "], please check if the directory has been broken, message:["
+                        + e.getMessage() + "]", e);
+            }
+        }else {
+            saveDir.mkdir();//Ignore
+        }
+        //TODO has a problem, we don't know the source file name or suffix name of tmp file downloaded from BML
+        LOG.info("Move tempFile:[" + tempFile.getPath() +"] to saveDir:[" + saveDir.getPath() + "]");
+        try {
+            FileUtils.moveDirectory(tempFile, saveDir);
+        } catch (IOException e) {
+            throw new EngineConnPluginLoadResourceException("Fail to move tempFile:[" + tempFile.getPath() +"] to saveDir:[" + saveDir.getPath() + "], message:["
+             + e.getMessage() + "]", e);
+        }
+    }
+
+    private String getResourceIdFromStorage(EngineTypeLabel typeLabel){
+        //TODO get resourceId from database by engineTypeLabel?
+        return null;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/resource/LocalEngineConnPluginResourceLoader.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/resource/LocalEngineConnPluginResourceLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.resource;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.loader.entity.EngineConnPluginInfo;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.EngineConnPluginsResourceLoader;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils.EngineConnPluginUtils;
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+
+public class LocalEngineConnPluginResourceLoader implements EngineConnPluginsResourceLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalEngineConnPluginResourceLoader.class);
+
+    @Override
+    public PluginResource loadEngineConnPluginResource(EngineConnPluginInfo pluginInfo, String savePath) {
+        File savePos = FileUtils.getFile(savePath);
+        if(savePos.exists() && savePos.isDirectory()){
+            long modifyTime = savePos.lastModified();
+            if(modifyTime > pluginInfo.resourceUpdateTime()){
+                EngineTypeLabel typeLabel = pluginInfo.typeLabel();
+                List<URL> urls = EngineConnPluginUtils.getJarsUrlsOfPath(savePath);
+                if(urls.size() > 0){
+                    LOG.info("Load local resource of engine conn plugin: [name: " + typeLabel.getEngineType() +
+                            ", version: " + typeLabel.getVersion() + "] uri: [" + savePath + "]");
+                }
+                return new PluginResource(null, null, modifyTime, urls.toArray(new URL[0]));
+            }
+        }
+        return null;
+    }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/resource/PluginResource.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/loaders/resource/PluginResource.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.resource;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.net.URL;
+
+
+public class PluginResource {
+    private String id;
+
+    private String version;
+
+    private long updateTime;
+
+    private URL[] urls = new URL[0];
+
+    PluginResource(){
+
+    }
+
+    PluginResource(String id, String version, long updateTime, URL[] urls){
+        this.id = id;
+        this.version = version;
+        this.updateTime = updateTime;
+        this.urls = urls;
+    }
+
+    public void merge(PluginResource pluginResource){
+        if(StringUtils.isNotBlank(pluginResource.id)){
+            this.id = pluginResource.id;
+        }
+        if(StringUtils.isNotBlank(pluginResource.version)){
+            this.version = pluginResource.version;
+        }
+        if(pluginResource.updateTime > 0){
+            this.updateTime = pluginResource.updateTime;
+        }
+
+    }
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public long getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(long updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public URL[] getUrls() {
+        return urls;
+    }
+
+    public void setUrls(URL[] urls) {
+        this.urls = urls;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/utils/EngineConnPluginUtils.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/utils/EngineConnPluginUtils.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.EngineConnPlugin;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.function.Function;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Description:
+ * Provide some methods to find classpath
+ */
+public class EngineConnPluginUtils {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(EngineConnPluginUtils.class);
+
+
+    private static final String JAR_SUF_NAME = ".jar";
+
+    private static final String CLASS_SUF_NAME = ".class";
+
+    public static final String FILE_SCHEMA = "file://";
+
+    private static final Class<EngineConnPlugin> PLUGIN_PARENT_CLASS = EngineConnPlugin.class;
+
+
+    public static List<URL> getJarsUrlsOfPath(String path){
+        List<URL> classPathURLs = new ArrayList<>();
+        return getJarsUrlsOfPathRecurse(path, classPathURLs);
+    }
+
+    public static String getEngineConnPluginClass(URLClassLoader engineClassloader){
+        URL[] urlsOfClassLoader = engineClassloader.getURLs();
+        String className;
+        for(URL classPath : urlsOfClassLoader){
+            String path = classPath.getPath();
+            className = getEngineConnPluginClassFromURL(path, (classFullName) ->
+                    isSubEngineConnPluginClass(classFullName, engineClassloader));
+            if(null != className){
+                return className;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Load EnginePlugin in spi( you should have constructor with no parameters)
+     * @param classLoader engine plugin classloader
+     * @return
+     */
+    public static EngineConnPlugin loadSubEngineConnPluginInSpi(ClassLoader classLoader){
+        ServiceLoader<EngineConnPlugin> serviceLoader = ServiceLoader.load(PLUGIN_PARENT_CLASS, classLoader);
+        Iterator<EngineConnPlugin> subClassIterator = serviceLoader.iterator();
+        //Just return the first one
+        if(subClassIterator.hasNext()){
+            return subClassIterator.next();
+        }
+        return null;
+    }
+
+    private static List<URL> getJarsUrlsOfPathRecurse(String path, List<URL> classPathURLs){
+        File parentFile = new File(path);
+        File[] childFiles = parentFile.listFiles((file) ->{
+          String name = file.getName();
+          return !name.startsWith(".") && (file.isDirectory() || name.endsWith(JAR_SUF_NAME) ||name.endsWith(CLASS_SUF_NAME));
+        });
+        if(null != childFiles && childFiles.length > 0){
+            for(File childFile : childFiles){
+                if (childFile.isDirectory()) {
+                    getJarsUrlsOfPathRecurse(childFile.getPath(), classPathURLs);
+                } else {
+                    try {
+                        classPathURLs.add(childFile.toURI().toURL());
+                    } catch (MalformedURLException e) {
+                        //Ignore
+                        LOG.warn("url {} cannot be added", FILE_SCHEMA + childFile.getPath());
+                    }
+                }
+            }
+        }
+        return classPathURLs;
+    }
+
+    /**
+     * Get engine plugin class
+     * @param url url
+     * @param acceptedFunction accept function
+     * @return
+     */
+    private static String getEngineConnPluginClassFromURL(String url, Function<String, Boolean> acceptedFunction){
+        if(url.endsWith(CLASS_SUF_NAME)){
+            String className = url.substring(0, url.lastIndexOf(CLASS_SUF_NAME));
+            int splitIndex = className.lastIndexOf(IOUtils.DIR_SEPARATOR);
+            if(splitIndex >= 0){
+                className = className.substring(splitIndex);
+            }
+            return acceptedFunction.apply(className) ? className : null;
+        }else if(url.endsWith(JAR_SUF_NAME)){
+            try {
+                JarFile jarFile = new JarFile(new File(url));
+                Enumeration<JarEntry> en = jarFile.entries();
+                while(en.hasMoreElements()){
+                    String name = en.nextElement().getName();
+                    if(name.endsWith(CLASS_SUF_NAME)){
+                        String className = name.substring(0, name.lastIndexOf(CLASS_SUF_NAME));
+                        //If the splicer is different in WINDOWS system?
+                        className = className.replaceAll(String.valueOf(IOUtils.DIR_SEPARATOR_UNIX), ".");
+                        if(acceptedFunction.apply(className)){
+                            return className;
+                        }
+                    }
+                }
+                return null;
+            } catch (IOException e) {
+                //Trace
+                LOG.trace("Fail to parse jar file:[" + url + "] in plugin classpath");
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isSubEngineConnPluginClass(String className, ClassLoader classLoader) {
+        if (StringUtils.isEmpty(className)) {
+            return false;
+        }
+        Class<?> clazz;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+            //Skip interface and abstract class
+            if (Modifier.isAbstract(clazz.getModifiers()) || Modifier.isInterface(clazz.getModifiers())) {
+                return false;
+            }
+        } catch (Throwable t) {
+            LOG.trace("Class: {} can not be found", className, t);
+            return false;
+        }
+        return EngineConnPluginUtils.PLUGIN_PARENT_CLASS.isAssignableFrom(clazz);
+    }
+
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/utils/ExceptionHelper.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/manager/utils/ExceptionHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils;
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException;
+
+
+public class ExceptionHelper {
+    public static void dealErrorException(int errorCode, String errorMsg, Throwable t) throws ErrorException {
+        ErrorException errorException = new ErrorException(errorCode, errorMsg);
+        errorException.initCause(t);
+        throw errorException;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/manager/config/EngineConnPluginLoaderConf.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/manager/config/EngineConnPluginLoaderConf.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.manager.config
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+
+
+object EngineConnPluginLoaderConf {
+
+  val ENGINE_PLUGIN_RESOURCE_ID_NAME_PREFIX: String = "wds.linkis.engineConn.plugin.loader.resource-id."
+
+  val CLASS_LOADER_CLASS_NAME: CommonVars[String] = CommonVars("wds.linkis.engineconn.plugin.loader.classname", "")
+
+  val ENGINE_PLUGIN_LOADER_DEFAULT_USER: CommonVars[String] = CommonVars("wds.linkis.engineconn.plugin.loader.defaultUser", "hadoop")
+
+  val ENGINE_PLUGIN_STORE_PATH: CommonVars[String] = CommonVars("wds.linkis.engineconn.plugin.loader.store.path", "")
+
+  val ENGINE_PLUGIN_PROPERTIES_NAME: CommonVars[String] = CommonVars("wds.linkis.engineconn.plugin.loader.properties.name", "plugins.properties")
+
+  val ENGINE_PLUGIN_LOADER_CACHE_REFRESH_INTERVAL: CommonVars[String] = CommonVars("wds.linkis.engineconn.plugin.loader.cache.refresh-interval", "300")
+
+  val DOWNLOAD_TEMP_DIR_PREFIX: CommonVars[String] = CommonVars("wds.linkis.engineconn.plugin.loader.download.tmpdir.prefix", ".BML_TMP_")
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/test/java/EngineConnPluginLoaderTest.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader/src/test/java/EngineConnPluginLoaderTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.classloader.EngineConnPluginClassLoader;
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.utils.EngineConnPluginUtils;
+
+import java.io.File;
+import java.net.URL;
+
+
+public class EngineConnPluginLoaderTest {
+    public static void main(String[] args) throws Exception {
+        EngineConnPluginClassLoader enginePluginClassLoader = new EngineConnPluginClassLoader(new URL[]{
+                new File("").toURI().toURL()
+        }, Thread.currentThread().getContextClassLoader());
+        String engineConnPluginClass = EngineConnPluginUtils.getEngineConnPluginClass(enginePluginClassLoader);
+        Class<?> clazz = Class.forName(engineConnPluginClass, true, enginePluginClassLoader);
+        clazz.newInstance();
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/pom.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/pom.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-plugin-server</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>asm</artifactId>
+                    <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tomcat</groupId>
+                    <artifactId>jasper-compiler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tomcat</groupId>
+                    <artifactId>jasper-runtime</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                    <artifactId>linkis-storage</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <artifactId>linkis-common</artifactId>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                </exclusion>
+            </exclusions>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-mybatis</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>linkis-common</artifactId>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                    <artifactId>linkis-storage</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-loader</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>linkis-common</artifactId>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                    <artifactId>linkis-storage</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+            <version>${json4s.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+            </resource>
+
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                    <include>**/*.yml</include>
+                </includes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/assembly/distribution.xml
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-application-manager</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>linkis-engineconn-plugin-server</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <!--<fileSet>
+            <directory>${basedir}/bin</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>bin</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <fileSet>
+            <directory>.</directory>
+            <excludes>
+                <exclude>*/**</exclude>
+            </excludes>
+            <outputDirectory>logs</outputDirectory>
+        </fileSet>  -->
+    </fileSets>
+
+</assembly>
+

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/LinkisEngineConnPluginServer.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/LinkisEngineConnPluginServer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server;
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+
+public class LinkisEngineConnPluginServer {
+
+    private static final Log logger = LogFactory.getLog(LinkisEngineConnPluginServer.class);
+
+    public static void main(String[] args) throws ReflectiveOperationException {
+        logger.info("Start to running LinkisEngineConnPluginServer");
+        DataWorkCloudApplication.main(args);
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/conf/EngineConnPluginSpringConfiguration.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/conf/EngineConnPluginSpringConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.conf;
+
+import com.webank.wedatasphere.linkis.engineplugin.server.localize.DefaultEngineConnBmlResourceGenerator;
+import com.webank.wedatasphere.linkis.engineplugin.server.localize.EngineConnBmlResourceGenerator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class EngineConnPluginSpringConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(EngineConnBmlResourceGenerator.class)
+    public EngineConnBmlResourceGenerator getEngineConnBmlResourceGenerator() {
+        return new DefaultEngineConnBmlResourceGenerator();
+    }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/dao/EngineConnBmlResourceDao.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/dao/EngineConnBmlResourceDao.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.dao;
+
+import com.webank.wedatasphere.linkis.engineplugin.server.entity.EngineConnBmlResource;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+
+@Mapper
+public interface EngineConnBmlResourceDao {
+
+    List<EngineConnBmlResource> getAllEngineConnBmlResource(@Param("engineConnType") String engineConnType, @Param("version") String version);
+
+    void save(@Param("engineConnBmlResource") EngineConnBmlResource engineConnBmlResource);
+
+    void update(@Param("engineConnBmlResource") EngineConnBmlResource engineConnBmlResource);
+
+    void delete(@Param("engineConnBmlResource") EngineConnBmlResource engineConnBmlResource);
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/dao/impl/EngineConnBmlResourceMapper.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/dao/impl/EngineConnBmlResourceMapper.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+
+
+<mapper namespace="com.webank.wedatasphere.linkis.engineplugin.server.dao.EngineConnBmlResourceDao">
+
+
+    <sql id="bml_resources">
+        `engine_conn_type`,`version`,`file_name`,`file_size`,`last_modified`,`bml_resource_id`,`bml_resource_version`,`create_time`,`last_update_time`
+    </sql>
+
+    <select id="getAllEngineConnBmlResource"
+            resultType="com.webank.wedatasphere.linkis.engineplugin.server.entity.EngineConnBmlResource">
+        SELECT * FROM linkis_engine_conn_plugin_bml_resources
+        WHERE engine_conn_type=#{engineConnType} and `version`=#{version}
+    </select>
+
+    <delete id="delete" parameterType="com.webank.wedatasphere.linkis.engineplugin.server.entity.EngineConnBmlResource">
+        delete from linkis_engine_conn_plugin_bml_resources where
+        engine_conn_type=#{engineConnBmlResource.engineConnType} and
+        `version`=#{engineConnBmlResource.version}
+        and file_name=#{engineConnBmlResource.fileName}
+    </delete>
+
+    <update id="update" parameterType="com.webank.wedatasphere.linkis.engineplugin.server.entity.EngineConnBmlResource">
+        update linkis_engine_conn_plugin_bml_resources
+        <trim prefix="set" suffixOverrides=",">
+            <if test="engineConnBmlResource.lastModified != null">`last_modified` =
+                #{engineConnBmlResource.lastModified},
+            </if>
+            <if test="engineConnBmlResource.fileSize != null">`file_size` = #{engineConnBmlResource.fileSize},</if>
+            <if test="engineConnBmlResource.bmlResourceVersion != null">`bml_resource_version` =
+                #{engineConnBmlResource.bmlResourceVersion},
+            </if>
+            <if test="engineConnBmlResource.lastUpdateTime != null">`last_update_time` =
+                #{engineConnBmlResource.lastUpdateTime},
+            </if>
+        </trim>
+        WHERE engine_conn_type=#{engineConnBmlResource.engineConnType} and `version`=#{engineConnBmlResource.version}
+        and file_name=#{engineConnBmlResource.fileName}
+    </update>
+
+    <insert id="save" parameterType="com.webank.wedatasphere.linkis.engineplugin.server.entity.EngineConnBmlResource">
+        insert into linkis_engine_conn_plugin_bml_resources(<include refid="bml_resources"/>)
+        values(#{engineConnBmlResource.engineConnType}, #{engineConnBmlResource.version},
+        #{engineConnBmlResource.fileName}, #{engineConnBmlResource.lastModified},
+        #{engineConnBmlResource.fileSize}, #{engineConnBmlResource.bmlResourceId},
+        #{engineConnBmlResource.bmlResourceVersion},
+        #{engineConnBmlResource.createTime}, #{engineConnBmlResource.lastUpdateTime})
+    </insert>
+
+
+</mapper>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/entity/EngineConnBmlResource.java
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/java/com/webank/wedatasphere/linkis/engineplugin/server/entity/EngineConnBmlResource.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.entity;
+
+import java.util.Date;
+
+
+public class EngineConnBmlResource {
+
+    private Long id;
+    private String engineConnType;
+    private String version;
+    private String fileName;
+    private Long lastModified;
+    private Long fileSize;
+    private String bmlResourceId;
+    private String bmlResourceVersion;
+    private Date createTime;
+    private Date lastUpdateTime;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEngineConnType() {
+        return engineConnType;
+    }
+
+    public void setEngineConnType(String engineConnType) {
+        this.engineConnType = engineConnType;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public Long getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Long lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public Long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(Long fileSize) {
+        this.fileSize = fileSize;
+    }
+
+    public String getBmlResourceId() {
+        return bmlResourceId;
+    }
+
+    public void setBmlResourceId(String bmlResourceId) {
+        this.bmlResourceId = bmlResourceId;
+    }
+
+    public String getBmlResourceVersion() {
+        return bmlResourceVersion;
+    }
+
+    public void setBmlResourceVersion(String bmlResourceVersion) {
+        this.bmlResourceVersion = bmlResourceVersion;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public Date getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(Date lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+    }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/resources/application.yml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+server:
+  port: 9103
+spring:
+  application:
+    name: linkis-cg-engineplugin
+
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://127.0.0.1:20303/eureka/
+  instance:
+    metadata-map:
+      test: wedatasphere
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh,info
+  health:
+    db:
+      enabled: false
+logging:
+  config: classpath:log4j2.xml
+
+ribbon:
+  ReadTimeout: 60000
+  ConnectTimeout: 60000

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/resources/linkis-server.properties
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/resources/linkis-server.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2019 WeBank
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+wds.linkis.engineconn.debug.enable=true
+##mybatis
+wds.linkis.server.mybatis.mapperLocations=classpath:com/webank/wedatasphere/linkis/engineplugin/server/dao/impl/*.xml
+wds.linkis.server.mybatis.typeAliasesPackage=
+wds.linkis.server.mybatis.BasePackage=com.webank.wedatasphere.linkis.engineplugin.server.dao
+wds.linkis.engineConn.plugin.cache.expire-in-seconds=100000
+wds.linkis.engineConn.dist.load.enable=true

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/resources/log4j2.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration status="error" monitorInterval="30">
+    <appenders>
+        <RollingFile name="RollingFile" fileName="${env:SERVER_LOG_PATH}/linkis.log"
+                     filePattern="${env:SERVER_LOG_PATH}/$${date:yyyy-MM}/linkis-log-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-40t] %c{1.} (%L) [%M] - %msg%xEx%n"/>
+            <SizeBasedTriggeringPolicy size="100MB"/>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <appender-ref ref="RollingFile"/>
+        </root>
+    </loggers>
+</configuration>
+

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/conf/EngineConnPluginConfiguration.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/conf/EngineConnPluginConfiguration.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.conf
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+
+
+object EngineConnPluginConfiguration {
+
+  val ENGINE_CONN_HOME = CommonVars("wds.linkis.engineconn.home",
+    CommonVars[String]("ENGINE_CONN_HOME", "").getValue)
+  val ENGINE_CONN_DIST_LOAD_ENABLE = CommonVars("wds.linkis.engineconn.dist.load.enable", true)
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/interceptor/EngineConnLaunchInterceptor.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/interceptor/EngineConnLaunchInterceptor.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.interceptor
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, RicherEngineConnBuildRequest}
+
+
+trait EngineConnLaunchInterceptor {
+
+  /**
+    * 补充资源文件信息，如：UDF、用户jar、Python文件等
+    * 补充启动参数信息等
+    *
+    * @param engineConnBuildRequest
+    */
+  def intercept(engineConnBuildRequest: EngineConnBuildRequest): RicherEngineConnBuildRequest
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/loader/EngineConnPluginsLoader.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/loader/EngineConnPluginsLoader.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.loader
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.manager.loaders.{DefaultEngineConnPluginLoader, EngineConnPluginsLoader}
+
+
+object EngineConnPluginsLoader {
+
+  private val engineConnPluginsLoader: EngineConnPluginsLoader = new DefaultEngineConnPluginLoader()
+
+  def getEngineConnPluginsLoader(): EngineConnPluginsLoader = engineConnPluginsLoader
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/localize/AbstractEngineConnBmlResourceGenerator.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/localize/AbstractEngineConnBmlResourceGenerator.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.localize
+
+import java.io.File
+import java.nio.file.Paths
+
+import com.webank.wedatasphere.linkis.engineplugin.server.conf.EngineConnPluginConfiguration.ENGINE_CONN_HOME
+import com.webank.wedatasphere.linkis.engineplugin.server.localize.EngineConnBmlResourceGenerator.NO_VERSION_MARK
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnPluginErrorException
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+import com.webank.wedatasphere.linkis.server.conf.ServerConfiguration
+import org.apache.commons.lang.StringUtils
+
+
+abstract class AbstractEngineConnBmlResourceGenerator extends EngineConnBmlResourceGenerator {
+
+  if(!new File(getEngineConnsHome).exists)
+    throw new EngineConnPluginErrorException(20001, "Cannot find the home path of engineConn.")
+
+  protected def getEngineConnsHome: String = {
+    if(StringUtils.isBlank(ENGINE_CONN_HOME.getValue))
+      Paths.get(ServerConfiguration.BDP_SERVER_HOME.getValue, "engineconns").toFile.getPath
+    else ENGINE_CONN_HOME.getValue
+  }
+
+  protected def getEngineConnDistHome(engineConnTypeLabel: EngineTypeLabel): String =
+    getEngineConnDistHome(engineConnTypeLabel.getEngineType, engineConnTypeLabel.getVersion)
+
+  protected def getEngineConnDistHome(engineConnType: String, version: String): String = {
+    val engineConnDistHome = Paths.get(getEngineConnsHome, engineConnType, "dist").toFile.getPath
+    if(!new File(engineConnDistHome).exists())
+      throw new EngineConnPluginErrorException(20001, "Cannot find the home path of engineconn dist.")
+    if(StringUtils.isBlank(version) || NO_VERSION_MARK == version) return engineConnDistHome
+    val engineConnPackageHome = Paths.get(engineConnDistHome, "v" + version).toFile.getPath
+    if(new File(engineConnPackageHome).exists()) engineConnPackageHome
+    else engineConnDistHome
+  }
+
+  protected def getEngineConnDistHomeList(engineConnType: String): Array[String] = {
+    val engineConnDistHome = Paths.get(getEngineConnsHome, engineConnType, "dist").toFile.getPath
+    val engineConnDistHomeFile = new File(engineConnDistHome)
+    if(!engineConnDistHomeFile.exists())
+      throw new EngineConnPluginErrorException(20001, "Cannot find the home path of engineconn dist.")
+    val children = engineConnDistHomeFile.listFiles()
+    if(children.isEmpty)
+      throw new EngineConnPluginErrorException(20001, s"The dist of ${engineConnType}EngineConn is empty.")
+    else if(!children.exists(_.getName.startsWith("v"))) {
+      Array(engineConnDistHome)
+    } else if(children.forall(_.getName.startsWith("v"))) children.map(_.getPath)
+    else throw new EngineConnPluginErrorException(20001, s"The dist of ${engineConnType}EngineConn is irregular, both the version dir and non-version dir are exist.")
+  }
+
+  def getEngineConnTypeListFromDisk: Array[String] = new File(getEngineConnsHome).listFiles().map(_.getName)
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/localize/DefaultEngineConnBmlResourceGenerator.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/localize/DefaultEngineConnBmlResourceGenerator.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.localize
+
+import java.io.{File, FileInputStream, InputStream}
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils, ZipUtils}
+import com.webank.wedatasphere.linkis.engineplugin.server.localize.EngineConnBmlResourceGenerator.NO_VERSION_MARK
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnPluginErrorException
+
+
+class DefaultEngineConnBmlResourceGenerator extends AbstractEngineConnBmlResourceGenerator with Logging {
+
+  override def generate(engineConnType: String): Map[String, Array[EngineConnLocalizeResource]] =
+
+    getEngineConnDistHomeList(engineConnType).map { path =>
+      val distFile = new File(path)
+      val key = if(distFile.getName.startsWith("v")) distFile.getName else NO_VERSION_MARK
+      Utils.tryCatch {
+        key -> generateDir(path)
+      } {
+        case t: Throwable =>
+          error(s"Generate dir : $path error, msg : " + t.getMessage, t)
+          throw t
+      }
+    }.toMap
+
+  override def generate(engineConnType: String, version: String): Array[EngineConnLocalizeResource] = {
+    val path = getEngineConnDistHome(engineConnType, version)
+    generateDir(path)
+  }
+
+  private def generateDir(path: String): Array[EngineConnLocalizeResource] = {
+    val distFile = new File(path)
+    val validFiles = distFile.listFiles().filterNot(f => f.getName.endsWith(".zip") &&
+      new File(path, f.getName.replace(".zip", "")).exists)
+     validFiles.map { file =>
+      if(file.isFile)
+        EngineConnLocalizeResourceImpl(file.getPath, file.getName, file.lastModified(), file.length())
+          .asInstanceOf[EngineConnLocalizeResource]
+      else {
+        val newFile = new File(path, file.getName + ".zip")
+        if(newFile.exists() && !newFile.delete()) {
+          throw new EngineConnPluginErrorException(20001, s"System have no permission to delete old engineConn file $newFile.")
+        }
+        ZipUtils.fileToZip(file.getPath, path, file.getName + ".zip")
+        // 如果是文件夹，这里的最后更新时间，采用文件夹的最后更新时间，而不是ZIP的最后更新时间.
+        EngineConnLocalizeResourceImpl(newFile.getPath, newFile.getName, file.lastModified(), newFile.length())
+          .asInstanceOf[EngineConnLocalizeResource]
+      }
+    }
+  }
+}
+case class EngineConnLocalizeResourceImpl(filePath: String, fileName: String, lastModified: Long, fileSize: Long)
+  extends EngineConnLocalizeResource {
+  override def getFileInputStream: InputStream = new FileInputStream(filePath)
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/localize/EngineConnBmlResourceGenerator.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/localize/EngineConnBmlResourceGenerator.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.localize
+
+import java.io.InputStream
+
+
+trait EngineConnBmlResourceGenerator {
+
+  def getEngineConnTypeListFromDisk: Array[String]
+
+  def generate(engineConnType: String): Map[String, Array[EngineConnLocalizeResource]]
+
+  def generate(engineConnType: String, version: String): Array[EngineConnLocalizeResource]
+
+}
+
+object EngineConnBmlResourceGenerator {
+  val NO_VERSION_MARK = "_default_"
+}
+
+trait EngineConnLocalizeResource {
+
+  val fileName: String
+  val lastModified: Long
+  val fileSize: Long
+
+  def getFileInputStream: InputStream
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/DefaultEngineConnLaunchService.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/DefaultEngineConnLaunchService.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.service
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineplugin.server.loader.EngineConnPluginsLoader
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnPluginErrorException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.EngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, EngineConnLaunchRequest}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.{EngineConnResourceGenerator, JavaProcessEngineConnLaunchBuilder}
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+
+@Component
+class DefaultEngineConnLaunchService extends EngineConnLaunchService with Logging {
+
+  @Autowired
+  private var engineConnResourceGenerator: EngineConnResourceGenerator = _
+
+  private def getEngineLaunchBuilder(engineTypeLabel: EngineTypeLabel): EngineConnLaunchBuilder = {
+    val engineConnPluginInstance = EngineConnPluginsLoader.getEngineConnPluginsLoader().getEngineConnPlugin(engineTypeLabel)
+    val builder = engineConnPluginInstance.plugin.getEngineConnLaunchBuilder
+    builder match {
+      case javaProcessEngineConnLaunchBuilder: JavaProcessEngineConnLaunchBuilder =>
+        javaProcessEngineConnLaunchBuilder.setEngineConnResourceGenerator(engineConnResourceGenerator)
+    }
+    builder
+  }
+
+  @Receiver
+  override def createEngineConnLaunchRequest(engineBuildRequest: EngineConnBuildRequest): EngineConnLaunchRequest = {
+    val engineTypeOption = engineBuildRequest.labels.find(_.isInstanceOf[EngineTypeLabel])
+    if (engineTypeOption.isDefined) {
+      val engineTypeLabel = engineTypeOption.get.asInstanceOf[EngineTypeLabel]
+      getEngineLaunchBuilder(engineTypeLabel).buildEngineConn(engineBuildRequest)
+    } else {
+      throw new EngineConnPluginErrorException(10001, "EngineTypeLabel are requested")
+    }
+  }
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/DefaultEngineConnResourceFactoryService.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/DefaultEngineConnResourceFactoryService.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.service
+
+import com.webank.wedatasphere.linkis.engineplugin.server.loader.EngineConnPluginsLoader
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnPluginErrorException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.{EngineResourceFactory, EngineResourceRequest}
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+
+@Component
+class DefaultEngineConnResourceFactoryService extends EngineConnResourceFactoryService {
+
+  override def getResourceFactoryBy(engineType: EngineTypeLabel): EngineResourceFactory = {
+    val engineConnPluginInstance = EngineConnPluginsLoader.getEngineConnPluginsLoader().getEngineConnPlugin(engineType)
+    engineConnPluginInstance.plugin.getEngineResourceFactory
+  }
+
+  @Receiver
+  override def createEngineResource(engineResourceRequest: EngineResourceRequest): NodeResource = {
+    val engineTypeOption = engineResourceRequest.labels.find(_.isInstanceOf[EngineTypeLabel])
+
+    if (engineTypeOption.isDefined) {
+      val engineTypeLabel = engineTypeOption.get.asInstanceOf[EngineTypeLabel]
+      getResourceFactoryBy(engineTypeLabel).createEngineResource(engineResourceRequest)
+    } else {
+      throw new EngineConnPluginErrorException(10001, "EngineTypeLabel are requested")
+    }
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/DefaultEngineConnResourceService.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/DefaultEngineConnResourceService.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.service
+
+import java.util.Date
+
+import com.webank.wedatasphere.linkis.bml.client.BmlClientFactory
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.engineplugin.server.conf.EngineConnPluginConfiguration
+import com.webank.wedatasphere.linkis.engineplugin.server.dao.EngineConnBmlResourceDao
+import com.webank.wedatasphere.linkis.engineplugin.server.entity.EngineConnBmlResource
+import com.webank.wedatasphere.linkis.engineplugin.server.localize.{EngineConnBmlResourceGenerator, EngineConnLocalizeResource}
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource
+import com.webank.wedatasphere.linkis.manager.common.protocol.bml.BmlResource.BmlResourceVisibility
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.exception.EngineConnPluginErrorException
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.{EngineConnResource, LaunchConstants}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import javax.annotation.PostConstruct
+import org.apache.commons.lang.StringUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+
+@Component
+class DefaultEngineConnResourceService extends EngineConnResourceService with Logging {
+
+  @Autowired
+  private var engineConnBmlResourceGenerator: EngineConnBmlResourceGenerator = _
+  @Autowired
+  private var engineConnBmlResourceDao: EngineConnBmlResourceDao = _
+  private val bmlClient = BmlClientFactory.createBmlClient()
+  private var isRefreshing: Boolean = false
+
+  @PostConstruct
+  override def init(): Unit = if (EngineConnPluginConfiguration.ENGINE_CONN_DIST_LOAD_ENABLE.getValue) {
+    info("Start to refresh all engineconn plugins when inited.")
+    refreshAll(false)
+  }
+
+
+  private def uploadToBml(localizeResource: EngineConnLocalizeResource): BmlResource = {
+    val response = bmlClient.uploadResource(Utils.getJvmUser, localizeResource.fileName, localizeResource.getFileInputStream)
+    val bmlResource = new BmlResource
+    bmlResource.setResourceId(response.resourceId)
+    bmlResource.setVersion(response.version)
+    bmlResource
+  }
+
+  private def uploadToBml(localizeResource: EngineConnLocalizeResource, resourceId: String): BmlResource = {
+    val response = bmlClient.updateResource(Utils.getJvmUser, resourceId, localizeResource.fileName, localizeResource.getFileInputStream)
+    val bmlResource = new BmlResource
+    bmlResource.setResourceId(response.resourceId)
+    bmlResource.setVersion(response.version)
+    bmlResource
+  }
+
+  override def refreshAll(wait: Boolean = false): Unit = {
+    if (!isRefreshing) {
+      synchronized {
+        if (!isRefreshing) {
+          val refreshTask = new Runnable {
+            override def run(): Unit = {
+              isRefreshing = true
+              info(s"Try to initialize the dist resources of all EngineConns.")
+              engineConnBmlResourceGenerator.getEngineConnTypeListFromDisk foreach { engineConnType =>
+                Utils.tryAndError {
+                  info(s"Try to initialize all versions of ${engineConnType}EngineConn.")
+                  engineConnBmlResourceGenerator.generate(engineConnType).foreach { case (version, localize) =>
+                    info(s"Try to initialize ${engineConnType}EngineConn-$version.")
+                    refresh(localize, engineConnType, version)
+                  }
+                }
+              }
+              isRefreshing = false
+            }
+          }
+          val future = Utils.defaultScheduler.submit(refreshTask)
+          if (wait) {
+            Utils.tryAndWarn(future.get())
+          }
+        } else {
+          info ("IsRefreshing EngineConns...")
+        }
+      }
+    }
+  }
+
+  @Receiver
+  def refeshAll(engineConnRefreshAllRequest: RefreshAllEngineConnResourceRequest): Boolean = {
+    info("Start to refresh all engineconn plugins.")
+    refreshAll(true)
+    true
+  }
+
+  @Receiver
+  override def refresh(engineConnRefreshRequest: RefreshEngineConnResourceRequest): Boolean = {
+    val engineConnType = engineConnRefreshRequest.getEngineConnType
+    val version = engineConnRefreshRequest.getVersion
+    if ("*" == version || StringUtils.isEmpty(version)) {
+      info(s"Try to refresh all versions of ${engineConnType}EngineConn.")
+      engineConnBmlResourceGenerator.generate(engineConnType).foreach { case (v, localize) =>
+        info(s"Try to refresh ${engineConnType}EngineConn-$v.")
+        refresh(localize, engineConnType, v)
+      }
+    } else {
+      info(s"Try to refresh ${engineConnType}EngineConn-$version.")
+      val localize = engineConnBmlResourceGenerator.generate(engineConnType, version)
+      refresh(localize, engineConnType, version)
+    }
+    true
+  }
+
+  private def refresh(localize: Array[EngineConnLocalizeResource], engineConnType: String, version: String): Unit = {
+    val engineConnBmlResources = asScalaBuffer(engineConnBmlResourceDao.getAllEngineConnBmlResource(engineConnType, version))
+    if(localize.count(localizeResource => localizeResource.fileName == LaunchConstants.ENGINE_CONN_CONF_DIR_NAME + ".zip" ||
+      localizeResource.fileName == LaunchConstants.ENGINE_CONN_LIB_DIR_NAME + ".zip") < 2)
+      throw new EngineConnPluginErrorException(20001, s"The `lib` and `conf` dir is necessary in ${engineConnType}EngineConn dist.")
+    localize.foreach { localizeResource =>
+      val resource = engineConnBmlResources.find(_.getFileName == localizeResource.fileName)
+      if(resource.isEmpty) {
+        info(s"Ready to upload a new bmlResource for ${engineConnType}EngineConn-$version. path: " + localizeResource.fileName)
+        val bmlResource = uploadToBml(localizeResource)
+        val engineConnBmlResource = new EngineConnBmlResource
+        engineConnBmlResource.setBmlResourceId(bmlResource.getResourceId)
+        engineConnBmlResource.setBmlResourceVersion(bmlResource.getVersion)
+        engineConnBmlResource.setCreateTime(new Date)
+        engineConnBmlResource.setLastUpdateTime(new Date)
+        engineConnBmlResource.setEngineConnType(engineConnType)
+        engineConnBmlResource.setFileName(localizeResource.fileName)
+        engineConnBmlResource.setFileSize(localizeResource.fileSize)
+        engineConnBmlResource.setLastModified(localizeResource.lastModified)
+        engineConnBmlResource.setVersion(version)
+        engineConnBmlResourceDao.save(engineConnBmlResource)
+      } else if(resource.exists(r => r.getFileSize != localizeResource.fileSize || r.getLastModified != localizeResource.lastModified)) {
+        info(s"Ready to upload a refreshed bmlResource for ${engineConnType}EngineConn-$version. path: " + localizeResource.fileName)
+        val engineConnBmlResource = resource.get
+        val bmlResource = uploadToBml(localizeResource, engineConnBmlResource.getBmlResourceId)
+        engineConnBmlResource.setBmlResourceVersion(bmlResource.getVersion)
+        engineConnBmlResource.setLastUpdateTime(new Date)
+        engineConnBmlResource.setFileSize(localizeResource.fileSize)
+        engineConnBmlResource.setLastModified(localizeResource.lastModified)
+        engineConnBmlResourceDao.update(engineConnBmlResource)
+      } else info(s"The file has no change in ${engineConnType}EngineConn-$version, path: " + localizeResource.fileName)
+    }
+  }
+
+  @Receiver
+  override def getEngineConnBMLResources(engineConnBMLResourceRequest: GetEngineConnResourceRequest): EngineConnResource = {
+    val engineConnType = engineConnBMLResourceRequest.getEngineConnType
+    val version = engineConnBMLResourceRequest.getVersion
+    val engineConnBmlResources = asScalaBuffer(engineConnBmlResourceDao.getAllEngineConnBmlResource(engineConnType, "v" + version))
+    val confBmlResource = engineConnBmlResources.find(_.getFileName == LaunchConstants.ENGINE_CONN_CONF_DIR_NAME + ".zip").map(parseToBmlResource).get
+    val libBmlResource = engineConnBmlResources.find(_.getFileName == LaunchConstants.ENGINE_CONN_LIB_DIR_NAME + ".zip").map(parseToBmlResource).get
+    val otherBmlResources = engineConnBmlResources.filterNot(r => r.getFileName == LaunchConstants.ENGINE_CONN_CONF_DIR_NAME + ".zip" ||
+      r.getFileName == LaunchConstants.ENGINE_CONN_LIB_DIR_NAME + ".zip").map(parseToBmlResource).toArray
+    new EngineConnResource {
+      override def getConfBmlResource: BmlResource = confBmlResource
+
+      override def getLibBmlResource: BmlResource = libBmlResource
+
+      override def getOtherBmlResources: Array[BmlResource] = otherBmlResources
+    }
+  }
+
+  private def parseToBmlResource(engineConnBmlResource: EngineConnBmlResource): BmlResource = {
+    val bmlResource = new BmlResource
+    bmlResource.setFileName(engineConnBmlResource.getFileName)
+    bmlResource.setOwner(Utils.getJvmUser)
+    bmlResource.setResourceId(engineConnBmlResource.getBmlResourceId)
+    bmlResource.setVersion(engineConnBmlResource.getBmlResourceVersion)
+    bmlResource.setVisibility(BmlResourceVisibility.Public)
+    bmlResource
+  }
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/EngineConnLaunchService.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/EngineConnLaunchService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.service
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequest, EngineConnLaunchRequest}
+
+
+trait EngineConnLaunchService {
+
+
+  def createEngineConnLaunchRequest(engineBuildRequest: EngineConnBuildRequest): EngineConnLaunchRequest
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/EngineConnResourceFactoryService.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/EngineConnResourceFactoryService.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.service
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.{EngineResourceFactory, EngineResourceRequest}
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+
+
+trait EngineConnResourceFactoryService {
+
+  def getResourceFactoryBy(engineType: EngineTypeLabel): EngineResourceFactory
+
+  def createEngineResource(engineResourceRequest: EngineResourceRequest): NodeResource
+
+}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/EngineConnResourceService.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/server/service/EngineConnResourceService.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineplugin.server.service
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.{EngineConnResource, EngineConnResourceGenerator}
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+import com.webank.wedatasphere.linkis.protocol.message.{RequestMethod, RequestProtocol}
+
+
+abstract class EngineConnResourceService extends EngineConnResourceGenerator {
+
+  def init(): Unit
+
+  def refreshAll(wait: Boolean): Unit
+
+  def refresh(engineConnRefreshRequest: RefreshEngineConnResourceRequest): Boolean
+
+  def getEngineConnBMLResources(engineConnBMLResourceRequest: GetEngineConnResourceRequest): EngineConnResource
+
+  override def getEngineConnBMLResources(engineTypeLabel: EngineTypeLabel): EngineConnResource = {
+    val engineConnBMLResourceRequest = new GetEngineConnResourceRequest
+    engineConnBMLResourceRequest.setEngineConnType(engineTypeLabel.getEngineType)
+    engineConnBMLResourceRequest.setVersion(engineTypeLabel.getVersion)
+    getEngineConnBMLResources(engineConnBMLResourceRequest)
+  }
+
+}
+
+abstract class EngineConnResourceRequest extends RequestProtocol with RequestMethod {
+
+  private var engineConnType: String = _
+  private var version: String = _
+
+  def getEngineConnType: String = engineConnType
+
+  def setEngineConnType(engineConnType: String): Unit = this.engineConnType = engineConnType
+
+  def getVersion: String = version
+
+  def setVersion(version: String): Unit = this.version = version
+}
+
+class RefreshEngineConnResourceRequest extends EngineConnResourceRequest {
+  override def method(): String = "/enginePlugin/engineConn/refresh"
+}
+
+class GetEngineConnResourceRequest extends EngineConnResourceRequest {
+  override def method(): String = "/enginePlugin/engineConn/getResource"
+}
+
+class RefreshAllEngineConnResourceRequest extends RequestProtocol with RequestMethod {
+  override def method(): String = "/enginePlugin/engineConn/refreshAll"
+}

--- a/linkis-engineconn-plugins/pom.xml
+++ b/linkis-engineconn-plugins/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineconn-plugins</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core</module>
+        <module>linkis-engineconn-plugin-framework/linkis-engineconn-plugin-cache</module>
+        <module>linkis-engineconn-plugin-framework/linkis-engineconn-plugin-loader</module>
+        <module>linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server</module>
+
+        <module>engineconn-plugins/hive</module>
+        <module>engineconn-plugins/spark</module>
+        <module>engineconn-plugins/python</module>
+
+        <module>engineconn-plugins/io_file</module>
+        <module>engineconn-plugins/shell</module>
+        <module>engineconn-plugins/pipeline</module>
+        <module>engineconn-plugins/jdbc</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
### What is the purpose of the change
Related issues: #576
Add a new module EngineConnPlugin for the Linkis1.0 architecture. This module is defined to simplify the user's implementation of a new Linkis underlying computation storage engine.

### Brief change log

1. A separate service that provides interfaces for LinkisManager to  obtain the resources when creating an EngineConn.

2. Provides interfaces for EngineConnManager to prepare the start-up argument information of EngineConn after ECM receives the EngineConnBuilder's requests from LinkisManager.

3. Be able to load the dependency jars required by the computation storage engine in real time, so those engines, which have been integreted to Linkis don't need to be pre-installed in EngineConnManager machines.

4. Be able to load the corresponding EngineConnPlugin on demand.