### PR TITLE
Split EngineReceiver of Linkis0.x into service and encapsulate executor

### DIFF
--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-accessible-executor</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-executor-core</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>reflections</artifactId>
+                    <groupId>org.reflections</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-launch</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <!--<dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-scheduler</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>-->
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>reflections</artifactId>
+                    <groupId>org.reflections</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/AbstractLogCache.java
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/AbstractLogCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.log;
+
+import com.webank.wedatasphere.linkis.common.log.LogUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+
+public abstract class AbstractLogCache implements LogCache {
+    protected String generateLog(LogEvent event) {
+        if (event.getLevel() == Level.INFO) {
+            return LogUtils.generateInfo(event.getMessage().toString());
+        } else if (event.getLevel() == Level.WARN) {
+            return LogUtils.generateWarn(event.getMessage().toString());
+        } else if (event.getLevel() == Level.ERROR) {
+            return LogUtils.generateERROR(event.getMessage().toString());
+        } else if (event.getLevel() == Level.FATAL) {
+            return LogUtils.generateSystemError(event.getMessage().toString());
+        }
+        return "";
+    }
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/LogCache.java
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/LogCache.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.log;
+
+
+import java.util.List;
+
+public interface LogCache {
+    /**
+     * Store logs in the cache for subsequent delivery
+     * 将日志存储到缓存当中，用于后续的发送
+     *
+     * @param log 日志信息
+     */
+    void cacheLog(String log);
+
+    /**
+     * Get the log of the number of num（获取num数目的日志）
+     *
+     * @param num The number of logs you want to get（希望获取的日志的数量）
+     * @return Log List Collection（日志List集合）
+     */
+    List<String> getLog(int num);
+
+    /**
+     * Take all the logs in the log cache for the engine to take out all the logs after performing a task
+     * 将日志缓存中的所有日志都取出，用于engine执行完一个任务之后将日志全部取出
+     *
+     * @return
+     */
+    List<String> getRemain();
+
+    int size();
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/MountLogCache.java
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/MountLogCache.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.log;
+
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf.AccessibleExecutorConfiguration;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MountLogCache extends AbstractLogCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(MountLogCache.class);
+
+    class CircularQueue {
+
+        private int max;
+        private String[] elements;
+        private int front, rear, count;
+
+        CircularQueue() {
+            this((Integer) AccessibleExecutorConfiguration.ENGINECONN_LOG_CACHE_NUM().getValue());
+        }
+
+        CircularQueue(int max) {
+            this.max = max;
+            this.elements = new String[max];
+        }
+
+        public boolean isEmpty() {
+            return count == 0;
+        }
+
+        public synchronized void enqueue(String value) {
+            if (count == max) {
+                logger.warn("Queue is full, log: {} needs to be dropped", value);
+            } else {
+                rear = (rear + 1) % max;
+                elements[rear] = value;
+                count++;
+            }
+        }
+
+        public String dequeue() {
+            if (count == 0) {
+                logger.debug("Queue is empty, nothing to get");
+                return null;
+            } else {
+                front = (front + 1) % max;
+                count--;
+                return elements[front];
+            }
+        }
+
+        public List<String> dequeue(int num) {
+            List<String> list = new ArrayList<>();
+            int index = 0;
+            while (index < num) {
+                String tempLog = dequeue();
+                if (StringUtils.isNotEmpty(tempLog)) {
+                    list.add(tempLog);
+                } else if (tempLog == null) {
+                    break;
+                }
+                index++;
+            }
+            return list;
+        }
+
+        public synchronized List<String> getRemain() {
+            List<String> list = new ArrayList<>();
+            while (!isEmpty()) {
+                list.add(dequeue());
+            }
+            return list;
+        }
+
+        public int size() {
+            return count;
+        }
+    }
+
+
+    private CircularQueue logs;
+
+
+    public MountLogCache(int loopMax) {
+        this.logs = new CircularQueue(loopMax);
+    }
+
+    @Override
+    public void cacheLog(String log) {
+        logs.enqueue(log);
+    }
+
+    @Override
+    public List<String> getLog(int num) {
+        return logs.dequeue(num);
+    }
+
+    @Override
+    public synchronized List<String> getRemain() {
+        return logs.getRemain();
+    }
+
+    @Override
+    public int size() {
+        return logs.size();
+    }
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/SendAppender.java
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/SendAppender.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.log;
+
+import com.webank.wedatasphere.linkis.common.utils.Utils;
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf.AccessibleExecutorConfiguration;
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.TaskLogUpdateEvent;
+import com.webank.wedatasphere.linkis.engineconn.core.EngineConnObject;
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.EngineConnSyncListenerBus;
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Plugin(name = "Send", category = "Core", elementType = "appender", printObject = true)
+public class SendAppender extends AbstractAppender {
+
+    /**
+     * @fields serialVersionUID
+     */
+    private static final long serialVersionUID = -830237775522429777L;
+
+    private static EngineConnSyncListenerBus engineConnSyncListenerBus = ExecutorListenerBusContext.getExecutorListenerBusContext().getEngineConnSyncListenerBus();
+
+    private LogCache logCache;
+    private static final Logger logger = LoggerFactory.getLogger(SendAppender.class);
+
+    private static final String IGNORE_WORDS = AccessibleExecutorConfiguration.ENGINECONN_IGNORE_WORDS().getValue();
+
+    private static final String[] IGNORE_WORD_ARR = IGNORE_WORDS.split(",");
+
+    private static final String PASS_WORDS = AccessibleExecutorConfiguration.ENGINECONN_PASS_WORDS().getValue();
+
+    private static final String[] PASS_WORDS_ARR = PASS_WORDS.split(",");
+
+
+    class SendThread implements Runnable {
+        @Override
+        public void run() {
+            if (engineConnSyncListenerBus == null) {
+                //ignore
+            } else {
+                if (logCache == null) {
+                    logger.warn("logCache is null");
+                    return;
+                }
+                List<String> logs = logCache.getRemain();
+                if (logs.size() > 0) {
+                    StringBuilder sb = new StringBuilder();
+                    for (String log : logs) {
+                        sb.append(log).append("\n");
+                    }
+                    if (EngineConnObject.isReady()) {
+                        engineConnSyncListenerBus.postToAll(new TaskLogUpdateEvent(null, sb.toString()));
+                    }
+                }
+            }
+        }
+    }
+
+
+    public SendAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout,
+                        final boolean ignoreExceptions) {
+        super(name, filter, layout, ignoreExceptions);
+        this.logCache = LogHelper.logCache();
+        SendThread thread = new SendThread();
+        Utils.defaultScheduler().scheduleAtFixedRate(thread, 10, (Integer) AccessibleExecutorConfiguration.ENGINECONN_LOG_SEND_TIME_INTERVAL().getValue(), TimeUnit.MILLISECONDS);
+    }
+
+
+
+    @Override
+    public void append(LogEvent event) {
+        if (engineConnSyncListenerBus == null) {
+            return;
+        }
+        String logStr = new String(getLayout().toByteArray(event));
+        if (event.getLevel().intLevel() == Level.INFO.intLevel()) {
+            boolean flag = false;
+            for (String ignoreLog : IGNORE_WORD_ARR) {
+                if (logStr.contains(ignoreLog)) {
+                    flag = true;
+                    break;
+                }
+            }
+            for (String word : PASS_WORDS_ARR) {
+                if (logStr.contains(word)) {
+                    flag = false;
+                    break;
+                }
+            }
+            if (!flag) {
+                logCache.cacheLog(logStr);
+            }
+        } else {
+            logCache.cacheLog(logStr);
+        }
+    }
+
+    @PluginFactory
+    public static SendAppender createAppender(@PluginAttribute("name") String name,
+                                              @PluginElement("Filter") final Filter filter,
+                                              @PluginElement("Layout") Layout<? extends Serializable> layout,
+                                              @PluginAttribute("ignoreExceptions") boolean ignoreExceptions) {
+        if (name == null) {
+            LOGGER.error("No name provided for SendAppender");
+            return null;
+        }
+        if (layout == null) {
+            layout = PatternLayout.createDefaultLayout();
+        }
+        return new SendAppender(name, filter, layout, ignoreExceptions);
+    }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/TimeLogCache.java
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/java/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/TimeLogCache.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.log;
+
+import java.util.List;
+
+/**
+ * Description: Cache with time as storage unit（以时间作为存储单位的缓存方式）
+ */
+public class TimeLogCache extends AbstractLogCache {
+    @Override
+    public void cacheLog(String log) {
+
+    }
+
+    @Override
+    public List<String> getLog(int num) {
+        return null;
+    }
+
+    @Override
+    public List<String> getRemain() {
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/conf/AccessibleExecutorConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/conf/AccessibleExecutorConfiguration.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+
+object AccessibleExecutorConfiguration {
+
+  val ENGINECONN_LOG_CACHE_NUM = CommonVars("wds.linkis.engineconn.log.cache.default", 500)
+
+
+  val ENGINECONN_IGNORE_WORDS = CommonVars("wds.linkis.engineconn.ignore.words", "org.apache.spark.deploy.yarn.Client")
+
+  val ENGINECONN_PASS_WORDS = CommonVars("wds.linkis.engineconn.pass.words", "org.apache.hadoop.hive.ql.exec.Task")
+
+  val ENGINECONN_LOG_NUM_SEND_ONCE = CommonVars("wds.linkis.engineconn.log.send.once", 100)
+
+  val ENGINECONN_LOG_SEND_TIME_INTERVAL = CommonVars("wds.linkis.engineconn.log.send.time.interval", 3)
+
+
+  val ENGINECONN_MAX_FREE_TIME = CommonVars("wds.linkis.engineconn.max.free.time", new TimeType("1h"))
+
+
+  val ENGINECONN_SUPPORT_PARALLELISM = CommonVars("wds.linkis.engineconn.support.parallelism", false)
+
+
+  val ENGINECONN_HEARTBEAT_TIME = CommonVars("wds.linkis.engineconn.heartbeat.time", new TimeType("3m"))
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/conf/AccessibleExecutorSpringConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/conf/AccessibleExecutorSpringConfiguration.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.info.{DefaultNodeOverLoadInfoManager, NodeOverLoadInfoManager}
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.service.{EngineConnConcurrentLockService, EngineConnTimedLockService, LockService}
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.{Bean, Configuration}
+
+@Configuration
+class AccessibleExecutorSpringConfiguration extends Logging {
+
+  private val asyncListenerBusContext = ExecutorListenerBusContext.getExecutorListenerBusContext().getEngineConnAsyncListenerBus
+
+  @Bean(Array("lockService"))
+  @ConditionalOnMissingBean
+  def createLockManager(): LockService = {
+
+    val lockService = if (AccessibleExecutorConfiguration.ENGINECONN_SUPPORT_PARALLELISM.getValue) new EngineConnConcurrentLockService
+    else new EngineConnTimedLockService
+    asyncListenerBusContext.addListener(lockService)
+    lockService
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(Array(classOf[NodeOverLoadInfoManager]))
+  def createNodeOverLoadInfoManager(): NodeOverLoadInfoManager = {
+
+    new DefaultNodeOverLoadInfoManager
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/entity/AccessibleExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/entity/AccessibleExecutor.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.ExecutorStatusChangedEvent
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.SensibleExecutor
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.scheduler.exception.SchedulerErrorException
+
+abstract class AccessibleExecutor extends SensibleExecutor {
+
+    private var isExecutorClosed = false
+
+    def isIdle = NodeStatus.isIdle(getStatus)
+
+    def isBusy = NodeStatus.isLocked(getStatus)
+
+    def whenBusy[A](f: => A) = whenStatus(NodeStatus.Busy, f)
+
+    def whenIdle[A](f: => A) = whenStatus(NodeStatus.Idle, f)
+
+    def whenStatus[A](_status: NodeStatus, f: => A) = if (getStatus == _status) f
+
+    def ensureBusy[A](f: => A): A = {
+        lastActivityTime = System.currentTimeMillis
+        if (isBusy) synchronized {
+            if (isBusy) return f
+        }
+        throw new SchedulerErrorException(20001, "%s is in status %s." format(toString, getStatus))
+    }
+
+    def ensureIdle[A](f: => A): A = ensureIdle(f, true)
+
+    def ensureIdle[A](f: => A, transitionState: Boolean): A = {
+        if (isIdle) synchronized {
+            if (isIdle) {
+                if (transitionState) transition(NodeStatus.Busy)
+                return Utils.tryFinally(f) {
+                    if (transitionState) transition(NodeStatus.Idle)
+                    callback()
+                }
+            }
+        }
+        throw new SchedulerErrorException(20001, "%s is in status %s." format(toString, getStatus))
+    }
+
+
+    def ensureAvailable[A](f: => A): A = {
+        if (NodeStatus.isAvailable(getStatus)) synchronized {
+            if (NodeStatus.isAvailable(getStatus)) return Utils.tryFinally(f)(callback())
+        }
+        throw new SchedulerErrorException(20001, "%s is in status %s." format(toString, getStatus))
+    }
+
+    def whenAvailable[A](f: => A): A = {
+        if (NodeStatus.isAvailable(getStatus)) return Utils.tryFinally(f)(callback())
+        throw new SchedulerErrorException(20001, "%s is in status %s." format(toString, getStatus))
+    }
+
+    protected def callback(): Unit
+
+    def supportCallBackLogs(): Boolean
+
+    protected override def onStatusChanged(fromStatus: NodeStatus, toStatus: NodeStatus): Unit = {
+        ExecutorListenerBusContext.getExecutorListenerBusContext().getEngineConnAsyncListenerBus.post(ExecutorStatusChangedEvent(this, fromStatus, toStatus))
+    }
+
+    override def close(): Unit = {
+        isExecutorClosed = true
+        super.close()
+    }
+
+    override def isClosed(): Boolean = isExecutorClosed
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/entity/ExecutorStatusInfo.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/entity/ExecutorStatusInfo.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.{NodeHealthyInfo, NodeOverLoadInfo}
+
+import scala.beans.BeanProperty
+
+class ExecutorStatusInfo {
+
+  @BeanProperty
+  var status: NodeStatus = NodeStatus.Starting
+
+  @BeanProperty
+  var healthyInfo: NodeHealthyInfo = null
+
+  @BeanProperty
+  var overLoadInfo: NodeOverLoadInfo = null
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/info/NodeHealthyInfoManager.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/info/NodeHealthyInfoManager.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.info
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeHealthy
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeHealthyInfo
+import org.springframework.stereotype.Component
+
+trait NodeHealthyInfoManager {
+
+  def getNodeHealthyInfo(): NodeHealthyInfo
+
+
+}
+
+
+@Component
+class DefaultNodeHealthyInfoManager extends NodeHealthyInfoManager with Logging {
+
+  override def getNodeHealthyInfo(): NodeHealthyInfo = {
+    val nodeHealthyInfo = new NodeHealthyInfo
+    nodeHealthyInfo.setMsg("")
+    nodeHealthyInfo.setNodeHealthy(NodeHealthy.Healthy)
+    nodeHealthyInfo
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/info/NodeHeartbeatMsgManager.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/info/NodeHeartbeatMsgManager.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.info
+
+trait NodeHeartbeatMsgManager {
+
+  def getHeartBeatMsg(): String
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/info/NodeOverLoadInfoManager.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/info/NodeOverLoadInfoManager.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.info
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, OverloadUtils}
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo
+import org.springframework.stereotype.Component
+
+trait NodeOverLoadInfoManager {
+  // TODO linkis/windows/docker overload
+  def getNodeOverLoadInfo: NodeOverLoadInfo
+
+}
+
+//@ConditionalOnMissingBean(name=Array("nodeOverLoadInfoManager"))
+@Component
+class DefaultNodeOverLoadInfoManager extends NodeOverLoadInfoManager with Logging {
+
+  override def getNodeOverLoadInfo: NodeOverLoadInfo = {
+    val nodeOverLoadInfo = new NodeOverLoadInfo
+    nodeOverLoadInfo.setMaxMemory(OverloadUtils.getProcessMaxMemory)
+    nodeOverLoadInfo.setUsedMemory(OverloadUtils.getProcessUsedMemory)
+    nodeOverLoadInfo.setSystemCPUUsed(OverloadUtils.getSystemCPUUsed)
+    nodeOverLoadInfo.setSystemLeftMemory(OverloadUtils.getSystemFreeMemory)
+    nodeOverLoadInfo
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/ExecutorLockListener.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/ExecutorLockListener.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.Event
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.{ExecutorLockEvent, ExecutorUnLockEvent}
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.EngineConnAsyncListener
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnAsyncEvent
+
+trait ExecutorLockListener extends EngineConnAsyncListener {
+
+  def onAddLock(addLockEvent: ExecutorLockEvent): Unit
+
+  def onReleaseLock(releaseLockEvent: ExecutorUnLockEvent): Unit
+
+  override def onEvent(event: EngineConnAsyncEvent): Unit = event match {
+    case addLockEvent: ExecutorLockEvent => onAddLock(addLockEvent)
+    case releaseLockEvent: ExecutorUnLockEvent => onReleaseLock(releaseLockEvent)
+    case _ =>
+  }
+
+  override def onEventError(event: Event, t: Throwable): Unit = {
+
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/ExecutorStatusListener.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/ExecutorStatusListener.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.Event
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.{ExecutorCompletedEvent, ExecutorCreateEvent, ExecutorStatusChangedEvent}
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.EngineConnAsyncListener
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnAsyncEvent
+
+trait ExecutorStatusListener extends EngineConnAsyncListener {
+
+  def onExecutorCreated(executorCreateEvent: ExecutorCreateEvent): Unit
+
+  def onExecutorCompleted(executorCompletedEvent: ExecutorCompletedEvent): Unit
+
+  def onExecutorStatusChanged(executorStatusChangedEvent: ExecutorStatusChangedEvent): Unit
+
+  override def onEvent(event: EngineConnAsyncEvent): Unit = event match {
+    case executorCreateEvent: ExecutorCreateEvent => onExecutorCreated(executorCreateEvent)
+    case executorCompletedEvent: ExecutorCompletedEvent => onExecutorCompleted(executorCompletedEvent)
+    case executorStatusChangedEvent: ExecutorStatusChangedEvent => onExecutorStatusChanged(executorStatusChangedEvent)
+    case _ =>
+  }
+
+  override def onEventError(event: Event, t: Throwable): Unit = {
+
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/LogListener.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/LogListener.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener
+
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.TaskLogUpdateEvent
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.EngineConnSyncListener
+
+trait LogListener extends EngineConnSyncListener {
+
+  def onLogUpdate(logUpdateEvent: TaskLogUpdateEvent)
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/NodeHealthyListener.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/NodeHealthyListener.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.Event
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.NodeHealthyUpdateEvent
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.EngineConnAsyncListener
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnAsyncEvent
+
+trait NodeHealthyListener extends EngineConnAsyncListener {
+
+
+  def onNodeHealthyUpdate(nodeHealthyUpdateEvent: NodeHealthyUpdateEvent): Unit
+
+  override def onEvent(event: EngineConnAsyncEvent): Unit = event match {
+
+    case nodeHealthyUpdateEvent: NodeHealthyUpdateEvent => onNodeHealthyUpdate(nodeHealthyUpdateEvent)
+    case _ =>
+  }
+
+  override def onEventError(event: Event, t: Throwable): Unit = {
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/event/AccessibleExecutorConnAsyncEvent.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/event/AccessibleExecutorConnAsyncEvent.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event
+
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnAsyncEvent
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeHealthyInfo
+
+trait AccessibleExecutorConnAsyncEvent extends EngineConnAsyncEvent {
+
+}
+
+case class ExecutorCreateEvent(executor: Executor) extends AccessibleExecutorConnAsyncEvent
+
+case class ExecutorCompletedEvent(executor: Executor, message: String) extends AccessibleExecutorConnAsyncEvent
+
+case class ExecutorStatusChangedEvent(executor: Executor, fromStatus: NodeStatus, toStatus: NodeStatus) extends AccessibleExecutorConnAsyncEvent
+
+case class ExecutorLockEvent(executor: Executor, lock: String) extends AccessibleExecutorConnAsyncEvent
+
+case class ExecutorUnLockEvent(executor: Executor, lock: String) extends AccessibleExecutorConnAsyncEvent
+
+case class NodeHealthyUpdateEvent(nodeHealthyInfo: NodeHealthyInfo) extends AccessibleExecutorConnAsyncEvent
+

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/event/LogUpdateEvent.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/event/LogUpdateEvent.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event
+
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnSyncEvent
+
+case class LogUpdateEvent(taskId: String, log: String) extends EngineConnSyncEvent

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/event/TaskEvent.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/listener/event/TaskEvent.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event
+
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnSyncEvent
+import com.webank.wedatasphere.linkis.governance.common.entity.ExecutionNodeStatus
+import com.webank.wedatasphere.linkis.protocol.engine.JobProgressInfo
+
+trait TaskEvent extends EngineConnSyncEvent {
+
+}
+
+case class TaskProgressUpdateEvent(taskId: String, progress: Float, progressInfo: Array[JobProgressInfo]) extends TaskEvent
+
+case class TaskLogUpdateEvent(taskId: String, log: String) extends TaskEvent
+
+case class TaskStatusChangedEvent(taskId: String, fromStatus: ExecutionNodeStatus, toStatus: ExecutionNodeStatus) extends TaskEvent
+
+case class TaskResultCreateEvent(taskId: String, resStr: String, alias: String) extends TaskEvent
+
+case class TaskResultSizeCreatedEvent(taskId: String, resultSize: Int) extends TaskEvent

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/lock/EngineConnTimedLock.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/lock/EngineConnTimedLock.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.lock
+
+import java.util.concurrent.{ScheduledFuture, ScheduledThreadPoolExecutor, Semaphore, TimeUnit}
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity.AccessibleExecutor
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.ExecutorUnLockEvent
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+
+class EngineConnTimedLock(private var timeout: Long) extends TimedLock with Logging {
+
+  var lock = new Semaphore(1)
+  val releaseScheduler = new ScheduledThreadPoolExecutor(1)
+  var releaseTask: ScheduledFuture[_] = null
+  var lastLockTime: Long = 0
+  var lockedBy: AccessibleExecutor = null
+
+  override def acquire(executor: AccessibleExecutor): Unit = {
+    lock.acquire()
+    lastLockTime = System.currentTimeMillis()
+    lockedBy = executor
+    scheduleTimeout
+  }
+
+  override def tryAcquire(executor: AccessibleExecutor): Boolean = {
+    if (null == executor) return false
+    val succeed = lock.tryAcquire()
+    debug("try to lock for succeed is  " + succeed.toString)
+    if (succeed) {
+      lastLockTime = System.currentTimeMillis()
+      lockedBy = executor
+      debug("try to lock for add time out task ! Locked by thread : " + lockedBy.getId)
+      scheduleTimeout
+    }
+    succeed
+  }
+
+  // Unlock callback is not called in release method, because release method is called actively
+  override def release(): Unit = {
+    debug("try to release for lock," + lockedBy + ",current thread " + Thread.currentThread().getName)
+    if (lockedBy != null) {
+      //&& lockedBy == Thread.currentThread()   Inconsistent thread(线程不一致)
+      debug("try to release for lockedBy and thread ")
+      if (releaseTask != null) {
+        releaseTask.cancel(true)
+        releaseTask = null
+        releaseScheduler.purge()
+      }
+      debug("try to release for lock release success")
+      lockedBy = null
+    }
+    resetLock()
+  }
+
+  private def resetLock(): Unit = {
+    lock.release()
+    lock = new Semaphore(1)
+  }
+
+  override def forceRelease(): Unit = {
+    if (isAcquired()) {
+      if (releaseTask != null) {
+        releaseTask.cancel(true)
+        releaseTask = null
+        releaseScheduler.purge()
+      }
+      lock.release()
+      lockedBy = null
+    }
+    resetLock()
+  }
+
+  private def scheduleTimeout: Unit = {
+    synchronized {
+      if (null == releaseTask || releaseTask.isDone) {
+        releaseTask = releaseScheduler.schedule(new Runnable {
+          override def run(): Unit = {
+            synchronized {
+              if (isExpired()) {
+                lock.release()
+                // unlockCallback depends on lockedBy, so lockedBy cannot be set null before unlockCallback
+                unlockCallback(lock.toString)
+                info(s"Lock : [${lock.toString} was released due to timeout." )
+                resetLock()
+              }
+            }
+          }
+        }, timeout, TimeUnit.MILLISECONDS)
+      }
+    }
+  }
+
+  override def isAcquired(): Boolean = {
+    lock.availablePermits() < 1
+  }
+
+  override def isExpired(): Boolean = {
+    if (lastLockTime == 0) return false
+    System.currentTimeMillis() - lastLockTime > timeout
+  }
+
+
+  override def numOfPending(): Int = {
+    lock.getQueueLength
+  }
+
+  override def renew(): Boolean = {
+    if (lockedBy != null && lockedBy == Thread.currentThread()) {
+      if (isAcquired && releaseTask != null) {
+        if (releaseTask.cancel(false)) {
+          releaseScheduler.purge()
+          scheduleTimeout
+          lastLockTime = System.currentTimeMillis()
+          return true
+        }
+      }
+    }
+    false
+  }
+
+  override def resetTimeout(timeout: Long): Unit = synchronized {
+    if (isAcquired()) {
+      if (null != releaseTask && !isExpired()) {
+        releaseTask.cancel(true)
+        this.timeout = timeout
+      }
+      scheduleTimeout
+    } else {
+      error("Lock is not acquired, so cannot be reset-Timeout")
+    }
+  }
+
+  private def unlockCallback(lockStr: String): Unit = {
+    if (null != lockedBy) {
+      lockedBy.transition(NodeStatus.Unlock)
+    }
+    ExecutorListenerBusContext.getExecutorListenerBusContext().getEngineConnAsyncListenerBus.post(ExecutorUnLockEvent(null, lockStr.toString))
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/lock/TimedLock.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/lock/TimedLock.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.lock
+
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity.AccessibleExecutor
+
+trait TimedLock {
+
+  @throws[Exception]
+  def acquire(executor: AccessibleExecutor): Unit
+
+  def tryAcquire(executor: AccessibleExecutor): Boolean
+
+  @throws[Exception]
+  def release(): Unit
+
+  @throws[Exception]
+  def forceRelease(): Unit
+
+  def numOfPending(): Int
+
+  def isAcquired(): Boolean
+
+  def isExpired(): Boolean
+
+  @throws[Exception]
+  def renew(): Boolean
+
+  def resetTimeout(timeout: Long): Unit
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/LogHelper.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/log/LogHelper.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.log
+
+import java.util
+
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf.AccessibleExecutorConfiguration
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.LogListener
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.TaskLogUpdateEvent
+import org.slf4j.LoggerFactory
+
+object LogHelper {
+  private val logger = LoggerFactory.getLogger(getClass)
+  val logCache = new MountLogCache(AccessibleExecutorConfiguration.ENGINECONN_LOG_CACHE_NUM.getValue)
+
+  private var logListener: LogListener = _
+
+  def setLogListener(logListener: LogListener): Unit = this.logListener = logListener
+
+  def pushAllRemainLogs(): Unit = {
+//    logger.info(s"start to push all remain logs")
+    Thread.sleep(30)
+    //logCache.synchronized{
+    if (logListener == null) {
+      logger.warn("logListener is null, can not push remain logs")
+      //return
+    } else {
+      var logs: util.List[String] = null
+      logCache.synchronized {
+        logs = logCache.getRemain
+      }
+      if (logs != null && logs.size > 0) {
+        val sb: StringBuilder = new StringBuilder
+        import scala.collection.JavaConversions._
+        logs map (log => log + "\n") foreach sb.append
+        logger.info(s"remain logs is ${sb.toString()}")
+        logListener.onLogUpdate(TaskLogUpdateEvent(null, sb.toString))
+      }
+    }
+    logger.info("end to push all remain logs")
+    // }
+    //    if (sendAppender == null){
+    //      logger.error("SendAppender has not been initialized")
+    //    }else{
+    //      val logCache = sendAppender.getLogCache
+    //      val logListener = SendAppender.getLogListener
+    //      logCache.synchronized{
+    //        val logs: util.List[String] = logCache.getRemain
+    //        if (logs.size > 0) {
+    //          val sb: StringBuilder = new StringBuilder
+    //          import scala.collection.JavaConversions._
+    //          logs map (log => log + "\n") foreach sb.append
+    //          logListener.onLogUpdate(null, sb.toString)
+    //        }
+    //      }
+    //    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/AccessibleService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/AccessibleService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.ExecutorStatusListener
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineSuicideRequest
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{RequestNodeStatus, ResponseNodeStatus}
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+
+trait AccessibleService extends ExecutorStatusListener {
+
+  def stopExecutor: Unit
+
+  def pauseExecutor: Unit
+
+  def reStartExecutor: Boolean
+
+  def dealEngineStopRequest(engineSuicideRequest: EngineSuicideRequest, smc: ServiceMethodContext): Unit
+
+
+  /**
+    * service 需要加定时任务判断Executor是否空闲很久，然后调用该方法进行释放
+    */
+  def requestManagerReleaseExecutor(msg: String): Unit
+
+
+  def dealRequestNodeStatus(requestNodeStatus: RequestNodeStatus): ResponseNodeStatus
+
+}
+

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/DefaultAccessibleService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/DefaultAccessibleService.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf.AccessibleExecutorConfiguration
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity.AccessibleExecutor
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.{ExecutorCompletedEvent, ExecutorCreateEvent, ExecutorStatusChangedEvent}
+import com.webank.wedatasphere.linkis.engineconn.core.EngineConnObject
+import com.webank.wedatasphere.linkis.engineconn.core.engineconn.EngineConnManager
+import com.webank.wedatasphere.linkis.engineconn.core.executor.ExecutorManager
+import com.webank.wedatasphere.linkis.engineconn.core.hook.ShutdownHook
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.{Executor, SensibleExecutor}
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext
+import com.webank.wedatasphere.linkis.engineconn.executor.service.ManagerService
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineConnReleaseRequest, EngineSuicideRequest}
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{RequestNodeStatus, ResponseNodeStatus}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.rpc.Sender
+import javax.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConverters._
+
+
+@Service
+class DefaultAccessibleService extends AccessibleService with Logging {
+
+  @Autowired
+  private var executorHeartbeatService: ExecutorHeartbeatService = _
+
+  private val asyncListenerBusContext = ExecutorListenerBusContext.getExecutorListenerBusContext.getEngineConnAsyncListenerBus
+
+  @Receiver
+  override def dealEngineStopRequest(engineSuicideRequest: EngineSuicideRequest, smc: ServiceMethodContext): Unit = {
+    // todo check user
+    if (DataWorkCloudApplication.getServiceInstance.equals(engineSuicideRequest.getServiceInstance)) {
+      stopEngine()
+      info(s"engine will suiside now.")
+      ShutdownHook.getShutdownHook.notifyStop()
+    } else {
+      if (null != engineSuicideRequest.getServiceInstance) {
+        error(s"Invalid serviceInstance : ${engineSuicideRequest.getServiceInstance.toString}, will not suicide.")
+      } else {
+        error("Invalid empty serviceInstance.")
+      }
+    }
+  }
+
+  private def executorShutDownHook(): Unit = {
+    var executor: Executor = ExecutorManager.getInstance().getDefaultExecutor
+    if (null != executor) {
+      executor.asInstanceOf[SensibleExecutor].transition(NodeStatus.ShuttingDown)
+    } else {
+      executor = SensibleExecutor.getDefaultErrorSensibleExecutor()
+    }
+    executorHeartbeatService.reportHeartBeatMsg(executor)
+    info("Reported status shuttingDown to manager.")
+  }
+
+  override def stopExecutor: Unit = {
+    // todo
+  }
+
+
+  override def pauseExecutor: Unit = {
+
+  }
+
+  override def reStartExecutor: Boolean = {
+    true
+  }
+
+  /**
+    * Service启动后则启动定时任务 空闲释放
+    */
+  @PostConstruct
+  private def init(): Unit = {
+    val context = EngineConnObject.getEngineCreationContext
+    val maxFreeTimeVar = AccessibleExecutorConfiguration.ENGINECONN_MAX_FREE_TIME.getValue(context.getOptions)
+    val maxFreeTimeStr = maxFreeTimeVar.toString
+    val maxFreeTime = maxFreeTimeVar.toLong
+    Utils.defaultScheduler.scheduleAtFixedRate(new Runnable {
+      override def run(): Unit = Utils.tryAndWarn {
+        val executor = ExecutorManager.getInstance().getDefaultExecutor
+        if (null == executor || !executor.isInstanceOf[AccessibleExecutor]) {
+          warn("Default is not AccessibleExecutor,do noting")
+          return
+        }
+        info("maxFreeTimeMills is " + maxFreeTime)
+        val accessibleExecutor = ExecutorManager.getInstance().getDefaultExecutor.asInstanceOf[AccessibleExecutor]
+        if (NodeStatus.isCompleted(accessibleExecutor.getStatus)) {
+          error(s"${accessibleExecutor.getId()} has completed with status ${accessibleExecutor.getStatus}, now stop it.")
+          ShutdownHook.getShutdownHook.notifyStop()
+        } else if (accessibleExecutor.getStatus == NodeStatus.ShuttingDown) {
+          warn(s"${accessibleExecutor.getId()} is ShuttingDown...")
+          ShutdownHook.getShutdownHook.notifyStop()
+        } else if (maxFreeTime > 0 && NodeStatus.isIdle(accessibleExecutor.getStatus) && System.currentTimeMillis - accessibleExecutor.getLastActivityTime > maxFreeTime) {
+          warn(s"${accessibleExecutor.getId()} has not been used for $maxFreeTimeStr, now try to shutdown it.")
+          requestManagerReleaseExecutor(" idle release")
+        }
+      }
+    }, 10 * 60 * 1000, AccessibleExecutorConfiguration.ENGINECONN_HEARTBEAT_TIME.getValue.toLong, TimeUnit.MILLISECONDS)
+    asyncListenerBusContext.addListener(this)
+    Utils.addShutdownHook(executorShutDownHook())
+  }
+
+  private def stopEngine(): Unit = {
+    Utils.tryAndWarn {
+      ExecutorManager.getInstance().getDefaultExecutor.asInstanceOf[SensibleExecutor].transition(NodeStatus.ShuttingDown)
+      val executors = ExecutorManager.getInstance().getAllExecutorsMap()
+      executors.asScala.map{
+        kv => kv._2.tryShutdown()
+      }
+      executors.clear()
+    }
+  }
+
+  /**
+    * service 需要加定时任务判断Executor是否空闲很久，然后调用该方法进行释放
+    */
+
+  override def requestManagerReleaseExecutor(msg: String): Unit = {
+    val engineReleaseRequest = new EngineConnReleaseRequest(Sender.getThisServiceInstance, Utils.getJvmUser, msg, EngineConnManager.getEngineConnManager.getEngineConn().getEngineCreationContext.getTicketId)
+    ManagerService.getManagerService.requestReleaseEngineConn(engineReleaseRequest)
+  }
+
+  @Receiver
+  override def dealRequestNodeStatus(requestNodeStatus: RequestNodeStatus): ResponseNodeStatus = {
+    val status = ExecutorManager.getInstance().getDefaultExecutor match {
+      case executor: SensibleExecutor =>
+        executor.getStatus
+      case _ => NodeStatus.Starting
+    }
+    val responseNodeStatus = new ResponseNodeStatus
+    responseNodeStatus.setNodeStatus(status)
+    responseNodeStatus
+  }
+
+  override def onExecutorCreated(executorCreateEvent: ExecutorCreateEvent): Unit = {
+
+  }
+
+  override def onExecutorCompleted(executorCompletedEvent: ExecutorCompletedEvent): Unit = {
+
+  }
+
+  override def onExecutorStatusChanged(executorStatusChangedEvent: ExecutorStatusChangedEvent): Unit = {
+    if (!ExecutorManager.getInstance().getDefaultExecutor.isInstanceOf[AccessibleExecutor]) {
+      warn("Default is not AccessibleExecutor,do noting")
+      return
+    }
+    val executor = ExecutorManager.getInstance().getDefaultExecutor.asInstanceOf[AccessibleExecutor]
+    executorHeartbeatService.reportHeartBeatMsg(executor)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/DefaultExecutorHeartbeatService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/DefaultExecutorHeartbeatService.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf.AccessibleExecutorConfiguration
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.info.{NodeHealthyInfoManager, NodeHeartbeatMsgManager, NodeOverLoadInfoManager}
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.NodeHealthyListener
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.NodeHealthyUpdateEvent
+import com.webank.wedatasphere.linkis.engineconn.core.executor.ExecutorManager
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.{Executor, ResourceExecutor, SensibleExecutor}
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext
+import com.webank.wedatasphere.linkis.engineconn.executor.service.ManagerService
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{NodeHeartbeatMsg, NodeHeartbeatRequest}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.rpc.Sender
+import javax.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultExecutorHeartbeatService extends ExecutorHeartbeatService with NodeHealthyListener with Logging {
+
+
+  @Autowired
+  private var nodeHealthyInfoManager: NodeHealthyInfoManager = _
+
+  @Autowired
+  private var nodeOverLoadInfoManager: NodeOverLoadInfoManager = _
+
+  @Autowired(required = false)
+  private var nodeHeartbeatMsgManager: NodeHeartbeatMsgManager = _
+
+  private val asyncListenerBusContext = ExecutorListenerBusContext.getExecutorListenerBusContext.getEngineConnAsyncListenerBus
+
+  @PostConstruct
+  private def init(): Unit = {
+    asyncListenerBusContext.addListener(this)
+    val heartbeatTime = AccessibleExecutorConfiguration.ENGINECONN_HEARTBEAT_TIME.getValue.toLong
+    Utils.defaultScheduler.scheduleAtFixedRate(new Runnable {
+      override def run(): Unit = Utils.tryAndWarn {
+        val executor = ExecutorManager.getInstance().getDefaultExecutor
+        reportHeartBeatMsg(executor)
+      }
+    }, 3 * 60 * 1000, heartbeatTime, TimeUnit.MILLISECONDS)
+  }
+
+  /**
+    * 定时上报心跳信息，依据Executor不同进行实现
+    *
+    * @param executor
+    */
+  override def reportHeartBeatMsg(executor: Executor): Unit = {
+    ManagerService.getManagerService.heartbeatReport(generateHeartBeatMsg(executor))
+  }
+
+
+  @Receiver
+  override def dealNodeHeartbeatRequest(nodeHeartbeatRequest: NodeHeartbeatRequest): NodeHeartbeatMsg = {
+    val executor = ExecutorManager.getInstance().getDefaultExecutor
+    generateHeartBeatMsg(executor)
+  }
+
+
+  override def onNodeHealthyUpdate(nodeHealthyUpdateEvent: NodeHealthyUpdateEvent): Unit = {
+    warn(s"node healthy update, tiger heartbeatReport")
+    val executor = ExecutorManager.getInstance().getDefaultExecutor
+    reportHeartBeatMsg(executor)
+  }
+
+  override def generateHeartBeatMsg(executor: Executor): NodeHeartbeatMsg = {
+    val nodeHeartbeatMsg = new NodeHeartbeatMsg
+
+    nodeHeartbeatMsg.setServiceInstance(Sender.getThisServiceInstance)
+    nodeHeartbeatMsg.setOverLoadInfo(nodeOverLoadInfoManager.getNodeOverLoadInfo)
+    nodeHeartbeatMsg.setHealthyInfo(nodeHealthyInfoManager.getNodeHealthyInfo())
+    executor match {
+      case sensibleExecutor: SensibleExecutor =>
+        nodeHeartbeatMsg.setStatus(sensibleExecutor.getStatus)
+      case _ =>
+    }
+    executor match {
+      case resourceExecutor: ResourceExecutor =>
+        nodeHeartbeatMsg.setNodeResource(resourceExecutor.getCurrentNodeResource())
+      case _ =>
+    }
+    if (null != nodeHeartbeatMsgManager) {
+      nodeHeartbeatMsg.setHeartBeatMsg(nodeHeartbeatMsgManager.getHeartBeatMsg())
+    }
+    nodeHeartbeatMsg
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/DefaultManagerService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/DefaultManagerService.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import java.util
+
+import com.webank.wedatasphere.linkis.engineconn.executor.service.ManagerService
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnReleaseRequest
+import com.webank.wedatasphere.linkis.manager.common.protocol.label.LabelReportRequest
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{NodeHeartbeatMsg, ResponseNodeStatus}
+import com.webank.wedatasphere.linkis.manager.common.protocol.resource.ResourceUsedProtocol
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+class DefaultManagerService extends ManagerService {
+
+
+  protected def getManagerSender: Sender = {
+    Sender.getSender(GovernanceCommonConf.MANAGER_SPRING_NAME.getValue)
+  }
+
+  protected def getEngineConnManagerSender: Sender = {
+    Sender.getSender(GovernanceCommonConf.ENGINE_CONN_MANAGER_SPRING_NAME.getValue)
+  }
+
+
+  override def labelReport(labels: util.List[Label[_]]): Unit = {
+    val labelReportRequest = LabelReportRequest(labels, Sender.getThisServiceInstance)
+    getManagerSender.send(labelReportRequest)
+  }
+
+
+  override def statusReport(status: NodeStatus): Unit = {
+    val responseNodeStatus = new ResponseNodeStatus
+    responseNodeStatus.setNodeStatus(status)
+    getManagerSender.send(responseNodeStatus)
+  }
+
+  override def requestReleaseEngineConn(engineConnReleaseRequest: EngineConnReleaseRequest): Unit = {
+    getManagerSender.send(engineConnReleaseRequest)
+  }
+
+  override def heartbeatReport(nodeHeartbeatMsg: NodeHeartbeatMsg): Unit = {
+    getManagerSender.send(nodeHeartbeatMsg)
+  }
+
+  override def reportUsedResource(resourceUsedProtocol: ResourceUsedProtocol): Unit = {
+    getManagerSender.send(resourceUsedProtocol)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/EngineConnTimedLockService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/EngineConnTimedLockService.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.conf.AccessibleExecutorConfiguration
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity.AccessibleExecutor
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.event.{ExecutorLockEvent, ExecutorUnLockEvent}
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.lock.EngineConnTimedLock
+import com.webank.wedatasphere.linkis.engineconn.core.executor.ExecutorManager
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.ExecutorListenerBusContext
+import com.webank.wedatasphere.linkis.governance.common.exception.engineconn.{EngineConnExecutorErrorCode, EngineConnExecutorErrorException}
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineLockType
+import com.webank.wedatasphere.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock, ResponseEngineLock, ResponseEngineUnlock}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.server.BDPJettyServerHelper
+import org.apache.commons.lang.StringUtils
+
+
+class EngineConnTimedLockService extends LockService with Logging {
+
+  private var engineConnLock: EngineConnTimedLock = null
+  private var lockString: String = null
+  private var lockType: EngineLockType = EngineLockType.Timed
+
+
+  private def isSupportParallelism: Boolean = AccessibleExecutorConfiguration.ENGINECONN_SUPPORT_PARALLELISM.getValue
+
+  /**
+    *
+    *
+    * @param lock
+    * @return
+    */
+  override def isLockExist(lock: String = null): Boolean = synchronized {
+    if (isSupportParallelism) true
+    else if (null != engineConnLock && engineConnLock.isAcquired()) {
+      if (StringUtils.isNotBlank(lock)) {
+        if (lock.equals(lockString)) true
+        else false
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+
+  }
+
+  /**
+    * Try to lock an Executor in the ExecutorManager. If the lock is successful, it will return the Executor ID as the ID.
+    * 尝试去锁住ExecutorManager里的一个Executor，如果锁成功的话，将返回Executor ID作为标识
+    *
+    * @return
+    */
+  @throws[EngineConnExecutorErrorException]
+  override def tryLock(requestEngineLock: RequestEngineLock): Option[String] = synchronized {
+    if (null != engineConnLock && engineConnLock.isAcquired()) return None
+    this.lockType = requestEngineLock.lockType
+    lockType match {
+      case EngineLockType.Always =>
+        timedLock(-1)
+      case EngineLockType.Timed =>
+        timedLock(requestEngineLock.timeout)
+      case o: Any =>
+        error("Invalid lockType : " + BDPJettyServerHelper.gson.toJson(o))
+        return Some(null)
+    }
+
+  }
+
+  private def timedLock(timeout: Long): Option[String] = {
+
+    // Lock is binded to engineconn, so choose default executor
+    ExecutorManager.getInstance().getDefaultExecutor match {
+      case accessibleExecutor: AccessibleExecutor =>
+        debug("try to lock for executor state is " + accessibleExecutor.getStatus)
+        debug("try to lock for executor id is " + accessibleExecutor.getId)
+        if (null == engineConnLock) {
+          engineConnLock = new EngineConnTimedLock(timeout)
+          debug("try to lock for executor get new lock " + engineConnLock)
+        }
+        if (engineConnLock.tryAcquire(accessibleExecutor)) {
+          debug("try to lock for tryAcquire is true ")
+          this.lockString = engineConnLock.lock.toString
+          ExecutorListenerBusContext.getExecutorListenerBusContext().getEngineConnAsyncListenerBus.post(ExecutorLockEvent(accessibleExecutor, lockString))
+          accessibleExecutor.transition(NodeStatus.Idle)
+          Some(lockString)
+        } else None
+      case _ =>
+        val msg = s"Invalid executor or not instance of SensibleEngine."
+        error(msg)
+        throw new EngineConnExecutorErrorException(EngineConnExecutorErrorCode.INVALID_ENGINE_TYPE, msg)
+    }
+  }
+
+  /**
+    * Unlock(解锁)
+    *
+    * @param lock
+    */
+  override def unlock(lock: String): Boolean = synchronized {
+    info("try to unlock for lockEntity is " + engineConnLock.toString + ",and lock is " + lock + ",acquired is " + engineConnLock.isAcquired().toString)
+    if (isLockExist(lock)) {
+      info(s"try to unlock lockEntity : lockString=${lockString},lockedBy=${engineConnLock.lockedBy.getId()}")
+      engineConnLock.release()
+      this.lockString = null
+    ExecutorListenerBusContext.getExecutorListenerBusContext().getEngineConnAsyncListenerBus.post(ExecutorUnLockEvent(null, lock))
+    ExecutorManager.getInstance().getDefaultExecutor match {
+      case accessibleExecutor: AccessibleExecutor =>
+        accessibleExecutor.transition(NodeStatus.Unlock)
+      case _ =>
+        val msg = s"Invalid executor or not instance of SensibleEngine."
+        error(msg)
+      }
+      true
+    } else {
+      false
+    }
+  }
+
+  @Receiver
+  override def requestUnLock(requestEngineUnlock: RequestEngineUnlock): ResponseEngineUnlock = {
+    if (StringUtils.isBlank(requestEngineUnlock.lock)) {
+      error("Invalid requestEngineUnlock: ")
+      ResponseEngineUnlock(false)
+    } else {
+      ResponseEngineUnlock(unlock(requestEngineUnlock.lock))
+    }
+  }
+
+  override def onAddLock(addLockEvent: ExecutorLockEvent): Unit = {
+
+  }
+
+  override def onReleaseLock(releaseLockEvent: ExecutorUnLockEvent): Unit = {
+
+  }
+
+
+  @Receiver
+  override def requestLock(requestEngineLock: RequestEngineLock): ResponseEngineLock = {
+    super.requestLock(requestEngineLock)
+  }
+}
+
+class EngineConnConcurrentLockService extends LockService {
+
+  override def isLockExist(lock: String): Boolean = true
+
+  override def tryLock(requestEngineLock: RequestEngineLock): Option[String] = {
+    /*ExecutorManager.getInstance().getDefaultExecutor match {
+      case accessibleExecutor: AccessibleExecutor =>
+        // Concurrent Engine don't change status when get lock, status will change in other rules
+//        accessibleExecutor.transition(NodeStatus.Idle)
+      case _ =>
+    }*/
+    Some("lock")
+  }
+
+  /**
+    * Unlock(解锁)
+    *
+    * @param lock
+    */
+  override def unlock(lock: String): Boolean = {
+    /*ExecutorManager.getInstance().getDefaultExecutor match {
+      case accessibleExecutor: AccessibleExecutor =>
+        accessibleExecutor.transition(NodeStatus.Unlock)
+      case _ =>
+    }*/
+    true
+  }
+
+  @Receiver
+  override def requestUnLock(requestEngineUnlock: RequestEngineUnlock): ResponseEngineUnlock = ResponseEngineUnlock(true)
+
+  override def onAddLock(addLockEvent: ExecutorLockEvent): Unit = {}
+
+  override def onReleaseLock(releaseLockEvent: ExecutorUnLockEvent): Unit = {}
+
+  @Receiver
+  override def requestLock(requestEngineLock: RequestEngineLock): ResponseEngineLock = {
+    super.requestLock(requestEngineLock)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/ExecutorHeartbeatService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/ExecutorHeartbeatService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.{NodeHeartbeatMsg, NodeHeartbeatRequest}
+
+trait ExecutorHeartbeatService {
+
+  /**
+    * 定时上报心跳信息，依据Executor不同进行实现
+    *
+    * @param executor
+    */
+  def reportHeartBeatMsg(executor: Executor): Unit
+
+  def generateHeartBeatMsg(executor: Executor): NodeHeartbeatMsg
+
+
+  def dealNodeHeartbeatRequest(nodeHeartbeatRequest: NodeHeartbeatRequest): NodeHeartbeatMsg
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/LockService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/LockService.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.listener.ExecutorLockListener
+import com.webank.wedatasphere.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock, ResponseEngineLock, ResponseEngineUnlock}
+import com.webank.wedatasphere.linkis.server.BDPJettyServerHelper
+import org.apache.commons.lang.StringUtils
+
+trait LockService extends ExecutorLockListener with Logging {
+
+  def isLockExist(lock: String): Boolean
+
+  def tryLock(requestEngineLock: RequestEngineLock): Option[String]
+
+  /**
+    * Unlock(解锁)
+    *
+    * @param lock
+    */
+  def unlock(lock: String): Boolean
+
+  def requestLock(requestEngineLock: RequestEngineLock): ResponseEngineLock = {
+    var response: ResponseEngineLock = null
+    tryLock(requestEngineLock) match {
+      case Some(lockStr) =>
+        // Engine can be locked
+        if (!StringUtils.isBlank(lockStr)) {
+          // lock success
+          response = ResponseEngineLock(true, lockStr, s"Lock for ${requestEngineLock.timeout} ms")
+        } else {
+          // lock failed
+          response = ResponseEngineLock(false, lockStr, "lock str is blank")
+        }
+      case None =>
+        // Engine is busy
+        response = ResponseEngineLock(false, null, "Engine is busy.")
+    }
+    info ("RequestLock : " + BDPJettyServerHelper.gson.toJson(requestEngineLock) + "\nResponseLock : " + BDPJettyServerHelper.gson.toJson(response))
+    response
+  }
+
+  def requestUnLock(requestEngineUnlock: RequestEngineUnlock): ResponseEngineUnlock
+
+}
+

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/LogService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/service/LogService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.service
+
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.log.LogCache
+
+trait LogService {
+
+
+  def getLogCache(): LogCache
+
+  def sendLog(): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/utils/AccessableExecutorUtils.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/com/webank/wedatasphere/linkis/engineconn/acessible/executor/utils/AccessableExecutorUtils.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.acessible.executor.utils
+
+object AccessibleExecutorUtils {
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-callback-service</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-executor-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnAfterStartCallback.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnAfterStartCallback.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.callback.service
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+
+class EngineConnAfterStartCallback(emInstance: ServiceInstance) extends AbstractEngineConnStartUpCallback(emInstance) {
+
+  override def callback(): Unit = {
+
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnCallback.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnCallback.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.callback.service
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+trait EngineConnCallback {
+
+  protected def getEMSender: Sender
+
+  def callback(): Unit
+
+}
+
+abstract class AbstractEngineConnStartUpCallback(emInstance: ServiceInstance) extends EngineConnCallback {
+
+  override protected def getEMSender: Sender = {
+    Sender.getSender(emInstance)
+  }
+
+
+  def callback(protocol: RequestProtocol): Unit = {
+    getEMSender.send(protocol)
+  }
+}
+

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnPidCallback.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnPidCallback.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.callback.service
+
+import java.lang.management.ManagementFactory
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.engineconn.core.EngineConnObject
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.ResponseEngineConnPid
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+
+class EngineConnPidCallback(emInstance: ServiceInstance) extends AbstractEngineConnStartUpCallback(emInstance) {
+
+  override def callback(): Unit = {
+    val pid = ManagementFactory.getRuntimeMXBean.getName.split("@")(0)
+    val instance = Sender.getThisServiceInstance
+    val context = EngineConnObject.getEngineCreationContext
+    callback(ResponseEngineConnPid(instance, pid, context.getTicketId))
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnTimedCallback.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/callback-service/src/main/scala/com/webank/wedatasphere/linkis/engineconn/callback/service/EngineConnTimedCallback.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.callback.service
+
+/**
+  *  常规callBack
+  */
+trait EngineConnTimedCallback extends EngineConnCallback {
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-executor-core</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-protocol</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/conf/EngineConnExecutorConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/conf/EngineConnExecutorConfiguration.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+
+object EngineConnExecutorConfiguration {
+
+
+  val TMP_PATH = CommonVars("wds.linkis.dataworkclod.engine.tmp.path", "file:///tmp/")
+
+  val ENGINE_SPRING_APPLICATION_NAME = CommonVars("wds.linkis.engine.application.name", "")
+
+  val ENGINE_LOG_PREFIX = CommonVars("wds.linkis.log4j2.prefix", "/appcom/logs/linkis/" + ENGINE_SPRING_APPLICATION_NAME.getValue)
+
+  val CLEAR_LOG = CommonVars("wds.linkis.log.clear", false)
+
+
+  val ENGINE_IGNORE_WORDS = CommonVars("wds.linkis.engine.ignore.words", "org.apache.spark.deploy.yarn.Client")
+
+  val ENGINE_PASS_WORDS = CommonVars("wds.linkis.engine.pass.words", "org.apache.hadoop.hive.ql.exec.Task")
+
+
+
+
+  val ENTRANCE_SPRING_APPLICATION_NAME = CommonVars("wds.linkis.entrance.application.name", "linkis-cg-entrance")
+
+  val ENGINE_SERVER_LISTENER_ASYNC_QUEUE_CAPACITY = CommonVars("wds.linkis.engine.listener.async.queue.size.max", 300)
+
+  val ENGINE_SERVER_LISTENER_ASYNC_CONSUMER_THREAD_MAX = CommonVars("wds.linkis.engine.listener.async.consumer.thread.max", 5)
+
+  val ENGINE_SERVER_LISTENER_ASYNC_CONSUMER_THREAD_FREE_TIME_MAX = CommonVars("wds.linkis.engine.listener.async.consumer.freetime.max", new TimeType("5000ms"))
+
+  // todo better to rename
+  val EXECUTOR_MANAGER_SERVICE_CLAZZ = CommonVars("wds.linkis.engineconn.executor.manager.service.clazz", "com.webank.wedatasphere.linkis.engineconn.acessible.executor.service.DefaultManagerService")
+
+  /*val EXECUTOR_MANAGER_CLAZZ = CommonVars("wds.linkis.engineconn.executor.manager.claazz", "")*/
+
+  val DEFAULT_EXECUTOR_NAME = CommonVars("wds.linkis.engineconn.executor.default.name", "ComputationExecutor")
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/Executor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/Executor.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.entity
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+
+trait Executor extends Logging {
+
+  def getId(): String
+
+  def init(): Unit
+
+  def tryReady(): Boolean
+
+  def tryShutdown(): Boolean
+
+  def tryFailed(): Boolean
+
+  /**
+    * 仅用于Kill Executor
+    * EngineConn kill 在AccessibleService
+    */
+  def close(): Unit = {
+    warn(s"executor ${getId()} exit by close")
+  }
+
+  def isClosed(): Boolean
+
+}
+
+trait ConcurrentExecutor extends Executor {
+
+  def getConcurrentLimit: Int
+
+  def killAll(): Unit
+
+}
+

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/LabelExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/LabelExecutor.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.entity
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+trait LabelExecutor extends Executor {
+
+  def getExecutorLabels(): util.List[Label[_]]
+
+  def setExecutorLabels(labels: util.List[Label[_]]): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/ResourceExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/ResourceExecutor.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.entity
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+
+trait ResourceExecutor extends Executor {
+
+
+  def requestExpectedResource(expectedResource: NodeResource): NodeResource
+
+  def getCurrentNodeResource(): NodeResource
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/SensibleExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/SensibleExecutor.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.entity
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+
+import scala.beans.BeanProperty
+
+trait SensibleExecutor extends Executor {
+
+  protected var status: NodeStatus = NodeStatus.Starting
+
+  @BeanProperty
+  var lastActivityTime = System.currentTimeMillis
+
+  def getStatus: NodeStatus = status
+
+  protected def onStatusChanged(fromStatus: NodeStatus, toStatus: NodeStatus): Unit
+
+  def transition(toStatus: NodeStatus) = this synchronized {
+    lastActivityTime = System.currentTimeMillis
+    this.status match {
+      case NodeStatus.Failed | NodeStatus.Success =>
+        warn(s"$toString attempt to change status ${this.status} => $toStatus, ignore it.")
+      case NodeStatus.ShuttingDown =>
+        toStatus match {
+          case NodeStatus.Failed | NodeStatus.Success =>
+            val oldState = status
+            this.status = toStatus
+            onStatusChanged(oldState, toStatus)
+          case _ => warn(s"$toString attempt to change a Executor.ShuttingDown session to $toStatus, ignore it.")
+        }
+      case _ =>
+
+    }
+    info(s"$toString change status ${status} => $toStatus.")
+    val oldState = status
+    this.status = toStatus
+    onStatusChanged(oldState, toStatus)
+  }
+
+}
+
+object SensibleExecutor {
+
+  lazy val defaultErrorSensibleExecutor: SensibleExecutor = new SensibleExecutor {
+    override def getStatus: NodeStatus = NodeStatus.ShuttingDown
+
+    override protected def onStatusChanged(fromStatus: NodeStatus, toStatus: NodeStatus): Unit = {}
+
+    override def getId(): String = "0"
+
+    override def init(): Unit = {}
+
+    override def tryReady(): Boolean = false
+
+    override def tryShutdown(): Boolean = true
+
+    override def tryFailed(): Boolean = true
+
+    override def isClosed(): Boolean = true
+  }
+
+  def getDefaultErrorSensibleExecutor(): SensibleExecutor = defaultErrorSensibleExecutor
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/YarnExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/entity/YarnExecutor.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.entity
+
+import scala.beans.BeanProperty
+
+trait YarnExecutor extends Executor {
+
+  @BeanProperty
+  var applicationId: String
+
+  @BeanProperty
+  var applicationURL: String
+
+  @BeanProperty
+  var yarnMode: String
+
+  @BeanProperty
+  var queue: String
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnAsyncListener.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnAsyncListener.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.EventListener
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnAsyncEvent
+
+trait EngineConnAsyncListener extends EventListener {
+
+  def onEvent(event: EngineConnAsyncEvent): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnAsyncListenerBus.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnAsyncListenerBus.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.ListenerEventBus
+import com.webank.wedatasphere.linkis.engineconn.executor.conf.EngineConnExecutorConfiguration
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnAsyncEvent
+
+class EngineConnAsyncListenerBus(eventQueueCapacity: Int, name: String,
+                                 listenerConsumerThreadSize: Int,
+                                 listenerThreadMaxFreeTime: Long)
+  extends ListenerEventBus[EngineConnAsyncListener, EngineConnAsyncEvent](eventQueueCapacity, name)(listenerConsumerThreadSize, listenerThreadMaxFreeTime) {
+
+  /**
+    * Post an event to the specified listener. `onPostEvent` is guaranteed to be called in the same
+    * thread for all listeners.
+    */
+  override protected def doPostEvent(listener: EngineConnAsyncListener, event: EngineConnAsyncEvent): Unit = {
+    listener.onEvent(event)
+  }
+
+}
+
+object EngineConnAsyncListenerBus {
+
+  def NAME: String = "EngineServerAsyncListenerBus"
+
+  lazy val getInstance = new EngineConnAsyncListenerBus(
+    EngineConnExecutorConfiguration.ENGINE_SERVER_LISTENER_ASYNC_QUEUE_CAPACITY.getValue,
+    NAME,
+    EngineConnExecutorConfiguration.ENGINE_SERVER_LISTENER_ASYNC_CONSUMER_THREAD_MAX.getValue,
+    EngineConnExecutorConfiguration.ENGINE_SERVER_LISTENER_ASYNC_CONSUMER_THREAD_FREE_TIME_MAX.getValue.toLong)
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnSyncListener.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnSyncListener.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.EventListener
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnSyncEvent
+
+trait EngineConnSyncListener extends EventListener {
+
+  def onEvent(event: EngineConnSyncEvent): Unit
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnSyncListenerBus.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/EngineConnSyncListenerBus.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener
+
+import com.webank.wedatasphere.linkis.common.listener.ListenerBus
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.executor.listener.event.EngineConnSyncEvent
+
+class EngineConnSyncListenerBus extends ListenerBus[EngineConnSyncListener, EngineConnSyncEvent] with Logging {
+
+  /**
+    * Post an event to the specified listener. `onPostEvent` is guaranteed to be called in the same
+    * thread for all listeners.
+    */
+  override protected def doPostEvent(listener: EngineConnSyncListener, event: EngineConnSyncEvent): Unit = {
+    debug(s"$listener start to deal event $event")
+    listener.onEvent(event)
+    debug(s"$listener Finished  to deal event $event")
+  }
+}
+
+object EngineConnSyncListenerBus {
+
+  def NAME: String = "EngineServerSyncListenerBus"
+
+  lazy val getInstance = new EngineConnSyncListenerBus()
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/ExecutorListenerBusContext.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/ExecutorListenerBusContext.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener
+
+import com.webank.wedatasphere.linkis.engineconn.executor.conf.EngineConnExecutorConfiguration
+
+class ExecutorListenerBusContext {
+
+  private val engineConnAsyncListenerBus: EngineConnAsyncListenerBus = new EngineConnAsyncListenerBus(
+    EngineConnExecutorConfiguration.ENGINE_SERVER_LISTENER_ASYNC_QUEUE_CAPACITY.getValue,
+    "EngineConn-Asyn-Thread",
+    EngineConnExecutorConfiguration.ENGINE_SERVER_LISTENER_ASYNC_CONSUMER_THREAD_MAX.getValue,
+    EngineConnExecutorConfiguration.ENGINE_SERVER_LISTENER_ASYNC_CONSUMER_THREAD_FREE_TIME_MAX.getValue.toLong
+  )
+
+  private val engineConnSyncListenerBus: EngineConnSyncListenerBus = new EngineConnSyncListenerBus
+
+  def getEngineConnAsyncListenerBus: EngineConnAsyncListenerBus = {
+    engineConnAsyncListenerBus
+  }
+
+  def getEngineConnSyncListenerBus: EngineConnSyncListenerBus = engineConnSyncListenerBus
+
+}
+
+object ExecutorListenerBusContext {
+
+  private val executorListenerBusContext = new ExecutorListenerBusContext
+
+  def getExecutorListenerBusContext() = executorListenerBusContext
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/event/EngineConnAsyncEvent.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/event/EngineConnAsyncEvent.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener.event
+
+import com.webank.wedatasphere.linkis.common.listener.Event
+
+trait EngineConnAsyncEvent extends Event {
+
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/event/EngineConnSyncEvent.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/listener/event/EngineConnSyncEvent.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.listener.event
+
+import com.webank.wedatasphere.linkis.common.listener.Event
+
+trait EngineConnSyncEvent extends Event {
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/service/LabelService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/service/LabelService.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.service
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+trait LabelService {
+
+  /*def labelUpdate(labelUpdateRequest: LabelUpdateRequest): Unit*/
+
+  def labelReport(labels: util.List[Label[_]], executor: Executor): Unit
+
+}
+
+class DefaultLabelService extends LabelService with Logging {
+
+
+  /*override def labelUpdate(labelUpdateRequest: LabelUpdateRequest): Unit = ???*/
+
+  override def labelReport(labels: util.List[Label[_]], executor: Executor): Unit = {
+    info(s"executor ${executor.getId()} prepare to report Labels ")
+    ManagerService.getManagerService.labelReport(labels)
+    info(s"executor ${executor.getId()} end to report Labels ")
+  }
+
+
+}
+
+object LabelService {
+
+  private val labelService = new DefaultLabelService
+
+  def getLabelService: LabelService = this.labelService
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/service/ManagerService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/com/webank/wedatasphere/linkis/engineconn/executor/service/ManagerService.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.executor.service
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.engineconn.executor.conf.EngineConnExecutorConfiguration
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnReleaseRequest
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.NodeHeartbeatMsg
+import com.webank.wedatasphere.linkis.manager.common.protocol.resource.ResourceUsedProtocol
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+trait ManagerService {
+
+  def labelReport(labels: java.util.List[Label[_]]): Unit
+
+  def statusReport(status: NodeStatus): Unit
+
+  def requestReleaseEngineConn(engineConnReleaseRequest: EngineConnReleaseRequest): Unit
+
+  def heartbeatReport(nodeHeartbeatMsg: NodeHeartbeatMsg): Unit
+
+  def reportUsedResource(resourceUsedProtocol: ResourceUsedProtocol): Unit
+
+}
+
+object ManagerService {
+
+  private val managerService: ManagerService = Utils.getClassInstance[ManagerService](EngineConnExecutorConfiguration.EXECUTOR_MANAGER_SERVICE_CLAZZ.getValue)
+
+  def getManagerService = managerService
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/resource-executor/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/resource-executor/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-resource-executor</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-executor-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>


### PR DESCRIPTION
### What is the purpose of the change
Related issues: #577  
This module splits the EngineReceiver of Linkis0.x into multiple services, and decouples the service and listener. These services are scattered into multiple exeuctor modules, which are freely selected by specific types of engines according to needs, and the details of each are as follows:

### Brief change log

1. The core module of executor, including the entity class of excutor and the top-level abstract interface, and the basic service of LabelService.
2. Accessable-executor module, including lock and heartbeat services.
3. The resource-executor module, including resource management services.
4. Callback-service module, including callback AM and EM services.