### PR TITLE
Add the ability of microservice tagging, and support the tagging of each microservice

### DIFF
--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/pom.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>instance-label-client</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>**/*.properties</exclude>
+                    <exclude>**/application.yml</exclude>
+                    <exclude>**/bootstrap.yml</exclude>
+                    <exclude>**/log4j2.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+
+
+</project>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/com/webank/wedatasphere/linkis/instance/label/client/EurekaInstanceLabelClient.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/com/webank/wedatasphere/linkis/instance/label/client/EurekaInstanceLabelClient.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.client
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.protocol.label.{InsLabelAttachRequest, InsLabelRemoveRequest}
+import com.webank.wedatasphere.linkis.rpc.Sender
+import javax.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cloud.client.serviceregistry.Registration
+import org.springframework.context.event.{ContextClosedEvent, EventListener}
+import org.springframework.stereotype.Component
+
+
+@Component
+class EurekaInstanceLabelClient extends Logging {
+
+
+  @Autowired
+  private var registration: Registration = _
+
+
+  @PostConstruct
+  def init(): Unit = {
+    info("EurekaInstanceLabelClient init")
+    val metadata = registration.getMetadata
+    if (null != metadata) {
+      info(s"Start to register label for instance $metadata")
+      val insLabelAttachRequest = new InsLabelAttachRequest
+      insLabelAttachRequest.setLabels(metadata.asInstanceOf[java.util.Map[String, Object]])
+      insLabelAttachRequest.setServiceInstance(Sender.getThisServiceInstance)
+      InstanceLabelClient.getInstance.attachLabelsToInstance(insLabelAttachRequest)
+    }
+  }
+
+  @EventListener
+  def shutdown(contextClosedEvent: ContextClosedEvent): Unit = {
+    info("To remove labels for instance")
+    val insLabelRemoveRequest = new InsLabelRemoveRequest
+    insLabelRemoveRequest.setServiceInstance(Sender.getThisServiceInstance)
+    InstanceLabelClient.getInstance.removeLabelsFromInstance(insLabelRemoveRequest)
+  }
+
+
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/com/webank/wedatasphere/linkis/instance/label/client/InstanceLabelClient.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-client/src/main/scala/com/webank/wedatasphere/linkis/instance/label/client/InstanceLabelClient.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.client
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+import com.webank.wedatasphere.linkis.protocol.label.{InsLabelAttachRequest, InsLabelRemoveRequest}
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+
+class InstanceLabelClient {
+
+
+  def attachLabelsToInstance(insLabelAttachRequest: InsLabelAttachRequest): Unit = {
+    getSender().send(insLabelAttachRequest)
+  }
+
+  def getSender(): Sender = {
+    Sender.getSender(InstanceLabelClient.INSTANCE_LABEL_SERVER_NAME.getValue)
+  }
+
+  def removeLabelsFromInstance(insLabelRemoveRequest: InsLabelRemoveRequest): Unit = {
+    getSender().send(insLabelRemoveRequest)
+  }
+}
+
+object InstanceLabelClient {
+  val INSTANCE_LABEL_SERVER_NAME = CommonVars("wds.linkis.instance.label.server.name", "linkis-ps-publicservice")
+
+  private val instanceLabelClient = new InstanceLabelClient
+
+  def getInstance = instanceLabelClient
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/pom.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-instance-label</artifactId>
+    <properties>
+        <caffeine.version>2.8.4</caffeine.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-mybatis</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-label-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <!-- caffeine -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>**/*.properties</exclude>
+                    <exclude>**/application.yml</exclude>
+                    <exclude>**/bootstrap.yml</exclude>
+                    <exclude>**/log4j2.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/InsLabelAutoConfiguration.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/InsLabelAutoConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label;
+
+import com.netflix.discovery.EurekaClient;
+import com.webank.wedatasphere.linkis.instance.label.service.InsLabelAccessService;
+import com.webank.wedatasphere.linkis.instance.label.service.InsLabelServiceAdapter;
+import com.webank.wedatasphere.linkis.instance.label.service.annotation.AdapterMode;
+import com.webank.wedatasphere.linkis.instance.label.service.impl.DefaultInsLabelService;
+import com.webank.wedatasphere.linkis.instance.label.service.impl.DefaultInsLabelServiceAdapter;
+import com.webank.wedatasphere.linkis.instance.label.service.impl.EurekaInsLabelService;
+import com.webank.wedatasphere.linkis.mybatis.DataSourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.util.List;
+
+
+@Configuration
+public class InsLabelAutoConfiguration {
+    private static final Logger LOG = LoggerFactory.getLogger(InsLabelAutoConfiguration.class);
+
+    @ConditionalOnClass({DataSourceConfig.class})
+    @Bean
+    @Scope("prototype")
+    public InsLabelAccessService defaultInsLabelService(){
+        return new DefaultInsLabelService();
+    }
+
+    @ConditionalOnMissingBean({InsLabelServiceAdapter.class})
+    @Bean(initMethod = "init")
+    public InsLabelServiceAdapter insLabelServiceAdapter(List<InsLabelAccessService> accessServices){
+        LOG.info("Discover instance label accessServices: [" + accessServices.size() + "]");
+        InsLabelServiceAdapter insLabelServiceAdapter = new DefaultInsLabelServiceAdapter();
+        accessServices.forEach(accessService -> {
+            AdapterMode adapterMode = AnnotationUtils.findAnnotation(accessService.getClass(), AdapterMode.class);
+            if(null != adapterMode){
+                LOG.info("Register instance label access service: " + accessService.getClass().getSimpleName() + " to service adapter");
+                insLabelServiceAdapter.registerServices(accessService, adapterMode.order());
+            }
+        });
+        return insLabelServiceAdapter;
+    }
+
+    /**
+     * Configuration in eureka environment
+     */
+    @Configuration
+    @ConditionalOnClass({EurekaClient.class})
+    public static class EurekaClientConfiguration{
+        @ConditionalOnMissingBean({EurekaInsLabelService.class})
+        @Bean
+        @Scope("prototype")
+        public EurekaInsLabelService eurekaInsLabelService(EurekaDiscoveryClient discoveryClient){
+            return new EurekaInsLabelService(discoveryClient);
+        }
+
+    }
+
+    /**
+     * Enable the rpc service
+     * @return
+     */
+    /*//@ConditionalOnExpression("${wds.linkis.is.gateway:false}==false")
+    @ConditionalOnMissingBean({InsLabelRpcService.class})
+    public InsLabelRpcService insLabelRpcService(){
+        LOG.info("Use the default implement of rpc service: [" + DefaultInsLabelRpcService.class + "]");
+        return new DefaultInsLabelRpcService();
+    }*/
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/async/AsyncConsumerQueue.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/async/AsyncConsumerQueue.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.async;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+
+public interface AsyncConsumerQueue<T> {
+
+    /**
+     * Size of queue
+     * @return value
+     */
+    int size();
+
+    /**
+     * Inserts the specified entity
+     * @param entity entity
+     * @return if the queue is full, return false
+     */
+    boolean offer(T entity);
+
+    /**
+     * Inserts the specified entity
+     * @param entity entity
+     * @param timeout timeout
+     * @param timeUnit unit
+     * @return if the queue is full, return false
+     */
+    boolean offer(T entity, long timeout, TimeUnit timeUnit) throws InterruptedException;
+
+    /**
+     * Define the consumer
+     * @param batchSize batch size for each consuming
+     * @param interval consume interval
+     * @param timeUnit time unit of interval
+     * @param consumer consume function
+     */
+    void consumer(int batchSize, long interval, TimeUnit timeUnit, Consumer<List<T>> consumer);
+
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/async/GenericAsyncConsumerQueue.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/async/GenericAsyncConsumerQueue.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.async;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+
+public class GenericAsyncConsumerQueue<T> implements AsyncConsumerQueue<T>{
+
+    private static final Logger LOG = LoggerFactory.getLogger(GenericAsyncConsumerQueue.class);
+    private ArrayBlockingQueue<T> innerQueue;
+
+    private ReentrantLock consumeLock = new ReentrantLock();
+
+    private ExecutorService consumeService;
+
+    private Condition consumeCondition = consumeLock.newCondition();
+
+    private AtomicInteger consumeBatchSize = new AtomicInteger(-1);
+
+    private boolean exit = true;
+
+    public GenericAsyncConsumerQueue(int maxQueueSize){
+        this.innerQueue = new ArrayBlockingQueue<T>(maxQueueSize);
+        this.consumeService = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public int size() {
+        return this.innerQueue.size();
+    }
+
+    @Override
+    public boolean offer(T entity) {
+        if(innerQueue.offer(entity)){
+            tryToNotifyConsumer();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean offer(T entity, long timeout, TimeUnit timeUnit) throws InterruptedException {
+        if(innerQueue.offer(entity, timeout, timeUnit)){
+            tryToNotifyConsumer();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public synchronized void consumer(int batchSize, long interval, TimeUnit timeUnit, Consumer<List<T>> consumer) {
+        if(!exit){
+            throw new IllegalStateException("The consumer has been defined, please don't define repeatedly");
+        }
+        this.consumeBatchSize.set(batchSize);
+        this.consumeService.submit(()->{
+            long triggerTime = System.currentTimeMillis();
+            long intervalInMillis = TimeUnit.MILLISECONDS.convert(interval, timeUnit);
+            while(!exit){
+                long nowMillsTime = System.currentTimeMillis();
+                if(triggerTime >= nowMillsTime){
+                    LOG.trace("wait until the next time: " + triggerTime);
+                    consumeLock.lock();
+                    try {
+                        consumeCondition.await(triggerTime - nowMillsTime , TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        LOG.error("Interrupt in awaiting action, message: [" + e.getMessage() +"]", e);
+                        continue;
+                    }finally{
+                        if(consumeLock.isLocked()){
+                            consumeLock.unlock();
+                        }
+                    }
+                    try {
+                        List<T> elementsWaitForDeal = new ArrayList<>();
+                        //Do not block
+                        innerQueue.drainTo(elementsWaitForDeal, innerQueue.size());
+                        if (!elementsWaitForDeal.isEmpty()) {
+                            consumer.accept(elementsWaitForDeal);
+                        }
+                    }catch(Throwable e){
+                        LOG.error("Exception in consuming queue, message: [" + e.getMessage() +"]", e);
+                    }
+                }
+                triggerTime = System.currentTimeMillis() + intervalInMillis;
+            }
+        });
+        this.exit = false;
+    }
+
+    /**
+     * Notify consumer
+     */
+    private void tryToNotifyConsumer(){
+        if(innerQueue.size() >= consumeBatchSize.get()){
+            consumeLock.lock();
+            try{
+                if(!innerQueue.isEmpty()){
+                    consumeCondition.signalAll();
+                }
+            }finally{
+                consumeLock.unlock();
+            }
+        }
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/cache/InsLabelCacheConfiguration.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/cache/InsLabelCacheConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.webank.wedatasphere.linkis.instance.label.conf.InsLabelConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Use spring cache and caffeine
+ */
+@ConditionalOnClass(Caffeine.class)
+@EnableCaching
+@Configuration
+public class InsLabelCacheConfiguration extends CachingConfigurerSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(InsLabelCacheConfiguration.class);
+    @Bean
+    @Primary
+    @Override
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(InsLabelConf.CACHE_EXPIRE_TIME.getValue(), TimeUnit.SECONDS)
+                .maximumSize(InsLabelConf.CACHE_MAX_SIZE.getValue()));
+        cacheManager.setCacheNames(Arrays.asList(InsLabelConf.CACHE_NAMES.getValue().split(",")));
+        return cacheManager;
+    }
+
+    @Bean
+    @Primary
+    @Override
+    public KeyGenerator keyGenerator() {
+        return new KeyGenerator() {
+            static final String SPLIT_SYMBOL = ":";
+            final Logger LOG = LoggerFactory.getLogger(KeyGenerator.class);
+
+            @Override
+            public Object generate(Object target, Method method, Object... params) {
+                StringBuilder keyBuilder = new StringBuilder()
+                        .append(target.getClass().getSimpleName()).append(SPLIT_SYMBOL)
+                        .append(method.getName());
+                if(params.length > 0){
+                    keyBuilder.append(SPLIT_SYMBOL);
+                    for (int i = 0; i < params.length; i++) {
+                        //For label toString() is all right
+                        keyBuilder.append(params[i]);
+                        if (i < params.length - 1) {
+                            keyBuilder.append(SPLIT_SYMBOL);
+                        }
+                    }
+                }
+                LOG.trace("Generate key: [" + keyBuilder.toString() + "]");
+                return keyBuilder.toString();
+            }
+        };
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/conf/InsLabelConf.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/conf/InsLabelConf.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.conf;
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars;
+
+
+public class InsLabelConf {
+
+    /**
+     * Limit the size of batch operation
+     */
+    public static final CommonVars<Integer> DB_PERSIST_BATCH_SIZE = CommonVars.apply("wds.linkis.instance.label.persist.batch.size", 100);
+
+    /**
+     * Capacity of async queue
+     */
+    public static final CommonVars<Integer> ASYNC_QUEUE_CAPACITY = CommonVars.apply("wds.linkis.instance.label.async.queue.capacity", 1000);
+
+    public static final CommonVars<Integer> ASYNC_QUEUE_CONSUME_BATCH_SIZE = CommonVars.apply("wds.linkis.instance.label.async.queue.batch.size", 100);
+
+    /**
+     * Interval of consuming period
+     */
+    public static final CommonVars<Long> ASYNC_QUEUE_CONSUME_INTERVAL = CommonVars.apply("wds.linkis.instance.label.async.queue.interval-in-seconds", 10L);
+
+    /**
+     * Expire time of cache
+     */
+    public static final CommonVars<Integer> CACHE_EXPIRE_TIME = CommonVars.apply("wds.linkis.instance.label.cache.expire.time-in-seconds", 10);
+
+    public static final CommonVars<Integer> CACHE_MAX_SIZE = CommonVars.apply("wds.linkis.instance.label.cache.maximum.size", 1000);
+
+    public static final CommonVars<String> CACHE_NAMES = CommonVars.apply("wds.linkis.instance.label.cache.names", "instance,label");
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/InsLabelRelationDao.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/InsLabelRelationDao.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.dao;
+
+import com.webank.wedatasphere.linkis.instance.label.entity.InsPersistenceLabel;
+import com.webank.wedatasphere.linkis.instance.label.entity.InstanceInfo;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Operate the relation between label and instance
+ */
+public interface InsLabelRelationDao {
+
+    /**
+     * Search instances
+     * @param valueContent key -> value map
+     * @return
+     */
+    List<InstanceInfo> searchInsDirectByValues(@Param("valueMapList") List<Map<String, String>> valueContent, @Param("relation")String relation);
+
+    List<InstanceInfo> searchInsDirectByLabels(List<InsPersistenceLabel> labels);
+
+    /**
+     * Search instances( will fetch the labels of instance cascade)
+     * @param valueContent key -> value map
+     * @return
+     */
+    List<InstanceInfo> searchInsCascadeByValues(List<Map<String, String>> valueContent, String relation);
+
+    List<InstanceInfo> searchInsCascadeByLabels(List<InsPersistenceLabel> labels);
+
+    /**
+     * Search instances that are not related with other labels
+     * @param instanceInfo
+     * @return
+     */
+    List<InstanceInfo> searchUnRelateInstances(InstanceInfo instanceInfo);
+
+    List<InstanceInfo> searchLabelRelatedInstances(InstanceInfo instanceInfo);
+    /**
+     * Search labels
+     * @param instance instance value (http:port)
+     * @return
+     */
+    List<InsPersistenceLabel> searchLabelsByInstance(String instance);
+
+    /**
+     * Drop relationships by instance and label ids
+     * @param instance instance value (http:port)
+     * @param labelIds label ids
+     */
+    void dropRelationsByInstanceAndLabelIds(@Param("instance") String instance, @Param("labelIds")List<Integer> labelIds);
+
+    void dropRelationsByInstance(String instance);
+    /**
+     * Insert relationship
+     * @param instance instance
+     * @param labelIds label ids
+     */
+    void insertRelations(@Param("instance")String instance, @Param("labelIds")List<Integer> labelIds);
+
+    /**
+     * If has relationship
+     * @param labelId
+     * @return
+     */
+    Integer existRelations(Integer labelId);
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/InstanceInfoDao.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/InstanceInfoDao.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.dao;
+
+import com.webank.wedatasphere.linkis.instance.label.entity.InstanceInfo;
+
+
+public interface InstanceInfoDao {
+
+    /**
+     * Insert method
+     * @param instanceInfo instance information
+     */
+    void insertOne(InstanceInfo instanceInfo);
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/InstanceLabelDao.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/InstanceLabelDao.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.dao;
+
+import com.webank.wedatasphere.linkis.instance.label.entity.InsPersistenceLabel;
+import com.webank.wedatasphere.linkis.instance.label.entity.InsPersistenceLabelValue;
+import com.webank.wedatasphere.linkis.instance.label.vo.InsPersistenceLabelSearchVo;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+
+public interface InstanceLabelDao {
+
+    /**
+     * Select by id ( tip: select ... for update)
+     * @param labelId label id
+     * @return
+     */
+    InsPersistenceLabel selectForUpdate(Integer labelId);
+
+    /**
+     * Select by label_key and label_value (tip: select ... for update)
+     * @param labelKey label key
+     * @param labelValue label value
+     * @return
+     */
+    InsPersistenceLabel searchForUpdate(@Param("labelKey")String labelKey, @Param("labelValue")String labelValue);
+
+    /**
+     * Insert label entities
+     * If you want to get id from multiple insert operation, use MyBatis 3.3.x
+     * @param labels labels
+     */
+    void insertBatch(List<InsPersistenceLabel> labels);
+
+    /**
+     * Insert label
+     * @param label label entity
+     */
+    void insert(InsPersistenceLabel label);
+
+    /**
+     * To fetch update lock of record in transaction
+     * @param labelId
+     */
+    int updateForLock(Integer labelId);
+    /**
+     * Search labels by key and string value
+     * @param labelSearch search vo
+     * @return
+     */
+    List<InsPersistenceLabel> search(List<InsPersistenceLabelSearchVo> labelSearch);
+
+    /**
+     * Remove label
+     * @param label label entity
+     */
+    void remove(InsPersistenceLabel label);
+
+    /**
+     * Insert key -> value of label
+     * @param keyValues key -> value
+     */
+    void doInsertKeyValues(List<InsPersistenceLabelValue> keyValues);
+
+    /**
+     * Remove key -> value map from label id
+     * @param labelId
+     */
+    void doRemoveKeyValues(Integer labelId);
+
+    void doRemoveKeyValuesBatch(List<Integer> labelIds);
+
+
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/impl/InsLabelRelationMapper.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/impl/InsLabelRelationMapper.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.webank.wedatasphere.linkis.instance.label.dao.InsLabelRelationDao">
+    <resultMap id="instanceInfoMap" type="InstanceInfo">
+        <result property="id" column="id"/>
+        <result property="instance" column="instance"/>
+        <result property="applicationName" column="name"/>
+        <result property="updateTime" column="update_time"/>
+        <result property="createTime" column="create_time"/>
+    </resultMap>
+    <resultMap id="instanceInfoCascadeMap" type="InstanceInfo">
+        <result property="id" column="id"/>
+        <result property="instance" column="instance"/>
+        <result property="applicationName" column="name"/>
+        <result property="updateTime" column="update_time"/>
+        <result property="createTime" column="create_time"/>
+        <collection property="labels" column="instance" select="selectLabelsByIns" ofType="InsPersistenceLabel"/>
+    </resultMap>
+
+    <sql id="label_search_columns">
+        l.`id`, l.`label_key`, l.`label_value`, l.`label_feature`,
+        l.`label_value_size`, l.`update_time`, l.`create_time`
+    </sql>
+
+    <sql id="search_ins_columns">
+        s.`id`, s.`instance`, s.`name`, s.`update_time`, s.`create_time`
+    </sql>
+    <select id="selectLabelsByIns" resultType="InsPersistenceLabel">
+        <![CDATA[
+            SELECT l.`id`, l.`label_key` AS `labelKey`, l.`label_value` AS `stringValue`,
+            l.`label_feature` AS `feature`, l.`label_value_size` AS `labelValueSize`,
+            l.`update_time` AS `updateTime`, l.`create_time` AS `createTime`
+            FROM `linkis_instance_label` l INNER JOIN `linkis_instance_label_relation` r
+            ON l.`id` = r.`label_id` AND r.`service_instance` = #{instance}
+            ]]>
+    </select>
+
+    <select id="searchInsDirectByValues" resultMap="instanceInfoMap">
+        <![CDATA[SELECT ]]>
+        <include refid="search_ins_columns"/>
+        <![CDATA[ FROM `linkis_instance_info` s INNER JOIN `linkis_instance_label_relation` l ON s.`instance` = l.`service_instance` AND l.`label_id` IN ]]>
+        <foreach collection="valueMapList" item="mapValue" open="(" close=")" separator=" UNION ">
+            <![CDATA[SELECT v.`label_id` FROM `linkis_instance_label_value_relation` v WHERE (v.`label_value_key`, v.`label_value_content`) IN ]]>
+            <foreach collection="mapValue" index="key" item="value" open="(" close=")" separator=",">
+                <![CDATA[(#{key}, #{value})]]>
+            </foreach>
+            GROUP BY v.`label_id`
+            <if test="relation == 'ALL'">
+                <!-- cost time -->
+                HAVING COUNT(1) = (SELECT `label_value_size` FROM `linkis_instance_label` WHERE `id` = v.`label_id`) AND COUNT(1) = ${mapValue.size}
+            </if>
+            <if test="relation == 'AND'">
+                HAVING COUNT(1) = ${mapValue.size}
+            </if>
+            <if test="relation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+    <select id="searchInsDirectByLabels" resultMap="instanceInfoMap">
+        <![CDATA[SELECT ]]>
+        <include refid="search_ins_columns"/>
+        <![CDATA[ FROM `linkis_instance_info` s INNER JOIN `linkis_instance_label_relation` l ON s.`instance` = l.`service_instance` AND l.`label_id` IN
+            (SELECT `label_id` FROM `linkis_instance_label` WHERE (`label_key`, `label_value`) IN
+        ]]>
+        <foreach collection="list" item="item" open="(" close=")" separator=",">
+            <![CDATA[(#{item.labelKey}, #{item.stringValue})]]>
+        </foreach>
+        <![CDATA[);]]>
+    </select>
+
+    <select id="searchUnRelateInstances" resultMap="instanceInfoMap">
+        <![CDATA[SELECT ]]>
+        <include refid="search_ins_columns"/>
+        <![CDATA[ FROM `linkis_instance_info` s ]]>
+        <where>
+            <if test="applicationName != null and applicationName != ''">
+                <![CDATA[AND s.`name` = #{applicationName}]]>
+            </if>
+            <![CDATA[AND NOT EXISTS(SELECT 1 FROM `linkis_instance_label_relation`
+             WHERE `service_instance` =  s.`instance` LIMIT 1);]]>
+        </where>
+    </select>
+
+    <select id="searchLabelRelatedInstances" resultMap="instanceInfoMap">
+        <![CDATA[SELECT ]]>
+        <include refid="search_ins_columns"/>
+        <![CDATA[ FROM `linkis_instance_info` s ]]>
+        <where>
+            <if test="applicationName != null and applicationName != ''">
+                <![CDATA[AND s.`name` = #{applicationName}]]>
+            </if>
+            <![CDATA[AND EXISTS(SELECT 1 FROM `linkis_instance_label_relation`
+               WHERE `service_instance` =  s.`instance` LIMIT 1);]]>
+        </where>
+    </select>
+
+    <select id="searchLabelsByInstance" resultMap="instanceInfoMap">
+        <![CDATA[SELECT ]]>
+        <include refid="label_search_columns"/>
+        <![CDATA[ FROM `linkis_instance_label` l
+        INNER JOIN `linkis_instance_label_relation` r
+        ON l.`id` = r.`label_id` AND r.`service_instance` = #{instance};]]>
+    </select>
+
+    <delete id="dropRelationsByInstanceAndLabelIds">
+        <![CDATA[DELETE FROM `linkis_instance_label_relation`
+        WHERE `service_instance` = #{instance} AND `label_id` IN ]]>
+        <foreach collection="labelIds" item="item" open="(" close=")" separator=",">
+            #{item}
+        </foreach>
+    </delete>
+
+    <delete id="dropRelationsByInstance">
+        <![CDATA[DELETE FROM `linkis_instance_label_relation` WHERE `service_instance` = #{instance};]]>
+    </delete>
+
+    <insert id="insertRelations">
+        <foreach collection="labelIds" item="item" open="" close="">
+            <![CDATA[INSERT INTO `linkis_instance_label_relation`
+            (`service_instance`, `label_id`) VALUES(#{instance}, #{item});]]>
+        </foreach>
+    </insert>
+
+    <select id="existRelations" resultType="Integer">
+        <![CDATA[SELECT 1 FROM `linkis_instance_label_relation` WHERE `label_id` =  #{labelId} LIMIT 1;]]>
+    </select>
+
+    <select id="searchInsCascadeByValues" resultMap="instanceInfoCascadeMap">
+        <![CDATA[SELECT ]]>
+        <include refid="search_ins_columns"/>
+        <![CDATA[ FROM `linkis_instance_info` s INNER JOIN `linkis_instance_label_relation` l ON s.`instance` = l.`service_instance` AND l.`label_id` IN ]]>
+        <foreach collection="valueMapList" item="mapValue" open="(" close=")" separator=" UNION ">
+            <![CDATA[SELECT v.`label_id` FROM `linkis_instance_label_value_relation` v WHERE (v.`label_value_key`, v.`label_value_content`) IN ]]>
+            <foreach collection="mapValue" index="key" item="value" open="(" close=")" separator=",">
+                <![CDATA[(#{key}, #{value})]]>
+            </foreach>
+            GROUP BY v.`label_id`
+            <if test="relation == 'ALL'">
+                <!-- cost time -->
+                HAVING COUNT(1) = (SELECT `label_value_size` FROM `linkis_instance_label` WHERE `id` = v.`label_id`) AND COUNT(1) = ${mapValue.size}
+            </if>
+            <if test="relation == 'AND'">
+                HAVING COUNT(1) = ${mapValue.size}
+            </if>
+            <if test="relation == 'OR'">
+                HAVING COUNT(1) > 0
+            </if>
+        </foreach>
+    </select>
+
+    <select id="searchInsCascadeByLabels" resultMap="instanceInfoCascadeMap">
+        <![CDATA[SELECT ]]>
+        <include refid="search_ins_columns"/>
+        <![CDATA[ FROM `linkis_instance_info` s INNER JOIN `linkis_instance_label_relation` l ON s.`instance` = l.`service_instance` AND l.`label_id` IN
+            (SELECT `label_id` FROM `linkis_instance_label` WHERE (`label_key`, `label_value`) IN
+        ]]>
+        <foreach collection="list" item="item" open="(" close=")" separator=",">
+            <![CDATA[(#{item.labelKey}, #{item.stringValue})]]>
+        </foreach>
+        <![CDATA[);]]>
+    </select>
+</mapper>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/impl/InstanceInfoMapper.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/impl/InstanceInfoMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.webank.wedatasphere.linkis.instance.label.dao.InstanceInfoDao">
+    <insert id="insertOne" parameterType="InstanceInfo">
+        <![CDATA[INSERT INTO `linkis_instance_info`(`instance`, `name`)
+        VALUES(#{instance}, #{applicationName})]]>
+    </insert>
+</mapper>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/impl/InstanceLabelMapper.xml
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/dao/impl/InstanceLabelMapper.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.webank.wedatasphere.linkis.instance.label.dao.InstanceLabelDao">
+
+    <resultMap id="insPersistenceLabelMap" type="InsPersistenceLabel">
+        <result property="id" column="id"/>
+        <result property="labelKey" column="label_key"/>
+        <result property="stringValue" column="label_value"/>
+        <result property="feature" column="label_feature"/>
+        <result property="labelValueSize" column="label_value_size"/>
+        <result property="updateTime" column="update_time"/>
+        <result property="createTime" column="create_time"/>
+    </resultMap>
+
+    <sql id="label_search_columns">
+        `id`, `label_key`, `label_value`, `label_feature`,
+        `label_value_size`, `update_time`, `create_time`
+    </sql>
+
+    <sql id="label_insert_columns">
+        `label_key`, `label_value`, `label_feature`,
+        `label_value_size`
+    </sql>
+    <select id="selectForUpdate" parameterType="Integer">
+        <![CDATA[SELECT ]]>
+        <include refid="label_search_columns" />
+        <![CDATA[ FROM `linkis_instance_label` WHERE `id` = #{labelId} FOR UPDATE;]]>
+    </select>
+
+    <select id="searchForUpdate">
+        <![CDATA[SELECT ]]>
+        <include refid="label_search_columns"/>
+        <![CDATA[ FROM `linkis_instance_label` WHERE `label_key` = #{labelKey}
+        AND `label_value` = #{stringValue} FOR UPDATE;]]>
+    </select>
+
+    <insert id="insertBatch" keyProperty="id" useGeneratedKeys="true">
+        <foreach collection="list" item="item" separator="" open="" close="">
+            <![CDATA[INSERT INTO `linkis_instance_label`(]]>
+            <include refid="label_insert_columns"/>
+            <![CDATA[) VALUES(#{item.labelKey}, #{item.stringValue},
+             #{item.feature}, #{item.labelValueSize});]]>
+        </foreach>
+    </insert>
+
+    <insert id="insert">
+        <![CDATA[INSERT INTO `linkis_instance_label`(]]>
+        <include refid="label_insert_columns"/>
+        <![CDATA[) VALUES(#{item.labelKey}, #{item.stringValue},
+             #{item.feature}, #{item.labelValueSize});]]>
+    </insert>
+
+    <update id="updateForLock">
+        <![CDATA[UPDATE `linkis_instance_label` SET `update_time` = CURRENT_TIMESTAMP WHERE `id` = #{labelId};]]>
+    </update>
+
+    <select id="search" resultMap="insPersistenceLabelMap">
+        <![CDATA[SELECT * FROM `linkis_instance_label` ]]>
+        <where>
+            <![CDATA[(`label_key`, `label_value`) IN ]]>
+            <foreach collection="list" item="item" open="(" close=")" separator=",">
+                (#{item.labelKey}, #{item.stringValue})
+            </foreach>
+        </where>
+    </select>
+
+    <delete id="remove">
+        <choose>
+            <when test="id != null and id != ''">
+                <![CDATA[DELETE FROM `linkis_instance_label` WHERE `id` = #{id}]]>
+            </when>
+            <otherwise>
+                <![CDATA[DELETE FROM `linkis_instance_label` WHERE `label_key` = #{labelKey}
+        AND `label_value` = #{stringValue}]]>
+            </otherwise>
+        </choose>
+    </delete>
+
+    <insert id="doInsertKeyValues">
+        <foreach collection="list" item="item" open="" close="">
+            <![CDATA[INSERT INTO `linkis_instance_label_value_relation`
+            (`label_value_key`, `label_value_content`, `label_id`)
+             VALUES(#{valueKey}, #{valueContent}, #{labelId});
+            ]]>
+        </foreach>
+    </insert>
+
+    <delete id="doRemoveKeyValues">
+        <![CDATA[DELETE FROM `linkis_instance_label_value_relation` WHERE `label_id` = #{labelId}]]>
+    </delete>
+
+    <delete id="doRemoveKeyValuesBatch">
+        <foreach collection="list" item="item" open="" close="">
+            <![CDATA[DELETE FROM `linkis_instance_label_value_relation` WHERE `label_id` = #{item}]]>
+        </foreach>
+    </delete>
+</mapper>

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/entity/InsPersistenceLabel.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/entity/InsPersistenceLabel.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.entity;
+
+import com.webank.wedatasphere.linkis.manager.label.entity.GenericLabel;
+
+import java.util.Date;
+
+
+public class InsPersistenceLabel extends GenericLabel {
+    private Integer id;
+    private int labelValueSize = -1;
+    private String stringValue;
+
+    private Date updateTime;
+    private Date createTime;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public int getLabelValueSize() {
+        return labelValueSize;
+    }
+
+    public void setLabelValueSize(int labelValueSize) {
+        this.labelValueSize = labelValueSize;
+    }
+
+    @Override
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    @Override
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if(null != this.getLabelKey() && other instanceof InsPersistenceLabel){
+            InsPersistenceLabel otherInsLabel = (InsPersistenceLabel)other;
+            if(this.getLabelKey().equals(otherInsLabel.getLabelKey())){
+                return (null == this.getStringValue() && null == otherInsLabel.getStringValue()) ||
+                        (null != this.getStringValue() && this.getStringValue().equals(otherInsLabel.getStringValue()));
+            }
+        }
+        return super.equals(other);
+    }
+
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/entity/InsPersistenceLabelValue.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/entity/InsPersistenceLabelValue.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.entity;
+
+
+public class InsPersistenceLabelValue {
+
+    private Integer labelId;
+
+    private String valueKey;
+
+    private String valueContent;
+
+    public InsPersistenceLabelValue(){
+
+    }
+
+    public InsPersistenceLabelValue(Integer labelId, String key, String content){
+        this.labelId = labelId;
+        this.valueKey = key;
+        this.valueContent = content;
+    }
+
+    public String getValueKey() {
+        return valueKey;
+    }
+
+    public void setValueKey(String valueKey) {
+        this.valueKey = valueKey;
+    }
+
+    public String getValueContent() {
+        return valueContent;
+    }
+
+    public void setValueContent(String valueContent) {
+        this.valueContent = valueContent;
+    }
+
+    public Integer getLabelId() {
+        return labelId;
+    }
+
+    public void setLabelId(Integer labelId) {
+        this.labelId = labelId;
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/entity/InstanceInfo.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/entity/InstanceInfo.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.entity;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Extends ServiceInstance, store the relationship of label
+ */
+public class InstanceInfo extends ServiceInstance {
+    /**
+     * Automatic increment
+     */
+    private Integer id;
+
+    private Date updateTime;
+
+    private Date createTime;
+    /**
+     * Labels related
+     */
+    private List<InsPersistenceLabel> labels = new ArrayList<>();
+
+    public InstanceInfo(){
+
+    }
+    public InstanceInfo(ServiceInstance serviceInstance){
+        super.setInstance(serviceInstance.getInstance());
+        super.setApplicationName(serviceInstance.getApplicationName());
+    }
+
+    public List<InsPersistenceLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<InsPersistenceLabel> labels) {
+        this.labels = labels;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/InsLabelAccessService.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/InsLabelAccessService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.List;
+
+
+public interface InsLabelAccessService {
+
+    /**
+     * Add label to instance
+     * @param label label entity
+     * @param serviceInstance service instance
+     */
+    void attachLabelToInstance(Label<?> label, ServiceInstance serviceInstance);
+
+    void attachLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance);
+
+    /**
+     * Refresh all the labels of instance (to init the relationship of instance and labels)
+     * @param labels
+     * @param serviceInstance
+     */
+    void refreshLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance);
+    /**
+     * Remove all relationship between label and instance
+     * @param serviceInstance service instance
+     */
+    void removeLabelsFromInstance(ServiceInstance serviceInstance);
+
+    /**
+     * Search instances from labels
+     * @param labels label list
+     */
+    List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels);
+
+    /**
+     * Search instances from labels
+     * @param labels label list
+     * @param relation relation type
+     */
+    List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels, Label.ValueRelation relation);
+
+    /**
+     * Search instances that are not related with other labels
+     * @param serviceInstance instance info for searching
+     * @return
+     */
+    List<ServiceInstance> searchUnRelateInstances(ServiceInstance serviceInstance);
+
+    /**
+     * Search instances that are related with other labels
+     * @param serviceInstance instance info for searching
+     * @return
+     */
+    List<ServiceInstance> searchLabelRelatedInstances(ServiceInstance serviceInstance);
+    /**
+     * Remove labels
+     * @param labels
+     */
+    void removeLabelsIfNotRelation(List<? extends Label<?>> labels);
+
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/InsLabelService.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/InsLabelService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+import java.util.List;
+
+
+
+@CacheConfig
+public interface InsLabelService {
+    /**
+     * Add label to instance
+     * @param label label entity
+     * @param serviceInstance service instance
+     */
+    @CacheEvict(cacheNames = {"label"}, allEntries = true)
+    void attachLabelToInstance(Label<?> label, ServiceInstance serviceInstance);
+
+    @CacheEvict(cacheNames = {"label"}, allEntries = true)
+    void attachLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance);
+
+    /**
+     * Refresh all the labels of instance (to init the relationship of instance and labels)
+     * @param labels
+     * @param serviceInstance
+     */
+    @CacheEvict(cacheNames = {"instance"}, allEntries = true)
+    void refreshLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance);
+
+    /**
+     * Remove all relationship between label and instance
+     * @param serviceInstance service instance
+     */
+    @CacheEvict(cacheNames = {"instance"}, allEntries = true)
+    void removeLabelsFromInstance(ServiceInstance serviceInstance);
+
+    /**
+     * Search instances from labels
+     * @param labels label list
+     */
+    @Cacheable({"instance"})
+    List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels);
+
+    /**
+     * Search instances that are not related with other labels
+     * @param serviceInstance
+     * @return
+     */
+    @Cacheable({"instance"})
+    List<ServiceInstance> searchUnRelateInstances(ServiceInstance serviceInstance);
+
+    /**
+     * Search instances that are related with other labels
+     * @param serviceInstance instance info for searching
+     * @return
+     */
+    @Cacheable({"instance"})
+    List<ServiceInstance> searchLabelRelatedInstances(ServiceInstance serviceInstance);
+
+    @CacheEvict(cacheNames = {"instance", "label"}, allEntries = true)
+    void evictCache();
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/InsLabelServiceAdapter.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/InsLabelServiceAdapter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service;
+
+
+public interface InsLabelServiceAdapter extends InsLabelService {
+
+    /**
+     * Register service
+     * @param insLabelAccessService service implement <em>InsLabelAccessService</em>
+     */
+    void registerServices(InsLabelAccessService insLabelAccessService);
+
+    void registerServices(InsLabelAccessService insLabelAccessService, int order);
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/annotation/AdapterMode.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/annotation/AdapterMode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service.annotation;
+
+import java.lang.annotation.*;
+
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface AdapterMode {
+    int order() default -1;
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/impl/DefaultInsLabelService.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/impl/DefaultInsLabelService.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.instance.label.async.AsyncConsumerQueue;
+import com.webank.wedatasphere.linkis.instance.label.async.GenericAsyncConsumerQueue;
+import com.webank.wedatasphere.linkis.instance.label.conf.InsLabelConf;
+import com.webank.wedatasphere.linkis.instance.label.dao.InsLabelRelationDao;
+import com.webank.wedatasphere.linkis.instance.label.dao.InstanceInfoDao;
+import com.webank.wedatasphere.linkis.instance.label.dao.InstanceLabelDao;
+import com.webank.wedatasphere.linkis.instance.label.entity.InsPersistenceLabel;
+import com.webank.wedatasphere.linkis.instance.label.entity.InsPersistenceLabelValue;
+import com.webank.wedatasphere.linkis.instance.label.entity.InstanceInfo;
+import com.webank.wedatasphere.linkis.instance.label.service.InsLabelAccessService;
+import com.webank.wedatasphere.linkis.instance.label.service.annotation.AdapterMode;
+import com.webank.wedatasphere.linkis.instance.label.vo.InsPersistenceLabelSearchVo;
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactory;
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import com.webank.wedatasphere.linkis.manager.label.utils.LabelUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopContext;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Resource;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+
+@AdapterMode
+public class DefaultInsLabelService implements InsLabelAccessService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultInsLabelService.class);
+
+    @Resource
+    private InstanceLabelDao instanceLabelDao;
+
+    @Resource
+    private InstanceInfoDao instanceDao;
+
+    @Resource
+    private InsLabelRelationDao insLabelRelationDao;
+
+    private AsyncConsumerQueue<InsPersistenceLabel> asyncRemoveLabelQueue;
+
+    private InsLabelAccessService selfService;
+
+    private AtomicBoolean asyncQueueInit = new AtomicBoolean(false);
+    /**
+     * init method
+     */
+    private synchronized void initQueue(){
+        if(!asyncQueueInit.get()) {
+            selfService = (InsLabelAccessService) AopContext.currentProxy();
+            LOG.info("SelfService: [" + this.getClass().getName() + "]");
+            asyncRemoveLabelQueue = new GenericAsyncConsumerQueue<>(InsLabelConf.ASYNC_QUEUE_CAPACITY.getValue());
+            asyncRemoveLabelQueue.consumer(InsLabelConf.ASYNC_QUEUE_CONSUME_BATCH_SIZE.getValue(),
+                    InsLabelConf.ASYNC_QUEUE_CONSUME_INTERVAL.getValue(), TimeUnit.SECONDS, insLabels -> {
+                        selfService.removeLabelsIfNotRelation(insLabels);
+                    });
+            asyncQueueInit.set(true);
+        }
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void attachLabelToInstance(Label<?> label, ServiceInstance serviceInstance) {
+        attachLabelsToInstance(Collections.singletonList(label), serviceInstance);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void attachLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance) {
+        List<InsPersistenceLabel> insLabels = toInsPersistenceLabels(labels);
+        List<InsPersistenceLabel> labelsNeedInsert = filterLabelNeededInsert(insLabels, true);
+        if(!labelsNeedInsert.isEmpty()) {
+            LOG.info("Persist labels: [" + LabelUtils.Jackson.toJson(labels, null) + "]");
+            doInsertInsLabels(labelsNeedInsert);
+        }
+        LOG.info("Insert/Update service instance info: [" + serviceInstance + "]");
+        doInsertInstance(serviceInstance);
+        List<Integer> insLabelIds = insLabels.stream().map(InsPersistenceLabel :: getId).collect(Collectors.toList());
+        LOG.trace("Build relation between labels: " +
+                LabelUtils.Jackson.toJson(insLabelIds, null)
+        + " and instance: [" + serviceInstance.getInstance() + "]");
+        batchOperation(insLabelIds, subInsLabelIds -> insLabelRelationDao.insertRelations(serviceInstance.getInstance(), subInsLabelIds), InsLabelConf.DB_PERSIST_BATCH_SIZE.getValue());
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void refreshLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance) {
+        List<InsPersistenceLabel> insLabels = toInsPersistenceLabels(labels);
+        //Label candidate to be removed
+        List<InsPersistenceLabel> labelsCandidateRemoved = insLabelRelationDao.searchLabelsByInstance(serviceInstance.getInstance());
+        if(!labelsCandidateRemoved.isEmpty()){
+            labelsCandidateRemoved.removeAll(insLabels);
+        }
+        LOG.info("Drop relationships related by instance: [" + serviceInstance.getInstance() + "]");
+        insLabelRelationDao.dropRelationsByInstance(serviceInstance.getInstance());
+        //Attach labels to instance
+        attachLabelsToInstance(insLabels, serviceInstance);
+        // Async to delete labels that have no relationship
+        if(!labelsCandidateRemoved.isEmpty()){
+            if(!asyncQueueInit.get()) {
+                initQueue();
+            }
+            labelsCandidateRemoved.forEach( label -> {
+                if(!asyncRemoveLabelQueue.offer(label)){
+                    LOG.warn("Async queue for removing labels maybe full. current size: [" + asyncRemoveLabelQueue.size() + "]");
+                }
+            });
+        }
+    }
+
+    @Override
+    @Transactional(rollbackFor=Exception.class)
+    public void removeLabelsFromInstance(ServiceInstance serviceInstance) {
+        //Label candidate to be removed
+        List<InsPersistenceLabel> labelsCandidateRemoved = insLabelRelationDao.searchLabelsByInstance(serviceInstance.getInstance());
+        LOG.info("Drop relationships related by instance: [" + serviceInstance.getInstance() + "]");
+        insLabelRelationDao.dropRelationsByInstance(serviceInstance.getInstance());
+        // Async to delete labels that have no relationship
+        if(!labelsCandidateRemoved.isEmpty()){
+            labelsCandidateRemoved.forEach( label -> {
+                if(!asyncQueueInit.get()) {
+                    initQueue();
+                }
+                if(!asyncRemoveLabelQueue.offer(label)){
+                    LOG.warn("Async queue for removing labels maybe full. current size: [" + asyncRemoveLabelQueue.size() + "]");
+                }
+            });
+        }
+    }
+
+
+    @Override
+    public List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels) {
+        return searchInstancesByLabels(labels, Label.ValueRelation.ALL);
+    }
+
+    @Override
+    public List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels, Label.ValueRelation relation) {
+        List<InsPersistenceLabel> insLabels = toInsPersistenceLabels(labels);
+        if (!insLabels.isEmpty()) {
+            List<Map<String, String>> valueContent = new ArrayList<>();
+            AtomicBoolean searchByValues = new AtomicBoolean(false);
+            insLabels.forEach(insLabel -> {
+                //It means that the labels provided is not regular,
+                //so we should search instances by key-value map of labels
+                if (StringUtils.isBlank(insLabel.getStringValue())) {
+                    searchByValues.set(true);
+                }
+                valueContent.add(insLabel.getValue());
+            });
+            List<InstanceInfo> instanceInfoList = new ArrayList<>();
+            if ((relation != Label.ValueRelation.ALL || searchByValues.get()) && valueContent.size() > 0) {
+                instanceInfoList = insLabelRelationDao.searchInsDirectByValues(valueContent, relation.name());
+            } else if (relation == Label.ValueRelation.ALL && !searchByValues.get()) {
+                instanceInfoList = insLabelRelationDao.searchInsDirectByLabels(insLabels);
+            }
+            return instanceInfoList.stream().map(instanceInfo -> (ServiceInstance)instanceInfo).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ServiceInstance> searchUnRelateInstances(ServiceInstance serviceInstance) {
+        if(null != serviceInstance) {
+            return insLabelRelationDao.searchUnRelateInstances(new InstanceInfo(serviceInstance))
+                    .stream().map(instanceInfo -> (ServiceInstance) instanceInfo).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ServiceInstance> searchLabelRelatedInstances(ServiceInstance serviceInstance) {
+        if(null != serviceInstance){
+            return insLabelRelationDao.searchLabelRelatedInstances(new InstanceInfo(serviceInstance))
+                    .stream().map(instanceInfo -> (ServiceInstance) instanceInfo).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void removeLabelsIfNotRelation(List<? extends Label<?>> labels) {
+        List<InsPersistenceLabel> insLabels = toInsPersistenceLabels(labels);
+        insLabels.forEach(insLabel -> {
+            if(Optional.ofNullable(insLabel.getId()).isPresent()){
+                insLabel = instanceLabelDao.selectForUpdate(insLabel.getId());
+            }else{
+                insLabel = instanceLabelDao.searchForUpdate(insLabel.getLabelKey(), insLabel.getStringValue());
+            }
+            if(null != insLabel) {
+                Integer exist = insLabelRelationDao.existRelations(insLabel.getId());
+                //Not exist
+                if(null == exist){
+                    LOG.info("Remove information of instance label: [" + insLabel.toString() + "]");
+                    instanceLabelDao.remove(insLabel);
+                    instanceLabelDao.doRemoveKeyValues(insLabel.getId());
+                }
+            }
+        });
+    }
+
+    /**
+     * Filter labels
+     * @param insLabels labels
+     * @return
+     */
+    private List<InsPersistenceLabel> filterLabelNeededInsert(List<InsPersistenceLabel> insLabels, boolean needLock){
+        List<InsPersistenceLabel> storedLabels = instanceLabelDao.search(insLabels.stream().map(InsPersistenceLabelSearchVo :: new).collect(Collectors.toList()));
+        if(!storedLabels.isEmpty()){
+            List<InsPersistenceLabel> labelsNeedInsert = new ArrayList<>(insLabels);
+            labelsNeedInsert.removeIf(labelNeedInsert -> {
+                for(InsPersistenceLabel storedLabel : storedLabels){
+                    if(labelNeedInsert.equals(storedLabel)){
+                        Integer labelId = storedLabel.getId();
+                        labelNeedInsert.setId(labelId);
+                        if(needLock) {
+                            //Update to lock the record
+                            return instanceLabelDao.updateForLock(labelId) >= 0;
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            });
+            return labelsNeedInsert;
+        }
+        return insLabels;
+    }
+
+    /**
+     * Operation of inserting labels
+     * @param insLabels labels
+     */
+    private void doInsertInsLabels(List<InsPersistenceLabel> insLabels){
+        //Try to insert, use ON DUPLICATE KEY on mysql
+        batchOperation(insLabels, subInsLabels -> instanceLabelDao.insertBatch(subInsLabels), InsLabelConf.DB_PERSIST_BATCH_SIZE.getValue());
+        List<InsPersistenceLabelValue> labelValues = insLabels.stream().flatMap(insLabel -> {
+            if(!Optional.ofNullable(insLabel.getId()).isPresent()){
+                throw new IllegalArgumentException("Cannot get the generated id from bulk insertion, please check your mybatis version");
+            }
+            return insLabel.getValue().entrySet().stream().map( entry ->
+                    new InsPersistenceLabelValue(insLabel.getId(), entry.getKey(), entry.getValue()));
+        }).collect(Collectors.toList());
+        batchOperation(labelValues, subLabelValues -> instanceLabelDao.doInsertKeyValues(subLabelValues), InsLabelConf.DB_PERSIST_BATCH_SIZE.getValue());
+    }
+
+    /**
+     * Operation of inserting instances
+     * @param serviceInstance service instance
+     */
+    private void doInsertInstance(ServiceInstance serviceInstance){
+        //ON DUPLICATE KEY
+        instanceDao.insertOne(new InstanceInfo(serviceInstance));
+    }
+
+    /**
+     * Transform to <em>InsPersistenceLabel</em>
+     * @param labels
+     * @return
+     */
+    private List<InsPersistenceLabel> toInsPersistenceLabels(List<? extends Label<?>> labels){
+        LabelBuilderFactory builderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory();
+        return labels.stream().map(label -> {
+            if(label instanceof InsPersistenceLabel){
+                return (InsPersistenceLabel)label;
+            }
+            InsPersistenceLabel insLabel = builderFactory.convertLabel(label, InsPersistenceLabel.class);
+            insLabel.setStringValue(label.getStringValue());
+            if(StringUtils.isNotBlank(insLabel.getStringValue())){
+                insLabel.setLabelValueSize(insLabel.getValue().size());
+            }
+            return insLabel;
+        }).collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends List<?>>void batchOperation(T input, Consumer<T> batchFunc, int batchSize){
+        int listLen = input.size();
+        if(listLen > 0) {
+            for (int from = 0; from < listLen; ) {
+                int to = Math.min(from + batchSize, listLen);
+                T subInput = (T) input.subList(from, to);
+                batchFunc.accept(subInput);
+                from = to;
+            }
+        }
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/impl/DefaultInsLabelServiceAdapter.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/impl/DefaultInsLabelServiceAdapter.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.instance.label.service.InsLabelAccessService;
+import com.webank.wedatasphere.linkis.instance.label.service.InsLabelServiceAdapter;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+
+public class DefaultInsLabelServiceAdapter implements InsLabelServiceAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultInsLabelServiceAdapter.class);
+
+    private List<AccessServiceContext> serviceContexts = new ArrayList<>();
+
+    public void init(){
+        this.serviceContexts.sort((left, right) -> {
+            int compare = left.order - right.order;
+            if (compare == 0){
+                if(DefaultInsLabelService.class.isAssignableFrom(left.accessService.getClass())){
+                    return -1;
+                }else if(DefaultInsLabelService.class.isAssignableFrom(right.accessService.getClass())){
+                    return 1;
+                }
+            }
+            return compare;
+        });
+    }
+
+    @Override
+    public void registerServices(InsLabelAccessService instanceService) {
+        registerServices(instanceService, -1);
+    }
+
+    @Override
+    public void registerServices(InsLabelAccessService insLabelAccessService, int order) {
+        serviceContexts.add(new AccessServiceContext(insLabelAccessService, order));
+    }
+
+
+    @Override
+    public void attachLabelToInstance(Label<?> label, ServiceInstance serviceInstance) {
+        execOnServiceChain("attachLabelToInstance", insLabelAccessService -> {
+            insLabelAccessService.attachLabelToInstance(label, serviceInstance);
+            return true;
+        }, true, true);
+    }
+
+    @Override
+    public void attachLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance) {
+        execOnServiceChain("attachLabelsToInstance", insLabelAccessService -> {
+            insLabelAccessService.attachLabelsToInstance(labels, serviceInstance);
+            return true;
+        }, true, true);
+    }
+
+    @Override
+    public void refreshLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance) {
+        execOnServiceChain("refreshLabelsToInstance", insLabelAccessService -> {
+            insLabelAccessService.refreshLabelsToInstance(labels, serviceInstance);
+            return true;
+        }, true, true);
+    }
+
+    @Override
+    public void removeLabelsFromInstance(ServiceInstance serviceInstance) {
+        execOnServiceChain("removeLabelsFromInstance", insLabelAccessService -> {
+            insLabelAccessService.removeLabelsFromInstance(serviceInstance);
+            return true;
+        }, true, true);
+    }
+
+    @Override
+    public List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels) {
+        return execOnServiceChain("searchInstancesByLabels", insLabelAccessService ->
+                insLabelAccessService
+                .searchInstancesByLabels(labels, Label.ValueRelation.ALL),
+                false, false);
+    }
+
+    @Override
+    public List<ServiceInstance> searchUnRelateInstances(ServiceInstance serviceInstance) {
+        return execOnServiceChain("searchUnRelateInstances", insLabelAccessService ->
+                insLabelAccessService
+                        .searchUnRelateInstances(serviceInstance),
+                false, false);
+    }
+
+    @Override
+    public List<ServiceInstance> searchLabelRelatedInstances(ServiceInstance serviceInstance) {
+        return execOnServiceChain("searchLabelRelatedInstances", insLabelAccessService ->
+                insLabelAccessService.searchLabelRelatedInstances(serviceInstance),
+                false, false);
+    }
+
+    @Override
+    public void evictCache() {
+        //Empty
+    }
+
+    /**
+     * Execute the function on services' chain
+     * @param execFunc function
+     * @param isFilter if is true, will iterator all the services on the chain
+     * @param allSuccess if is true, will require all the callings is successful
+     * @param <R> return type
+     * @return result
+     */
+    private <R>R execOnServiceChain(String funcName, Function<InsLabelAccessService, R> execFunc, boolean isFilter, boolean allSuccess){
+        R returnStored = null;
+        List<Throwable> errors = new ArrayList<>();
+        for(int i = 0; i < serviceContexts.size(); i ++){
+            AccessServiceContext context = serviceContexts.get(i);
+            try {
+                R callResult = context.exec(execFunc);
+                if(null == returnStored){
+                    //Only store the result of service which is in the head of chain
+                    returnStored = callResult;
+                }
+                if(!isFilter){
+                    break;
+                }
+            }catch(Throwable e){
+                LOG.error("Execute [" + funcName + "] on service: [ " + context.accessService.getClass().getSimpleName() + "] failed, " +
+                        "message: [" + e.getMessage() + "]", e);
+                errors.add(e);
+                if(allSuccess || (i <= serviceContexts.size() - 1 && errors.size() == serviceContexts.size())){
+                    //TODO throw exception
+                }
+            }
+        }
+        return returnStored;
+    }
+    private static class AccessServiceContext {
+        private InsLabelAccessService accessService;
+
+        private int order;
+
+        AccessServiceContext(InsLabelAccessService accessService, int order){
+            this.accessService = accessService;
+            this.order = order;
+        }
+
+        public <R>R exec(Function<InsLabelAccessService, R> execFunc){
+            return execFunc.apply(this.accessService);
+        }
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/impl/EurekaInsLabelService.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/service/impl/EurekaInsLabelService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service.impl;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.instance.label.service.InsLabelAccessService;
+import com.webank.wedatasphere.linkis.instance.label.service.annotation.AdapterMode;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
+
+import java.util.List;
+
+
+@AdapterMode
+public class EurekaInsLabelService implements InsLabelAccessService {
+
+    public EurekaInsLabelService(EurekaDiscoveryClient discoveryClient){
+
+    }
+
+
+    @Override
+    public void attachLabelToInstance(Label<?> label, ServiceInstance serviceInstance) {
+
+    }
+
+    @Override
+    public void attachLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance) {
+
+    }
+
+    @Override
+    public void refreshLabelsToInstance(List<? extends Label<?>> labels, ServiceInstance serviceInstance) {
+
+    }
+
+    @Override
+    public void removeLabelsFromInstance(ServiceInstance serviceInstance) {
+
+    }
+
+    @Override
+    public List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels) {
+        return null;
+    }
+
+    @Override
+    public List<ServiceInstance> searchInstancesByLabels(List<? extends Label<?>> labels, Label.ValueRelation relation) {
+        return null;
+    }
+
+    @Override
+    public List<ServiceInstance> searchUnRelateInstances(ServiceInstance serviceInstance) {
+        return null;
+    }
+
+    @Override
+    public List<ServiceInstance> searchLabelRelatedInstances(ServiceInstance serviceInstance) {
+        return null;
+    }
+
+    @Override
+    public void removeLabelsIfNotRelation(List<? extends Label<?>> labels) {
+
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/vo/InsPersistenceLabelSearchVo.java
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/java/com/webank/wedatasphere/linkis/instance/label/vo/InsPersistenceLabelSearchVo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.vo;
+
+import com.webank.wedatasphere.linkis.instance.label.entity.InsPersistenceLabel;
+
+
+public class InsPersistenceLabelSearchVo {
+
+    private Integer id;
+
+    private String labelKey;
+
+    private String stringValue;
+
+    public InsPersistenceLabelSearchVo(){
+
+    }
+    public InsPersistenceLabelSearchVo(InsPersistenceLabel insLabel){
+        this.id = insLabel.getId();
+        this.labelKey = insLabel.getLabelKey();
+        this.stringValue = insLabel.getStringValue();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getLabelKey() {
+        return labelKey;
+    }
+
+    public void setLabelKey(String labelKey) {
+        this.labelKey = labelKey;
+    }
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/scala/com/webank/wedatasphere/linkis/instance/label/service/InsLabelRpcService.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/scala/com/webank/wedatasphere/linkis/instance/label/service/InsLabelRpcService.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service
+
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.protocol.label.{InsLabelAttachRequest, InsLabelRefreshRequest, InsLabelRemoveRequest}
+
+
+trait InsLabelRpcService {
+
+  /**
+   * Attach labels
+   * @param insLabelAttachRequest request
+   */
+  def attachLabelsToInstance(context: ServiceMethodContext, insLabelAttachRequest: InsLabelAttachRequest): Unit = ???
+
+  /**
+   * Refresh labels
+   * @param insLabelRefreshRequest request
+   */
+  def refreshLabelsToInstance(context: ServiceMethodContext, insLabelRefreshRequest: InsLabelRefreshRequest): Unit = ???
+
+  /**
+   * Remove labels
+   * @param insLabelRemoveRequest request
+   */
+  def removeLabelsFromInstance(context: ServiceMethodContext, insLabelRemoveRequest: InsLabelRemoveRequest): Unit = ???
+}

--- a/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/scala/com/webank/wedatasphere/linkis/instance/label/service/rpc/DefaultInsLabelRpcService.scala
+++ b/linkis-public-enhancements/linkis-publicservice/linkis-instance-label/linkis-instance-label-server/src/main/scala/com/webank/wedatasphere/linkis/instance/label/service/rpc/DefaultInsLabelRpcService.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.instance.label.service.rpc
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.instance.label.service.{InsLabelRpcService, InsLabelServiceAdapter}
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.protocol.label.{InsLabelAttachRequest, InsLabelRefreshRequest, InsLabelRemoveRequest}
+import javax.annotation.{PostConstruct, Resource}
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+@Service
+class DefaultInsLabelRpcService extends InsLabelRpcService with Logging {
+  @Resource
+  private var insLabelService: InsLabelServiceAdapter = _
+
+
+  @PostConstruct
+  def init(): Unit = {
+    info("Use the default implement of rpc service: DefaultInsLabelRpcService")
+  }
+
+  @Receiver
+  override def attachLabelsToInstance(context: ServiceMethodContext, insLabelAttachRequest: InsLabelAttachRequest): Unit = {
+    val labelMap = Option(insLabelAttachRequest.getLabels)
+    val instance = Option(insLabelAttachRequest.getServiceInstance).getOrElse(
+      throw new ErrorException(-1, "field 'serviceInstance' in attachRequest cannot be blank")
+    )
+    val labels = getLabels(labelMap).filter(_ != null)
+    info(s"Start to attach labels[$labels] to instance[$instance]")
+    insLabelService.attachLabelsToInstance(labels, instance)
+    info(s"Success to attach labels[$labels] to instance[$instance]")
+  }
+
+  private def getLabels(labelMap: Option[util.Map[String, Object]]): util.List[Label[_]] = {
+    if(labelMap.isDefined) {
+      LabelBuilderFactoryContext.getLabelBuilderFactory.getLabels(labelMap.get)
+    }else{
+      new util.ArrayList[Label[_]]
+    }
+  }
+
+  @Receiver
+  override def refreshLabelsToInstance(context: ServiceMethodContext, insLabelRefreshRequest: InsLabelRefreshRequest): Unit = {
+    val labelMap = Option(insLabelRefreshRequest.getLabels)
+    val instance = Option(insLabelRefreshRequest.getServiceInstance).getOrElse(
+      throw new ErrorException(-1, "field 'serviceInstance' in refreshRequest cannot be blank")
+    )
+    val labels = getLabels(labelMap)
+    info(s"Start to refresh labels[$labels] to instance[$instance]")
+    insLabelService.refreshLabelsToInstance(labels, instance)
+    info(s"Success to refresh labels[$labels] to instance[$instance]")
+  }
+
+  @Receiver
+  override def removeLabelsFromInstance(context: ServiceMethodContext, insLabelRemoveRequest: InsLabelRemoveRequest): Unit = {
+    val instance = Option(insLabelRemoveRequest.getServiceInstance).getOrElse(
+      throw new ErrorException(-1, "field 'serviceInstance' in removeRequest cannot be blank")
+    )
+    info(s"Start to remove labels from instance[$instance]")
+    insLabelService.removeLabelsFromInstance(instance)
+    info(s"Success to remove labels from instance[$instance]")
+  }
+}


### PR DESCRIPTION
### What is the purpose of the change
Related issues: #604
To provide the ability of tagging for the micro services of linkis, the specific function points are as follows:

### Brief change log
1. Support to increase or decrease tags for related micro services of linkis

2. A unified storage layer is abstracted to allow the tag information of microservice to be stored in other storage media such as database / service registration discovery service

3. Provide a unified client and support crud for the tag information of microservice through RPC

4. The metadata information of Eureka can be registered as a label.