### PR TITLE
Enhance JDBCEngine, adapts to Linkis1.0's new architecture

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/pom.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-engineplugin-jdbc</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-computation-engineconn</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-storage</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <version>1.2.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-shims</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.aggregate</groupId>
+                    <artifactId>jetty-all</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.9.3</version>
+            <type>pom</type>
+        </dependency>
+
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                    <include>**/*.yml</include>
+                </includes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/assembly/distribution.xml
@@ -1,0 +1,71 @@
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-manager-enginePlugin-jdbc</id>
+    <formats>
+        <format>dir</format>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>jdbc</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>/dist/v${jdbc.version}/lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>false</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>linkis-engineconn.properties</include>
+                <include>log4j2-engineconn.xml</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>/dist/v${jdbc.version}/conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}/target</directory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*doc.jar</exclude>
+            </excludes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>/plugin/${jdbc.version}</outputDirectory>
+        </fileSet>
+
+    </fileSets>
+
+</assembly>
+

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/ConnectionManager.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/java/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/ConnectionManager.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc;
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp.BasicDataSourceFactory;
+import org.apache.commons.lang.StringUtils;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public  class  ConnectionManager {
+
+    Logger logger = LoggerFactory.getLogger(ConnectionManager.class);
+
+    private final Map<String, DataSource> databaseToDataSources = new HashMap<String, DataSource>();
+
+    private final Map<String, String> supportedDBs = new HashMap<String, String>();
+    private final List<String> supportedDBNames = new ArrayList<String>();
+
+    private volatile static ConnectionManager connectionManager;
+    private ConnectionManager(){
+    }
+    public static ConnectionManager getInstance(){
+        if (connectionManager== null) {
+            synchronized (ConnectionManager.class) {
+                if (connectionManager == null) {
+                    connectionManager = new ConnectionManager();
+                }
+            }
+        }
+        return connectionManager;
+    }
+
+    {
+        String supportedDBString = JDBCConfiguration.JDBC_SUPPORT_DBS().getValue();
+        String[] supportedDBs =  supportedDBString.split(",");
+        for (String supportedDB : supportedDBs) {
+            String[] supportedDBInfo = supportedDB.split("=>");
+            if(supportedDBInfo.length != 2) {
+                throw new IllegalArgumentException("Illegal driver info " + supportedDB);
+            }
+            try {
+                Class.forName(supportedDBInfo[1]);
+            } catch (ClassNotFoundException e) {
+                logger.info("Load " + supportedDBInfo[0] + " driver failed",e);
+            }
+            supportedDBNames.add(supportedDBInfo[0]);
+            this.supportedDBs.put(supportedDBInfo[0], supportedDBInfo[1]);
+        }
+    }
+
+    private void validateURL(String url) {
+        if(StringUtils.isEmpty(url)) {
+            throw new NullPointerException("jdbc.url cannot be null.");
+        }
+        if(!url.matches("jdbc:\\w+://\\S+:[0-9]{2,6}(/\\S*)?")) {
+            throw new IllegalArgumentException("Unknown jdbc.url " + url);
+        }
+        for (String supportedDBName: supportedDBNames) {
+            if(url.indexOf(supportedDBName) > 0) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException("Illegal url or not supported url type (url: " + url + ").");
+    }
+
+    private String getRealURL(String url) {
+        int index = url.indexOf("?");
+        if (index < 0) {
+            index = url.length();
+        }
+        return url.substring(0, index);
+    }
+
+
+    protected DataSource createDataSources(Map<String, String> properties) throws SQLException {
+        String url = properties.get("jdbc.url");
+        String username = properties.get("jdbc.username").trim();
+        String password = StringUtils.trim(properties.get("jdbc.password"));
+        validateURL(url);
+        int index = url.indexOf(":") + 1;
+        String dbType = url.substring(index, url.indexOf(":", index));
+        logger.info(String.format("Try to Create a new %s JDBC DBCP with url(%s), username(%s), password(%s).", dbType, url, username, password));
+        Properties props = new Properties();
+        props.put("driverClassName", supportedDBs.get(dbType));
+        props.put("url", url.trim());
+        props.put("username", username);
+        props.put("password", password);
+        props.put("maxIdle", 5);
+        props.put("minIdle", 0);
+        props.put("maxActive", 20);
+        props.put("initialSize", 1);
+        props.put("testOnBorrow", false);
+        props.put("testWhileIdle", true);
+        props.put("validationQuery", "select 1");
+        BasicDataSource dataSource;
+        try {
+            dataSource = (BasicDataSource) BasicDataSourceFactory.createDataSource(props);
+        } catch (Exception e) {
+            throw new SQLException(e);
+        }
+//        ComboPooledDataSource dataSource = new ComboPooledDataSource();
+//        dataSource.setUser(username);
+//        dataSource.setPassword(password);
+//        dataSource.setJdbcUrl(url.trim());
+//        try {
+//            dataSource.setDriverClass(supportedDBs.get(dbType));
+//        } catch (PropertyVetoException e) {
+//            throw new SQLException(e);
+//        }
+//        dataSource.setInitialPoolSize(1);
+//        dataSource.setMinPoolSize(0);
+//        dataSource.setMaxPoolSize(20);
+//        dataSource.setMaxStatements(40);
+//        dataSource.setMaxIdleTime(60);
+        return dataSource;
+    }
+
+    public Connection getConnection(Map<String, String> properties) throws SQLException {
+        String url = properties.get("jdbc.url");
+        if(StringUtils.isEmpty(properties.get("jdbc.username"))) {
+            throw new NullPointerException("jdbc.username cannot be null.");
+        }
+        url = getRealURL(url);
+        //这里通过URL+username识别
+        // String key = url + "/" + properties.get("jdbc.username").trim();
+        String key = url;
+        DataSource dataSource = databaseToDataSources.get(key);
+        if(dataSource == null) {
+            synchronized (databaseToDataSources) {
+                if(dataSource == null) {
+                    dataSource = createDataSources(properties);
+                    databaseToDataSources.put(key, dataSource);
+                }
+            }
+        }
+        return dataSource.getConnection();
+    }
+
+    public void close() {
+        for (DataSource dataSource: this.databaseToDataSources.values()) {
+            try {
+//                DataSources.destroy(dataSource);
+                ((BasicDataSource)dataSource).close();
+            } catch (SQLException e) {}
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+//        Pattern pattern = Pattern.compile("^(jdbc:\\w+://\\S+:[0-9]+)\\s*");
+        String url = "jdbc:mysql://xxx.xxx.xxx.xxx:8504/xx?useUnicode=true&amp;characterEncoding=UTF-8&amp;createDatabaseIfNotExist=true";
+        Properties properties = new Properties();
+        properties.put("driverClassName", "org.apache.hive.jdbc.HiveDriver");
+        properties.put("url", "jdbc:hive2://xxx.xxx.xxx.xxx:10000/");
+        properties.put("username", "username");
+        properties.put("password", "*****");
+        properties.put("maxIdle", 20);
+        properties.put("minIdle", 0);
+        properties.put("initialSize", 1);
+        properties.put("testOnBorrow", false);
+        properties.put("testWhileIdle", true);
+        properties.put("validationQuery", "select 1");
+        properties.put("initialSize", 1);
+        BasicDataSource dataSource = (BasicDataSource) BasicDataSourceFactory.createDataSource(properties);
+        Connection conn = dataSource.getConnection();
+        Statement statement = conn.createStatement();
+        ResultSet rs = statement.executeQuery("show tables");
+        while(rs.next()) {
+            System.out.println(rs.getObject(1));
+        }
+        rs.close();
+        statement.close();
+        conn.close();
+        dataSource.close();
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/resources/linkis-engineconn.properties
@@ -1,0 +1,29 @@
+#
+# Copyright 2019 WeBank
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+wds.linkis.server.version=v1
+
+wds.linkis.engineconn.debug.enable=true
+
+#wds.linkis.keytab.enable=true
+
+wds.linkis.engineconn.plugin.default.clazz=com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.JDBCEngineConnPlugin
+
+#wds.linkis.engine.io.opts=" -Dfile.encoding=UTF-8  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=49100 "
+
+wds.linkis.engineconn.support.parallelism=true
+

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/resources/log4j2-engineconn.xml
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/resources/log4j2-engineconn.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration status="error" monitorInterval="30">
+    <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <ThresholdFilter level="trace" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+        </Console>
+        <RollingFile name="RollingFile" fileName="linkis.log"
+                     filePattern="linkis-log-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+            <SizeBasedTriggeringPolicy size="100MB"/>
+            <DefaultRolloverStrategy max="20"/>
+        </RollingFile>
+        <Send name="Send" >
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} %L %M - %msg%xEx%n"/>
+        </Send>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <!--<appender-ref ref="RollingFile"/>-->
+            <appender-ref ref="Console"/>
+            <appender-ref ref="Send"/>
+        </root>
+        <logger name="com.netflix.discovery" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.hadoop.yarn" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.springframework" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="com.webank.wedatasphere.linkis.server.security" level="warn" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.hadoop.hive.ql.exec.mr.ExecDriver" level="fatal" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+        <logger name="org.apache.hadoop.hdfs.KeyProviderCache" level="fatal" additivity="true">
+            <appender-ref ref="Send"/>
+        </logger>
+    </loggers>
+</configuration>
+

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/JDBCEngineConnPlugin.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/JDBCEngineConnPlugin.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.EngineConnPlugin
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.creation.EngineConnFactory
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.EngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.{EngineResourceFactory, GenericEngineResourceFactory}
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.builder.JDBCProcessEngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.factory.JDBCEngineConnFactory
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+class JDBCEngineConnPlugin extends EngineConnPlugin {
+
+  private val EP_CONTEXT_CONSTRUCTOR_LOCK = new Object()
+
+  private var engineResourceFactory: EngineResourceFactory = _
+
+  private var engineLaunchBuilder: EngineConnLaunchBuilder = _
+
+  private var engineFactory: EngineConnFactory = _
+
+  private val defaultLabels: util.List[Label[_]] = new util.ArrayList[Label[_]]()
+
+  override def init(params: util.Map[String, Any]): Unit = {
+    /*val engineTypeLabel = new EngineTypeLabel()
+    engineTypeLabel.setEngineType(EngineType.IO_ENGINE.toString)
+    engineTypeLabel.setVersion(IOEngineConnConfiguration.DEFAULT_VERSION.getValue)
+    this.defaultLabels.add(engineTypeLabel)
+    val runTypeLabel = new EngineRunTypeLabel()
+    runTypeLabel.setRunType(RunType.IO.toString)*/
+  }
+
+  override def getEngineResourceFactory: EngineResourceFactory = EP_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+    if (null == engineResourceFactory) {
+      engineResourceFactory = new GenericEngineResourceFactory
+    }
+    engineResourceFactory
+  }
+
+  override def getEngineConnLaunchBuilder: EngineConnLaunchBuilder = EP_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+    if (null == engineLaunchBuilder) {
+      engineLaunchBuilder = new JDBCProcessEngineConnLaunchBuilder
+    }
+    engineLaunchBuilder
+  }
+
+  override def getEngineConnFactory: EngineConnFactory = EP_CONTEXT_CONSTRUCTOR_LOCK.synchronized {
+    if (null == engineFactory) {
+      engineFactory = new JDBCEngineConnFactory
+    }
+    engineFactory
+  }
+
+  override def getDefaultLabels: util.List[Label[_]] = this.defaultLabels
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/builder/JDBCProcessEngineConnLaunchBuilder.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/builder/JDBCProcessEngineConnLaunchBuilder.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.builder
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.JavaProcessEngineConnLaunchBuilder
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.UserCreatorLabel
+import com.webank.wedatasphere.linkis.storage.utils.StorageConfiguration
+
+class JDBCProcessEngineConnLaunchBuilder extends JavaProcessEngineConnLaunchBuilder {
+
+  override def getEngineStartUser(label: UserCreatorLabel): String = {
+    StorageConfiguration.HDFS_ROOT_USER.getValue
+  }
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/conf/JDBCConfiguration.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/conf/JDBCConfiguration.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{ByteType, CommonVars}
+
+object JDBCConfiguration {
+
+  val ENGINE_RESULT_SET_MAX_CACHE = CommonVars("wds.linkis.resultSet.cache.max", new ByteType("0k"))
+
+  val ENGINE_DEFAULT_LIMIT = CommonVars("wds.linkis.jdbc.default.limit", 5000)
+
+  val JDBC_QUERY_TIMEOUT = CommonVars("wds.linkis.jdbc.query.timeout", 1800)
+
+  val JDBC_SUPPORT_DBS = CommonVars("wds.linkis.jdbc.support.dbs", "mysql=>com.mysql.jdbc.Driver,postgresql=>org.postgresql.Driver,oracle=>oracle.jdbc.driver.OracleDriver,hive2=>org.apache.hive.jdbc.HiveDriver,presto=>com.facebook.presto.jdbc.PrestoDriver")
+
+  val JDBC_CONCURRENT_LIMIT = CommonVars[Int]("wds.linkis.engineconn.jdbc.concurrent.limit", 100)
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/exception/JDBCParamsIllegalException.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/exception/JDBCParamsIllegalException.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+
+case class JDBCParamsIllegalException(errorMsg: String) extends ErrorException(70012, errorMsg)
+
+case class JDBCSQLFeatureNotSupportedException(errorMsg: String) extends ErrorException(70013, errorMsg)
+
+case class JDBCStateMentNotInitialException(errorMsg: String) extends ErrorException(70014, errorMsg)

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/executer/JDBCEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/executer/JDBCEngineConnExecutor.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.executer
+
+import java.sql.{Connection, Statement}
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.{OverloadUtils, Utils}
+import com.webank.wedatasphere.linkis.engineconn.computation.executor.execute.{ConcurrentComputationExecutor, EngineExecutionContext}
+import com.webank.wedatasphere.linkis.engineconn.core.EngineConnObject
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{CommonNodeResource, LoadResource, NodeResource}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EngineConnPluginConf
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.ConnectionManager
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.protocol.engine.JobProgressInfo
+import com.webank.wedatasphere.linkis.rpc.Sender
+import com.webank.wedatasphere.linkis.scheduler.executer.{AliasOutputExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
+import com.webank.wedatasphere.linkis.storage.domain.{Column, DataType}
+import com.webank.wedatasphere.linkis.storage.resultset.ResultSetFactory
+import com.webank.wedatasphere.linkis.storage.resultset.table.{TableMetaData, TableRecord}
+import org.apache.commons.io.IOUtils
+import org.springframework.util.CollectionUtils
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int) extends ConcurrentComputationExecutor(outputPrintLimit) {
+
+
+  private val connectionManager = ConnectionManager.getInstance()
+
+  private var statement: Statement = null
+
+  private val executorLabels: util.List[Label[_]] = new util.ArrayList[Label[_]](2)
+  private var connection: Connection = null
+
+  override def executeLine(engineExecutorContext: EngineExecutionContext, code: String): ExecuteResponse = {
+    val realCode = code.trim()
+    val properties = engineExecutorContext.getProperties.asInstanceOf[util.Map[String, String]]
+    info(s"jdbc client begins to run jdbc code:\n ${realCode.trim}")
+    connection = connectionManager.getConnection(properties)
+    statement = connection.createStatement()
+    info(s"create statement is:  $statement")
+    val isResultSetAvailable = statement.execute(code)
+    info(s"Is ResultSet available ? : $isResultSetAvailable")
+    if (isResultSetAvailable) {
+      info("ResultSet is available")
+      val JDBCResultSet = statement.getResultSet
+      if (isDDLCommand(statement.getUpdateCount(), JDBCResultSet.getMetaData().getColumnCount)) {
+        info(s"current result is a ResultSet Object , but there are no more results :${code} ")
+        Utils.tryQuietly {
+          JDBCResultSet.close()
+          statement.close()
+          connection.close()
+        }
+        SuccessExecuteResponse()
+      } else {
+        val md = JDBCResultSet.getMetaData
+        val metaArrayBuffer = new ArrayBuffer[Tuple2[String, String]]()
+        for (i <- 1 to md.getColumnCount) {
+          metaArrayBuffer.add(Tuple2(md.getColumnName(i), JDBCHelper.getTypeStr(md.getColumnType(i))))
+        }
+        val columns = metaArrayBuffer.map { c => Column(c._1, DataType.toDataType(c._2), "") }.toArray[Column]
+        val metaData = new TableMetaData(columns)
+        val resultSetWriter = engineExecutorContext.createResultSetWriter(ResultSetFactory.TABLE_TYPE)
+        resultSetWriter.addMetaData(metaData)
+        var count = 0
+        Utils.tryCatch({
+          while (count < outputPrintLimit && JDBCResultSet.next()) {
+            val r: Array[Any] = columns.indices.map { i =>
+              val data = JDBCResultSet.getObject(i + 1) match {
+                case value: Any => value.toString
+                case _ => null
+              }
+              data
+            }.toArray
+            resultSetWriter.addRecord(new TableRecord(r))
+            count += 1
+          }
+        }) {
+          case e: Exception => return ErrorExecuteResponse("query jdbc failed", e)
+        }
+        val output = if (resultSetWriter != null) resultSetWriter.toString else null
+        Utils.tryQuietly {
+          JDBCResultSet.close()
+          statement.close()
+          connection.close()
+          IOUtils.closeQuietly(resultSetWriter)
+        }
+        info("sql execute completed")
+        AliasOutputExecuteResponse(null, output)
+      }
+    } else {
+      info(s"only return affect rows : ${statement.getUpdateCount}")
+      Utils.tryQuietly {
+        statement.close()
+        connection.close()
+      }
+      SuccessExecuteResponse()
+    }
+  }
+
+  protected def isDDLCommand(updatedCount: Int, columnCount: Int): Boolean = {
+    if (updatedCount < 0 && columnCount <= 0) {
+      true
+    } else {
+      false
+    }
+  }
+
+  override def getProgressInfo: Array[JobProgressInfo] = Array.empty[JobProgressInfo]
+
+  override protected def callback(): Unit = {}
+
+  override def progress(): Float = {
+    0
+  }
+
+  override def close(): Unit = {
+    if (statement != null) {
+      statement.close()
+    }
+    if (connection != null) {
+      connection.close()
+    }
+  }
+
+  override def executeCompletely(engineExecutorContext: EngineExecutionContext, code: String, completedLine: String): ExecuteResponse = null
+
+  override def getExecutorLabels(): util.List[Label[_]] = executorLabels
+
+  override def setExecutorLabels(labels: util.List[Label[_]]): Unit = {
+    if (!CollectionUtils.isEmpty(labels)) {
+      executorLabels.clear()
+      executorLabels.addAll(labels)
+    }
+  }
+
+  override def requestExpectedResource(expectedResource: NodeResource): NodeResource = null
+
+  override def getCurrentNodeResource(): NodeResource = {
+    val properties = EngineConnObject.getEngineCreationContext.getOptions
+    if (properties.containsKey(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key)) {
+      val settingClientMemory = properties.get(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key)
+      if (!settingClientMemory.toLowerCase().endsWith("g")) {
+        properties.put(EngineConnPluginConf.JAVA_ENGINE_REQUEST_MEMORY.key, settingClientMemory + "g")
+      }
+    }
+    val resource = new CommonNodeResource
+    val usedResource = new LoadResource(OverloadUtils.getProcessMaxMemory, 1)
+    resource.setUsedResource(usedResource)
+    resource
+  }
+
+  override def supportCallBackLogs(): Boolean = false
+
+  override def getId(): String = Sender.getThisServiceInstance.getInstance + s"_$id"
+
+  override def getConcurrentLimit: Int = JDBCConfiguration.JDBC_CONCURRENT_LIMIT.getValue
+
+  override def killAll(): Unit = {
+
+  }
+}
+

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/executer/JDBCHelper.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/executer/JDBCHelper.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.executer;
+
+import com.webank.wedatasphere.linkis.storage.domain.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class JDBCHelper {
+    protected String helper(ResultSet rs, int dataType, int col)
+            throws SQLException {
+        String retVal = null;
+        Integer intObj;
+        switch (dataType) {
+            case Types.DATE:
+                java.sql.Date date = rs.getDate(col);
+                retVal = date.toString();
+                break;
+            case Types.TIME:
+                java.sql.Time time = rs.getTime(col);
+                retVal = time.toString();
+                break;
+            case Types.TIMESTAMP:
+                java.sql.Timestamp timestamp = rs.getTimestamp(col);
+                retVal = timestamp.toString();
+                break;
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                retVal = rs.getString(col);
+                break;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                java.math.BigDecimal numeric = rs.getBigDecimal(col, 10);
+                retVal = numeric.toString();
+                break;
+            case Types.BIT:
+                boolean bit = rs.getBoolean(col);
+                Boolean boolObj = new Boolean(bit);
+                retVal = boolObj.toString();
+                break;
+            case Types.TINYINT:
+                byte tinyint = rs.getByte(col);
+                intObj = new Integer(tinyint);
+                retVal = intObj.toString();
+                break;
+            case Types.SMALLINT:
+                short smallint = rs.getShort(col);
+                intObj = new Integer(smallint);
+                retVal = intObj.toString();
+                break;
+            case Types.INTEGER:
+                int integer = rs.getInt(col);
+                intObj = new Integer(integer);
+                retVal = intObj.toString();
+                break;
+            case Types.BIGINT:
+                long bigint = rs.getLong(col);
+                Long longObj = new Long(bigint);
+                retVal = longObj.toString();
+                break;
+            case Types.REAL:
+                float real = rs.getFloat(col);
+                Float floatObj = new Float(real);
+                retVal = floatObj.toString();
+                break;
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                double longreal = rs.getDouble(col);
+                Double doubleObj = new Double(longreal);
+                retVal = doubleObj.toString();
+                break;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                byte[] binary = rs.getBytes(col);
+                retVal = new String(binary);
+                break;
+            default:
+                break;
+        }
+        return retVal;
+    }
+
+    public static String getTypeStr(int type) {
+        String retVal = null;
+        Integer intObj;
+        switch (type) {
+            case Types.NULL:
+                retVal = NullType.typeName();
+                break;
+            case Types.VARCHAR:
+                retVal = StringType.typeName();
+                break;
+            case Types.BOOLEAN:
+                retVal = BooleanType.typeName();
+                break;
+            case Types.TINYINT:
+                retVal = TinyIntType.typeName();
+                break;
+            case Types.SMALLINT:
+                retVal = ShortIntType.typeName();
+                break;
+            case Types.INTEGER:
+                retVal = IntType.typeName();
+                break;
+            case Types.LONGNVARCHAR:
+                retVal = LongType.typeName();
+                break;
+            case Types.LONGVARCHAR:
+                retVal = StringType.typeName();
+                break;
+            case Types.FLOAT:
+                retVal = FloatType.typeName();
+                break;
+            case Types.DOUBLE:
+                retVal = DoubleType.typeName();
+                break;
+            case Types.CHAR:
+                retVal = CharType.typeName();
+                break;
+            case Types.DATE:
+                retVal = DateType.typeName();
+                break;
+            case Types.TIMESTAMP:
+                retVal = TimestampType.typeName();
+                break;
+            case Types.BINARY:
+                retVal = BinaryType.typeName();
+                break;
+            case Types.DECIMAL:
+                retVal = DecimalType.typeName();
+                break;
+            case Types.ARRAY:
+                retVal = ArrayType.typeName();
+                break;
+            case Types.STRUCT:
+                retVal = StructType.typeName();
+                break;
+            case Types.BIGINT:
+                retVal = LongType.typeName();
+                break;
+            case Types.REAL:
+                retVal = DoubleType.typeName();
+                break;
+            default:
+                break;
+        }
+        return retVal;
+    }
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/executer/JDBCSQLCodeParser.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/executer/JDBCSQLCodeParser.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.executer
+
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration
+import org.apache.commons.lang.StringUtils
+
+import scala.collection.mutable.ArrayBuffer
+
+object JDBCSQLCodeParser {
+
+  val separator = ";"
+  val defaultLimit: Int = JDBCConfiguration.ENGINE_DEFAULT_LIMIT.getValue
+
+  def parse(code: String): Array[String] = {
+    val codeBuffer = new ArrayBuffer[String]()
+
+    def appendStatement(sqlStatement: String): Unit = {
+      codeBuffer.append(sqlStatement)
+    }
+
+    if (StringUtils.contains(code, separator)) {
+      StringUtils.split(code, ";").foreach {
+        case s if StringUtils.isBlank(s) =>
+        case s if isSelectCmdNoLimit(s) => appendStatement(s + " limit " + defaultLimit);
+        case s => appendStatement(s);
+      }
+    } else {
+      code match {
+        case s if StringUtils.isBlank(s) =>
+        case s if isSelectCmdNoLimit(s) => appendStatement(s + " limit " + defaultLimit);
+        case s => appendStatement(s);
+      }
+    }
+    codeBuffer.toArray
+  }
+
+  def isSelectCmdNoLimit(cmd: String): Boolean = {
+    var code = cmd.trim
+    if (!cmd.split("\\s+")(0).equalsIgnoreCase("select")) return false
+    if (code.contains("limit")) code = code.substring(code.lastIndexOf("limit")).trim
+    else if (code.contains("LIMIT")) code = code.substring(code.lastIndexOf("LIMIT")).trim.toLowerCase
+    else return true
+    val hasLimit = code.matches("limit\\s+\\d+\\s*;?")
+    if (hasLimit) {
+      if (code.indexOf(";") > 0) code = code.substring(5, code.length - 1).trim
+      else code = code.substring(5).trim
+      val limitNum = code.toInt
+      if (limitNum > defaultLimit) throw new IllegalArgumentException("We at most allowed to limit " + defaultLimit + ", but your SQL has been over the max rows.")
+    }
+    !hasLimit
+  }
+
+
+}

--- a/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/factory/JDBCEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/jdbc/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/jdbc/factory/JDBCEngineConnFactory.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.factory
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.{DefaultEngineConn, EngineConn}
+import com.webank.wedatasphere.linkis.engineconn.core.executor.ExecutorManager
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.creation.SingleExecutorEngineConnFactory
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration
+import com.webank.wedatasphere.linkis.manager.engineplugin.jdbc.executer.JDBCEngineConnExecutor
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineRunTypeLabel, EngineType, RunType}
+
+class JDBCEngineConnFactory extends SingleExecutorEngineConnFactory with Logging{
+
+  private var engineCreationContext: EngineCreationContext = _
+
+  override def createExecutor(engineCreationContext: EngineCreationContext, engineConn: EngineConn): Executor = {
+    this.engineCreationContext = engineCreationContext
+    val id = ExecutorManager.getInstance().generateId()
+    val executor = new JDBCEngineConnExecutor(JDBCConfiguration.ENGINE_DEFAULT_LIMIT.getValue, id)
+    val runTypeLabel = getDefaultEngineRunTypeLabel()
+    executor.getExecutorLabels().add(runTypeLabel)
+    executor
+  }
+
+  override def getDefaultEngineRunTypeLabel(): EngineRunTypeLabel = {
+    val runTypeLabel = new EngineRunTypeLabel
+    runTypeLabel.setRunType(RunType.JDBC.toString)
+    runTypeLabel
+  }
+
+  override def createEngineConn(engineCreationContext: EngineCreationContext): EngineConn = {
+    val engineConn = new DefaultEngineConn(engineCreationContext)
+    engineConn.setEngineType(EngineType.JDBC.toString)
+    engineConn
+  }
+
+
+}


### PR DESCRIPTION
close #592

### What is the purpose of the change

Linkis JDBC engine can help users to quickly access the underlying data source by adding different JDBC drivers,including oracle,mysql,PostgreSQL,and Hive.

### Brief change log

1. Add support for multiple JDBC drivers.
2. Add support for JDBC type scripts.