### PR TITLE
Add the EngineConn management plug-in in the Entrance module 

### DIFF
--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/pom.xml
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis-orchestrator</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-orchestrator-ecm-plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.webank.wedatasphere.linkis</groupId>
+                    <artifactId>linkis-rpc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-core</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-rpc</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-scheduler</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.yml</exclude>
+                        <exclude>**/*.properties</exclude>
+                        <exclude>**/*.sh</exclude>
+                        <exclude>log4j2-spring.xml</exclude>
+                        <exclude>${basedir}/src/test/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/java/com/webank/wedatasphere/linkis/orchestrator/ecm/entity/Policy.java
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/java/com/webank/wedatasphere/linkis/orchestrator/ecm/entity/Policy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.entity;
+
+
+public enum Policy {
+
+    Process, JobGroup, Job, Task;
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/ComputationEngineConnManager.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/ComputationEngineConnManager.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm
+
+import java.util
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineAskAsyncResponse, EngineAskRequest, EngineCreateError, EngineCreateSuccess}
+import com.webank.wedatasphere.linkis.manager.label.constant.LabelKeyConstant
+import com.webank.wedatasphere.linkis.orchestrator.ecm.cache.EngineAsyncResponseCache
+import com.webank.wedatasphere.linkis.orchestrator.ecm.conf.ECMPluginConf
+import com.webank.wedatasphere.linkis.orchestrator.ecm.entity.{DefaultMark, Mark, MarkReq, Policy}
+import com.webank.wedatasphere.linkis.orchestrator.ecm.exception.ECMPluginErrorException
+import com.webank.wedatasphere.linkis.orchestrator.ecm.service.EngineConnExecutor
+import com.webank.wedatasphere.linkis.orchestrator.ecm.service.impl.{ComputationConcurrentEngineConnExecutor, ComputationEngineConnExecutor}
+import com.webank.wedatasphere.linkis.rpc.Sender
+import com.webank.wedatasphere.linkis.rpc.exception.DWCRPCRetryException
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration.Duration
+
+
+class ComputationEngineConnManager extends AbstractEngineConnManager with Logging {
+
+  private val idCreator = new AtomicInteger()
+
+  private val cacheMap = EngineAsyncResponseCache.getCache
+
+  override def getPolicy(): Policy = Policy.Process
+
+  /**
+    * 申请获取一个Mark
+    * 1. 如果没有对应的Mark就生成新的
+    * 2. 生成新的Mark会存在请求引擎的过程，如果请求到了则存入Map中：Mark为Key，EngineConnExecutor为Value
+    * 3. 将Mark进行返回
+    *
+    * @param markReq
+    * @return
+    */
+  override def applyMark(markReq: MarkReq): Mark = {
+    if (null == markReq) return null
+    val markCache = getMarkCache().keys
+    val maybeMark = markCache.find(_.getMarkReq.equals(markReq))
+    maybeMark.getOrElse {
+      val mark = new DefaultMark(nextMarkId(), markReq)
+      addMark(mark, new util.ArrayList[ServiceInstance]())
+      mark
+    }
+  }
+
+
+  private def nextMarkId(): String = {
+    "mark_" + idCreator.getAndIncrement()
+  }
+
+  override protected def askEngineConnExecutor(engineAskRequest: EngineAskRequest): EngineConnExecutor = {
+    engineAskRequest.setTimeOut(getEngineConnApplyTime)
+    var count = getEngineConnApplyAttempts()
+    while (count >= 1) {
+      count = count - 1
+      val start = System.currentTimeMillis()
+      try {
+        val engineNode = getEngineNodeAskManager(engineAskRequest)
+        if (null != engineNode) {
+          val engineConnExecutor = if (null != engineAskRequest.getLabels &&
+            engineAskRequest.getLabels.containsKey(LabelKeyConstant.CONCURRENT_ENGINE_KEY)) {
+            new ComputationConcurrentEngineConnExecutor(engineNode, getParallelism())
+          } else {
+            new ComputationEngineConnExecutor(engineNode)
+          }
+          if (null != engineNode.getLabels) {
+            engineConnExecutor.setLabels(engineNode.getLabels.toList.toArray)
+          }
+          return engineConnExecutor
+        }
+      } catch {
+        case t: DWCRPCRetryException =>
+          count = count - 1
+          val taken = System.currentTimeMillis() - start
+          error(s"Failed to askEngineAskRequest time taken ($taken), with DWCRPCRetryException", t)
+        case t: Throwable =>
+          count = count - 1
+          val taken = System.currentTimeMillis() - start
+          error(s"Failed to askEngineAskRequest time taken ($taken), ${t.getMessage}")
+          throw t
+      }
+    }
+    throw new ECMPluginErrorException(ECMPluginConf.ECM_ERROR_CODE,
+      s"Failed to ask engineAskRequest $engineAskRequest by retry ${getEngineConnApplyAttempts - count}  ")
+  }
+
+  private def getEngineNodeAskManager(engineAskRequest: EngineAskRequest): EngineNode = {
+    getManagerSender().ask(engineAskRequest) match {
+      case engineNode: EngineNode =>
+        info(s"Succeed to get engineNode $engineNode")
+        engineNode
+      case EngineAskAsyncResponse(id, serviceInstance) =>
+        cacheMap.getAndRemove(id, Duration(getEngineConnApplyTime, TimeUnit.MILLISECONDS)) match {
+          case EngineCreateSuccess(id, engineNode) =>
+            info(s"id:$id success to async get EngineNode $engineNode")
+            engineNode
+          case EngineCreateError(id, exception) =>
+            error(s"id:$id Failed  to async get EngineNode")
+            throw new ECMPluginErrorException(ECMPluginConf.ECM_ENGNE_CREATION_ERROR_CODE, exception)
+        }
+      case _ =>
+        info(s"Failed to ask engineAskRequest $engineAskRequest, response is not engineNode")
+        null
+    }
+  }
+
+  private def getManagerSender(): Sender = {
+    Sender.getSender(GovernanceCommonConf.MANAGER_SPRING_NAME.getValue)
+  }
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/EngineConnManager.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/EngineConnManager.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineAskRequest
+import com.webank.wedatasphere.linkis.orchestrator.ecm.conf.ECMPluginConf
+import com.webank.wedatasphere.linkis.orchestrator.ecm.entity.{Mark, MarkReq, Policy}
+import com.webank.wedatasphere.linkis.orchestrator.ecm.exception.ECMPluginErrorException
+import com.webank.wedatasphere.linkis.orchestrator.ecm.service.EngineConnExecutor
+
+import scala.collection.JavaConversions._
+
+
+trait EngineConnManager {
+
+  /**
+    * 申请获取一个Mark
+    * 1. 如果没有对应的Mark就生成新的
+    * 2. 生成新的Mark会存在请求引擎的过程，如果请求到了则存入Map中：Mark为Key，EngineConnExecutor为Value
+    * 3. 将Mark进行返回
+    *
+    * @param markReq
+    * @return
+    */
+  def applyMark(markReq: MarkReq): Mark
+
+
+  /**
+    * 通过Mark向缓存中获取一个可用的EngineConnExecutor
+    *
+    * @param mark
+    * @return
+    */
+  def getAvailableEngineConnExecutor(mark: Mark): EngineConnExecutor
+
+
+  /**
+    * 移除和该Mark相关的engineConn
+    * 释放锁等信息
+    *
+    * @param mark
+    */
+  def releaseMark(mark: Mark): Unit
+
+  def releaseEngineConnExecutor(engineConnExecutor: EngineConnExecutor, mark: Mark): Unit
+
+  def getEngineConnExecutorCache(): util.Map[ServiceInstance, EngineConnExecutor]
+
+  protected def getMarkCache(): util.Map[Mark, util.List[ServiceInstance]]
+
+  def getPolicy(): Policy
+
+  def setParallelism(parallelism: Int): Unit
+
+  def getParallelism(): Int
+
+  def setEngineConnApplyTime(applyTime: Long): Unit
+
+  def getEngineConnApplyTime: Long
+
+  def setEngineConnApplyAttempts(attemptNumber: Int): Unit
+
+  def getEngineConnApplyAttempts(): Int
+
+}
+
+abstract class AbstractEngineConnManager extends EngineConnManager with Logging {
+
+  private var parallelism: Int = _
+
+  private var timeOut: Long = _
+
+  private var attemptNumber: Int = _
+
+  private val engineConnExecutorCache = new util.HashMap[ServiceInstance, EngineConnExecutor]()
+
+  private val markCache = new util.HashMap[Mark, util.List[ServiceInstance]]()
+
+  private val MARK_CACHE_LOCKER = new Object()
+
+  override def setEngineConnApplyAttempts(attemptNumber: Int): Unit = this.attemptNumber = attemptNumber
+
+  override def getEngineConnApplyAttempts(): Int = this.attemptNumber
+
+  override def getParallelism(): Int = this.parallelism
+
+  override def setParallelism(parallelism: Int): Unit = this.parallelism = parallelism
+
+  override def getEngineConnApplyTime: Long = this.timeOut
+
+  override def setEngineConnApplyTime(applyTime: Long): Unit = this.timeOut = applyTime
+
+  override def getEngineConnExecutorCache(): util.Map[ServiceInstance, EngineConnExecutor] = engineConnExecutorCache
+
+  override def getMarkCache(): util.Map[Mark, util.List[ServiceInstance]] = markCache
+
+  override def getAvailableEngineConnExecutor(mark: Mark): EngineConnExecutor = {
+    info(s"mark ${mark.getMarkId()} start to  getAvailableEngineConnExecutor")
+    if (null != mark && getMarkCache().containsKey(mark)) {
+      val instances = getInstances(mark)
+      if (null != instances) {
+        val executors = Utils.tryAndWarn {
+          instances.map(getEngineConnExecutorCache().get(_)).filter(null != _).sortBy { executor =>
+            if (null == executor.getRunningTaskCount) {
+              0
+            } else {
+              executor.getRunningTaskCount
+            }
+          }
+        }
+        if (null != executors && executors.nonEmpty) {
+          for (executor <- executors) {
+            if (executor.useEngineConn) {
+              info(s"mark ${mark.getMarkId()} Finished to   getAvailableEngineConnExecutor by reuse")
+              return executor
+            }
+          }
+        }
+      }
+
+      val engineConnExecutor = askEngineConnExecutor(mark.getMarkReq.createEngineConnAskReq())
+      engineConnExecutor.useEngineConn
+      getEngineConnExecutorCache().put(engineConnExecutor.getServiceInstance, engineConnExecutor)
+      if (null == getInstances(mark)) {
+        addMark(mark, new util.ArrayList[ServiceInstance]())
+      }
+      getMarkCache().get(mark).add(engineConnExecutor.getServiceInstance)
+      info(s"mark ${mark.getMarkId()} Finished to  getAvailableEngineConnExecutor by create")
+      engineConnExecutor
+    } else {
+      throw new ECMPluginErrorException(ECMPluginConf.ECM_ERROR_CODE, " mark cannot null")
+    }
+  }
+
+  protected def addMark(mark: Mark, instances: util.List[ServiceInstance]): Unit = MARK_CACHE_LOCKER.synchronized {
+    if (null != mark && !getMarkCache().containsKey(mark)) {
+      getMarkCache().put(mark, instances)
+    }
+  }
+
+  protected def getInstances(mark: Mark): util.List[ServiceInstance] = MARK_CACHE_LOCKER.synchronized {
+    if (null != mark && getMarkCache().containsKey(mark)) {
+      getMarkCache().get(mark)
+    } else {
+      null
+    }
+  }
+
+  override def releaseEngineConnExecutor(engineConnExecutor: EngineConnExecutor, mark: Mark): Unit = {
+    if (null != engineConnExecutor && null != mark && getMarkCache().containsKey(mark)) {
+      info(s"Start to release EngineConnExecutor mark id ${mark.getMarkId()} engineConnExecutor ${engineConnExecutor.getServiceInstance}")
+      getEngineConnExecutorCache().remove(engineConnExecutor.getServiceInstance)
+      engineConnExecutor.close()
+      val instances = getInstances(mark)
+      if (null != instances) {
+        instances.remove(engineConnExecutor.getServiceInstance)
+        if (instances.isEmpty) releaseMark(mark)
+      }
+    }
+  }
+
+  protected def askEngineConnExecutor(engineAskRequest: EngineAskRequest): EngineConnExecutor
+
+  override def releaseMark(mark: Mark): Unit = {
+    if (null != mark && getMarkCache().containsKey(mark)) {
+      info(s"Start to release mark ${mark.getMarkId()}")
+      val executors = getMarkCache().get(mark).map(getEngineConnExecutorCache().get(_))
+      Utils.tryAndError(executors.foreach { executor =>
+        getEngineConnExecutorCache().remove(executor.getServiceInstance)
+        executor.close()
+      })
+      removeMark(mark)
+      info(s"Finished to release mark ${mark.getMarkId()}")
+    }
+  }
+
+  protected def removeMark(mark: Mark): Unit = MARK_CACHE_LOCKER.synchronized {
+    if (null != mark && getMarkCache().containsKey(mark)) {
+      getMarkCache().remove(mark)
+    }
+  }
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/EngineConnManagerBuilder.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/EngineConnManagerBuilder.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.orchestrator.ecm.conf.ECMPluginConf
+import com.webank.wedatasphere.linkis.orchestrator.ecm.entity.Policy
+import org.reflections.Reflections
+
+
+trait EngineConnManagerBuilder {
+
+  def setPolicy(policy: Policy): EngineConnManagerBuilder
+
+  def setParallelism(parallelism: Int): EngineConnManagerBuilder
+
+  def setMarkApplyTime(applyTime: Long): EngineConnManagerBuilder
+
+  def setMarkApplyAttempts(attemptNumber: Int): EngineConnManagerBuilder
+
+  def build(): EngineConnManager
+
+}
+
+class DefaultEngineConnManagerBuilder extends EngineConnManagerBuilder with Logging {
+
+
+  private var policy: Policy = _
+
+  private var parallelism: Int = ECMPluginConf.ECM_ENGINE_PARALLELISM.getValue
+
+  private var applyTime: Long = ECMPluginConf.ECM_MARK_APPLY_TIME.getValue.toLong
+
+  private var attemptNumber: Int = ECMPluginConf.ECM_MARK_ATTEMPTS.getValue
+
+
+  override def setPolicy(policy: Policy): EngineConnManagerBuilder = {
+    this.policy = policy
+    this
+  }
+
+  override def setParallelism(parallelism: Int): EngineConnManagerBuilder = {
+    this.parallelism = parallelism
+    this
+  }
+
+  override def setMarkApplyTime(applyTime: Long): EngineConnManagerBuilder = {
+    this.applyTime = applyTime
+    this
+  }
+
+  override def setMarkApplyAttempts(attemptNumber: Int): EngineConnManagerBuilder = {
+    this.attemptNumber = attemptNumber
+    this
+  }
+
+  override def build(): EngineConnManager = {
+    if (null == policy) this.policy = Policy.Process
+    val engineManagerClazz = EngineConnManagerBuilder.getEngineManagerClazzByPolicy(this.policy)
+    val manager = engineManagerClazz.newInstance()
+    manager.setEngineConnApplyAttempts(this.attemptNumber)
+    manager.setEngineConnApplyTime(applyTime)
+    manager.setParallelism(parallelism)
+    manager
+  }
+
+
+}
+
+object EngineConnManagerBuilder extends Logging {
+
+  private val engineConnManagerClazzCache = new util.HashMap[String, Class[_ <: EngineConnManager]]()
+
+  private def init(): Unit = {
+
+    val reflections = new Reflections("com.webank.wedatasphere.linkis.orchestrator", classOf[EngineConnManagerBuilder].getClassLoader);
+
+    val allSubClass = reflections.getSubTypesOf(classOf[EngineConnManager])
+
+    if (null != allSubClass) {
+      val iterator = allSubClass.iterator()
+      while (iterator.hasNext) {
+        val clazz = iterator.next()
+        Utils.tryCatch {
+          val manager = clazz.newInstance()
+          if (engineConnManagerClazzCache.containsKey(manager.getPolicy().name())) {
+            throw new RuntimeException(s"EngineConnManager Type cannot be duplicated ${manager.getPolicy()} ")
+          }
+          engineConnManagerClazzCache.put(manager.getPolicy().name(), clazz)
+        } { t: Throwable =>
+          warn(s"Failed to Instantiation: ${clazz.getName}, reason ${t.getMessage}")
+          null
+        }
+      }
+    }
+
+  }
+
+  init()
+
+  def getEngineManagerClazzByPolicy(policy: Policy): Class[_ <: EngineConnManager] = {
+    engineConnManagerClazzCache.get(policy.name())
+  }
+
+  def builder: EngineConnManagerBuilder = new DefaultEngineConnManagerBuilder
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/cache/EngineAsyncResponseCache.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/cache/EngineAsyncResponseCache.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.cache
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineAsyncResponse, EngineCreateError}
+import com.webank.wedatasphere.linkis.orchestrator.ecm.conf.ECMPluginConf
+import com.webank.wedatasphere.linkis.orchestrator.ecm.exception.ECMPluginCacheException
+import org.apache.commons.lang.exception.ExceptionUtils
+
+import scala.concurrent.duration.Duration
+
+
+trait EngineAsyncResponseCache {
+
+  @throws[ECMPluginCacheException]
+  def put(id: String, engineAsyncResponse: EngineAsyncResponse): Unit
+
+  def get(id: String, timeout: Duration): EngineAsyncResponse
+
+  def getAndRemove(id: String, timeout: Duration): EngineAsyncResponse
+
+}
+
+
+object EngineAsyncResponseCache {
+
+  private val engineAsyncResponseCache: EngineAsyncResponseCache = new EngineAsyncResponseCacheMap
+
+  def getCache: EngineAsyncResponseCache = engineAsyncResponseCache
+
+}
+
+class EngineAsyncResponseCacheMap extends EngineAsyncResponseCache {
+
+  private val cacheMap: java.util.Map[String, EngineAsyncResponse] = new java.util.concurrent.ConcurrentHashMap[String, EngineAsyncResponse]()
+
+  override def get(id: String, timeout: Duration): EngineAsyncResponse = {
+    Utils.waitUntil(() => cacheMap.containsKey(id), timeout)
+    cacheMap.get(id)
+  }
+
+  override def getAndRemove(id: String, timeout: Duration): EngineAsyncResponse = {
+    try {
+      Utils.waitUntil(() => cacheMap.containsKey(id), timeout)
+    } catch {
+      case t: Throwable =>
+        put(id, EngineCreateError(id, ExceptionUtils.getRootCauseStackTrace(t).mkString("\n")))
+        throw t
+    }
+    cacheMap.remove(id)
+  }
+
+  @throws[ECMPluginCacheException]
+  override def put(id: String, engineAsyncResponse: EngineAsyncResponse): Unit = {
+    if (cacheMap.containsKey(id)) {
+      cacheMap.remove(id)
+      throw new ECMPluginCacheException(ECMPluginConf.ECM_CACHE_ERROR_CODE, "id duplicate")
+    }
+    cacheMap.put(id, engineAsyncResponse)
+  }
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/conf/ECMPluginConf.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/conf/ECMPluginConf.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+
+
+object ECMPluginConf {
+
+  val ECM_ENGINE_PARALLELISM = CommonVars("wds.linkis.orchestrator.ecm.engine.parallelism", 1)
+
+  val ECM_MARK_ATTEMPTS = CommonVars("wds.linkis.orchestrator.ecm.mark.apply.attempts", 2)
+
+  val ECM_MARK_APPLY_TIME = CommonVars("wds.linkis.orchestrator.ecm.mark.apply.time", new TimeType("5m"))
+
+  val ECM_ERROR_CODE = 12001
+
+  val ECM_CACHE_ERROR_CODE = 12002
+
+  val ECM_ENGNE_CREATION_ERROR_CODE = 12003
+
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/entity/Mark.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/entity/Mark.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.entity
+
+
+trait Mark {
+
+  def getMarkId(): String
+
+
+  def getMarkReq: MarkReq
+
+}
+
+class DefaultMark(markId: String, markReq: MarkReq) extends Mark {
+
+  override def getMarkId(): String = markId
+
+  override def getMarkReq: MarkReq = markReq
+
+  override def hashCode(): Int = markId.hashCode
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: Mark => other.getMarkId().equals(markId)
+    case _ => false
+  }
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/entity/MarkReq.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/entity/MarkReq.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.entity
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineAskRequest
+
+import scala.beans.BeanProperty
+import scala.collection.JavaConversions._
+
+
+
+trait MarkReq {
+
+
+  def createEngineConnAskReq(): EngineAskRequest
+
+  def getPolicyObj(): Policy
+
+  def setPolicyObj(policy: Policy): Unit
+
+
+  /**
+    * 只包含StartUp参数
+    */
+  @BeanProperty
+  var properties: util.Map[String, String] = null
+
+  /**
+    * 启动engineConn必要Label
+    */
+  @BeanProperty
+  var labels: util.Map[String, AnyRef] = null
+
+  /**
+    * executeUser
+    */
+  @BeanProperty
+  var user: String = null
+
+  /**
+    * 启动的服务：如linkis-entrance
+    */
+  @BeanProperty
+  var createService: String = null
+
+  @BeanProperty
+  var description: String = null
+
+  @BeanProperty
+  var engineConnCount: Int = _
+
+}
+
+class DefaultMarkReq extends MarkReq {
+
+  private var policy: Policy = _
+
+  override def createEngineConnAskReq(): EngineAskRequest = {
+    val engineAskRequest = new EngineAskRequest
+    engineAskRequest.setCreateService(getCreateService)
+    engineAskRequest.setDescription(getDescription)
+    engineAskRequest.setLabels(getLabels)
+    engineAskRequest.setProperties(getProperties)
+    engineAskRequest.setUser(getUser)
+    engineAskRequest
+  }
+
+  override def getPolicyObj(): Policy = this.policy
+
+  override def setPolicyObj(policy: Policy): Unit = this.policy = policy
+
+  override def equals(obj: Any): Boolean = {
+    var flag = false
+    if (null != obj && obj.isInstanceOf[MarkReq]) {
+      val other = obj.asInstanceOf[MarkReq]
+
+      if (other.getUser != getUser) {
+        return flag
+      }
+
+     /* if (other.getProperties != null && getProperties != null) {
+        val iterator = other.getProperties.iterator
+        while (iterator.hasNext) {
+          val next = iterator.next()
+          if (!next._2.equalsIgnoreCase(getProperties.get(next._1))) {
+            return flag
+          }
+        }
+      }*/
+      if (other.getLabels != null && getLabels != null) {
+        val iterator = other.getLabels.iterator
+        while (iterator.hasNext) {
+          val next = iterator.next()
+          if (null == next._2 || !next._2.equals(getLabels.get(next._1))) {
+            return false
+          }
+        }
+      }
+      flag = true
+    }
+    flag
+  }
+
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/exception/ECMPluginErrorException.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/exception/ECMPluginErrorException.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+
+
+class ECMPluginErrorException(errorCode: Int, errorMsg: String) extends ErrorException(errorCode, errorMsg) {
+
+  def this(errorCode: Int, errorMsg: String, t: Throwable) = {
+    this(errorCode, errorMsg)
+    initCause(t)
+  }
+
+}
+
+class ECMPluginCacheException(errorCode: Int, errorMsg: String) extends ECMPluginErrorException(errorCode, errorMsg) {
+
+  def this(errorCode: Int, errorMsg: String, t: Throwable) = {
+    this(errorCode, errorMsg)
+    initCause(t)
+  }
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/EngineAsyncResponseService.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/EngineAsyncResponseService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.service
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineCreateError, EngineCreateSuccess}
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+
+
+trait EngineAsyncResponseService {
+
+  def onSuccess(engineCreateSuccess: EngineCreateSuccess, smc: ServiceMethodContext): Unit
+
+  def onError(engineCreateError: EngineCreateError, smc: ServiceMethodContext): Unit
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/EngineConnExecutor.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/EngineConnExecutor.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.service
+
+import java.io.Closeable
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.governance.common.entity.ExecutionNodeStatus
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.RequestTask
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.scheduler.executer.ExecuteResponse
+
+
+trait EngineConnExecutor extends Closeable {
+
+  //
+
+
+  def getServiceInstance: ServiceInstance
+
+  def getLabels(): Array[Label[_]]
+
+  def setLabels(labels: Array[Label[_]])
+
+  def isAvailable: Boolean
+
+  def useEngineConn: Boolean
+
+  def unUseEngineConn: Unit
+
+  def getRunningTaskCount: Int
+
+  def execute(requestTask: RequestTask): ExecuteResponse
+
+  def killTask(execId: String): Boolean
+
+  def killAll(): Boolean
+
+  def pause(execId: String): Boolean
+
+  def pauseAll(): Boolean
+
+  def resume(execId: String): Boolean
+
+  def resumeAll(): Boolean
+
+  def status(execId: String): ExecutionNodeStatus
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[EngineConnExecutor]
+
+  def getLastUpdateTime(): Long
+
+  def updateLastUpdateTime(): Unit
+
+  override def equals(other: Any): Boolean = other match {
+    case that: EngineConnExecutor =>
+      (that canEqual this) &&
+        getServiceInstance == that.getServiceInstance
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(getServiceInstance)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
+
+}
+
+abstract class AbstractEngineConnExecutor extends EngineConnExecutor with Logging {
+
+  private var labels: Array[Label[_]] = _
+
+  protected var available: Boolean = true
+
+  private var lastUpdateTime: Long = System.currentTimeMillis()
+
+  private val runningTask: util.Map[String, RequestTask] = new util.HashMap[String, RequestTask]()
+
+
+  override def getLastUpdateTime(): Long = lastUpdateTime
+
+  override def updateLastUpdateTime(): Unit = lastUpdateTime = System.currentTimeMillis()
+
+  override def getLabels(): Array[Label[_]] = labels
+
+  override def setLabels(labels: Array[Label[_]]): Unit = this.labels = labels
+
+  override def isAvailable: Boolean = this.available
+
+  override def getRunningTaskCount: Int = this.runningTask.size()
+
+  protected def getRunningTasks: util.Map[String, RequestTask] = {
+    this.runningTask
+  }
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/TaskExecutionReceiver.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/TaskExecutionReceiver.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.service
+
+import com.webank.wedatasphere.linkis.governance.common.protocol.task._
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+
+
+
+trait TaskExecutionReceiver {
+
+
+  def taskLogReceiver(taskLog: ResponseTaskLog, smc: ServiceMethodContext): Unit
+
+  def taskProgressReceiver(taskProgress: ResponseTaskProgress, smc: ServiceMethodContext): Unit
+
+  def taskStatusReceiver(taskStatus: ResponseTaskStatus, smc: ServiceMethodContext): Unit
+
+  def taskResultSizeReceiver(taskResultSize: ResponseTaskResultSize, smc: ServiceMethodContext): Unit
+
+  def taskResultSetReceiver(taskResultSet: ResponseTaskResultSet, smc: ServiceMethodContext): Unit
+
+  def taskErrorReceiver(taskTaskError: ResponseTaskError, smc: ServiceMethodContext): Unit
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/impl/ComputationEngineConnExecutor.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/impl/ComputationEngineConnExecutor.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.service.impl
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+import com.webank.wedatasphere.linkis.governance.common.entity.ExecutionNodeStatus
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.{RequestTask, RequestTaskKill, RequestTaskStatus, ResponseTaskStatus}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.RequestManagerUnlock
+import com.webank.wedatasphere.linkis.orchestrator.ecm.conf.ECMPluginConf
+import com.webank.wedatasphere.linkis.orchestrator.ecm.exception.ECMPluginErrorException
+import com.webank.wedatasphere.linkis.orchestrator.ecm.service.AbstractEngineConnExecutor
+import com.webank.wedatasphere.linkis.rpc.Sender
+import com.webank.wedatasphere.linkis.scheduler.executer._
+
+
+
+class ComputationEngineConnExecutor(engineNode: EngineNode) extends AbstractEngineConnExecutor {
+
+  private val locker: String = engineNode.getLock
+
+  override def getServiceInstance: ServiceInstance = engineNode.getServiceInstance
+
+  private def getEngineConnSender: Sender = Sender.getSender(getServiceInstance)
+
+  override def close(): Unit = {
+    info(s"Start to release engineConn $getServiceInstance")
+    val requestManagerUnlock = RequestManagerUnlock(getServiceInstance, locker, Sender.getThisServiceInstance)
+    killAll()
+    getManagerSender.send(requestManagerUnlock)
+    info(s"Finished to release engineConn $getServiceInstance")
+  }
+
+  override def useEngineConn: Boolean = {
+    if (isAvailable) {
+      this.available = false
+      true
+    } else {
+      false
+    }
+  }
+
+  override def unUseEngineConn: Unit = {
+    if (!isAvailable) {
+      this.available = true
+    }
+  }
+
+  override def execute(requestTask: RequestTask): ExecuteResponse = {
+    info(s"Start to submit task to engineConn($getServiceInstance)")
+    requestTask.setLock(this.locker)
+    getEngineConnSender.ask(requestTask) match {
+      case submitResponse: SubmitResponse =>
+        info(s"Succeed to submit task to engineConn($getServiceInstance), Get asyncResponse execID is ${submitResponse}")
+        getRunningTasks.put(submitResponse.taskId, requestTask)
+        submitResponse
+      case outPutResponse: OutputExecuteResponse =>
+        info(s" engineConn($getServiceInstance) Succeed to execute task, and get Res")
+        outPutResponse
+      case errorExecuteResponse: ErrorExecuteResponse =>
+        error(s"engineConn($getServiceInstance) Failed to execute task ,error msg ${errorExecuteResponse.message}", errorExecuteResponse.t)
+        errorExecuteResponse
+      case successExecuteResponse: SuccessExecuteResponse =>
+        info(s" engineConn($getServiceInstance) Succeed to execute task, no res")
+        successExecuteResponse
+      case _ =>
+        throw new ECMPluginErrorException(ECMPluginConf.ECM_ERROR_CODE, s"engineConn($getServiceInstance) Failed to execute task, get response error")
+    }
+  }
+
+  override def killTask(execId: String): Boolean = {
+    Utils.tryCatch {
+      info(s"begin to send RequestTaskKill to engine, execID: $execId")
+      getEngineConnSender.send(RequestTaskKill(execId))
+      info(s"Finished to send RequestTaskKill to engine, execID: $execId")
+      true
+    } { t: Throwable =>
+      error(s"Failed to kill task $execId", t)
+      false
+    }
+  }
+
+  override def killAll(): Boolean = {
+    val execIds = getRunningTasks.keySet()
+    if (null == execIds || execIds.isEmpty) {
+      val iterator = execIds.iterator()
+      while (iterator.hasNext) {
+        val execId = iterator.next()
+        killTask(execId)
+      }
+    }
+    true
+  }
+
+  override def pause(execId: String): Boolean = {
+    //TODO
+    true
+  }
+
+  override def pauseAll(): Boolean = {
+    //TODO
+    true
+  }
+
+  override def resume(execId: String): Boolean = {
+    //TODO
+    true
+  }
+
+  override def resumeAll(): Boolean = {
+    //TODO
+    true
+  }
+
+  override def status(execId: String): ExecutionNodeStatus = {
+    getEngineConnSender.ask(RequestTaskStatus(execId)) match {
+      case ResponseTaskStatus(execId, status) =>
+        status
+      case _ =>
+        throw new ECMPluginErrorException(ECMPluginConf.ECM_ERROR_CODE, s"Failed to get engineConn status ")
+    }
+  }
+
+  private def getManagerSender: Sender = Sender.getSender(GovernanceCommonConf.MANAGER_SPRING_NAME.getValue)
+
+}
+
+class ComputationConcurrentEngineConnExecutor(engineNode: EngineNode, parallelism: Int) extends
+  ComputationEngineConnExecutor(engineNode) {
+
+  override def useEngineConn: Boolean = {
+    isAvailable
+  }
+
+  override def isAvailable: Boolean = {
+    if (parallelism > getRunningTasks.size()) {
+      true
+    } else {
+      false
+    }
+  }
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/impl/DefaultEngineAsyncResponseService.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/impl/DefaultEngineAsyncResponseService.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.service.impl
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.protocol.RequestManagerUnlock
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineCreateError, EngineCreateSuccess}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.orchestrator.ecm.cache.EngineAsyncResponseCache
+import com.webank.wedatasphere.linkis.orchestrator.ecm.service.EngineAsyncResponseService
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.springframework.stereotype.Service
+
+
+@Service
+class DefaultEngineAsyncResponseService extends EngineAsyncResponseService with Logging {
+
+  private val cacheMap = EngineAsyncResponseCache.getCache
+
+  @Receiver
+  override def onSuccess(engineCreateSuccess: EngineCreateSuccess, smc: ServiceMethodContext): Unit = {
+    info(s"Success to create engine $engineCreateSuccess")
+    Utils.tryCatch(cacheMap.put(engineCreateSuccess.id, engineCreateSuccess)) {
+      t: Throwable =>
+        error(s"client could be timeout, now to unlock engineNone", t)
+        val requestManagerUnlock = RequestManagerUnlock(engineCreateSuccess.engineNode.getServiceInstance,
+          engineCreateSuccess.engineNode.getLock, Sender.getThisServiceInstance)
+        smc.send(requestManagerUnlock)
+    }
+  }
+
+  @Receiver
+  override def onError(engineCreateError: EngineCreateError, smc: ServiceMethodContext): Unit = {
+    info(s"Failed to create engine ${engineCreateError.id}")
+    cacheMap.put(engineCreateError.id, engineCreateError)
+  }
+
+}

--- a/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/impl/DefaultTaskExecutionReceiver.scala
+++ b/linkis-orchestrator/plugin/linkis-orchestrator-ecm-plugin/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/ecm/service/impl/DefaultTaskExecutionReceiver.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.ecm.service.impl
+
+import com.webank.wedatasphere.linkis.governance.common.protocol.task._
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.orchestrator.ecm.service.TaskExecutionReceiver
+
+
+
+class DefaultTaskExecutionReceiver extends TaskExecutionReceiver {
+
+  @Receiver
+  override def taskLogReceiver(taskLog: ResponseTaskLog, smc: ServiceMethodContext): Unit = {
+
+  }
+
+  @Receiver
+  override def taskProgressReceiver(taskProgress: ResponseTaskProgress, smc: ServiceMethodContext): Unit = ???
+
+  @Receiver
+  override def taskStatusReceiver(taskStatus: ResponseTaskStatus, smc: ServiceMethodContext): Unit = ???
+
+  @Receiver
+  override def taskResultSizeReceiver(taskResultSize: ResponseTaskResultSize, smc: ServiceMethodContext): Unit = ???
+
+  @Receiver
+  override def taskResultSetReceiver(taskResultSet: ResponseTaskResultSet, smc: ServiceMethodContext): Unit = ???
+
+  override def taskErrorReceiver(taskTaskError: ResponseTaskError, smc: ServiceMethodContext): Unit = ???
+}

--- a/linkis-orchestrator/pom.xml
+++ b/linkis-orchestrator/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-orchestrator</artifactId>
+
+    <packaging>pom</packaging>
+    <modules>
+        <module>plugin/linkis-orchestrator-ecm-plugin</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
close #572
### What is the purpose of the change
Add the EngineConn management plug-in in the Entrance module 
### Brief change log
The plug-in is mainly to provide a usable EngineConn for Orchestrator's Task, as follows:
1.EnginConnManager manager, it is used to manage EngineConn
2.EngineConn, it is used for task execution and operation
3.EngineConnManagerBuilder, it is used to build a EnginConnManager