### PR TITLE
Enhance the management and control capabilities of Linkis and add the Linkis AppManager module to manage the life cycle of EC and ECM

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/pom.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!--<relativePath>../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-application-manager</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-service-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-persistence</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-core</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-resource-manager</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>guice</artifactId>
+                    <groupId>com.google.inject</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-label-manager</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-storage</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+            <version>${json4s.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- This package could only be added to one library path of  linkismanager-->
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-monitor</artifactId>
+            <version>${linkis.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>false</skipAssembly>
+                    <finalName>out</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/main/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                    <include>**/*.yml</include>
+                </includes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+
+</project>

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/assembly/distribution.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/assembly/distribution.xml
@@ -1,0 +1,74 @@
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.3 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>linkis-application-manager</id>
+    <formats>
+        <format>dir</format>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>linkis-application-manager</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
+            <!-- Now, select which projects to include in this module-set. -->
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>false</unpack>
+            <useStrictFiltering>true</useStrictFiltering>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>conf</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <!--<fileSet>
+            <directory>${basedir}/bin</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <fileMode>0777</fileMode>
+            <outputDirectory>bin</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <fileSet>
+            <directory>.</directory>
+            <excludes>
+                <exclude>*/**</exclude>
+            </excludes>
+            <outputDirectory>logs</outputDirectory>
+        </fileSet>-->
+    </fileSets>
+
+</assembly>
+

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/LinkisManagerApplication.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/LinkisManagerApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am;
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * @date 2020/7/7 16:22
+ */
+
+public class LinkisManagerApplication {
+
+    private static final Log logger = LogFactory.getLog(LinkisManagerApplication.class);
+
+    public static void main(String[] args) throws ReflectiveOperationException {
+        logger.info("Start to running LinkisManagerApplication");
+        DataWorkCloudApplication.main(args);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/exception/AMErrorException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/exception/AMErrorException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException;
+
+/**
+ * @date 2020/7/6 17:26
+ */
+public class AMErrorException extends ErrorException {
+
+    public AMErrorException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public AMErrorException(int errCode, String desc, Throwable t) {
+        this(errCode, desc);
+        this.initCause(t);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/exception/AMRetryException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/exception/AMRetryException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException;
+
+/**
+ * @date 2020/7/2 21:29
+ */
+public class AMRetryException extends DWCRetryException {
+
+    public AMRetryException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public AMRetryException(int errCode, String desc, Throwable t) {
+        this(errCode, desc);
+        initCause(t);
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/restful/EMRestfulApi.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/restful/EMRestfulApi.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.restful;
+
+import com.webank.wedatasphere.linkis.manager.am.service.em.EMInfoService;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EMNode;
+import com.webank.wedatasphere.linkis.server.Message;
+import com.webank.wedatasphere.linkis.server.security.SecurityFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Component
+@Path("linkisManager")
+public class EMRestfulApi {
+
+    @Autowired
+    private EMInfoService emInfoService;
+
+    @GET
+    @Path("/listAllEMs")
+    public Response listAllEMs(@Context HttpServletRequest req) {
+        String userName = SecurityFilter.getLoginUsername(req);
+        EMNode[] allEM = emInfoService.getAllEM();
+        return Message.messageToResponse(Message.ok().data("EMs", allEM));
+    }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/restful/EngineRestfulApi.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/com/webank/wedatasphere/linkis/manager/am/restful/EngineRestfulApi.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.restful;
+
+import com.webank.wedatasphere.linkis.manager.am.service.engine.EngineInfoService;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.AMEMNode;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode;
+import com.webank.wedatasphere.linkis.server.Message;
+import com.webank.wedatasphere.linkis.server.security.SecurityFilter;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.List;
+
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Component
+@Path("linkisManager")
+public class EngineRestfulApi {
+
+    @Autowired
+    private EngineInfoService engineInfoService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @GET
+    @Path("/listUserEngines")
+    public Response listUserEngines(@Context HttpServletRequest req) {
+        String userName = SecurityFilter.getLoginUsername(req);
+        List<EngineNode> engineNodes = engineInfoService.listUserEngines(userName);
+        return Message.messageToResponse(Message.ok().data("engines", engineNodes));
+    }
+
+    @POST
+    @Path("/listEMEngines")
+    public Response listEMEngines(@Context HttpServletRequest req, JsonNode jsonNode) throws IOException {
+        AMEMNode amemNode = objectMapper.readValue(jsonNode.get("em"), AMEMNode.class);
+        List<EngineNode> engineNodes = engineInfoService.listEMEngines(amemNode);
+        return Message.messageToResponse(Message.ok().data("engines", engineNodes));
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/resources/application.yml
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+server:
+  port: 9101
+spring:
+  application:
+    name: linkis-cg-linkismanager
+
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://127.0.0.1:20303/eureka/
+  instance:
+    metadata-map:
+      test: wedatasphere
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh,info
+  health:
+    db:
+      enabled: false
+logging:
+  config: classpath:log4j2.xml
+
+ribbon:
+  ReadTimeout: 10000
+  ConnectTimeout: 10000

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/resources/linkis-server.properties
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/resources/linkis-server.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2019 WeBank
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##restful
+wds.linkis.server.restful.scan.packages=com.webank.wedatasphere.linkis.manager.am.restful,com.webank.wedatasphere.linkis.resourcemanager.restful
+##mybatis
+wds.linkis.server.mybatis.mapperLocations=classpath:com/webank/wedatasphere/linkis/manager/dao/impl/*.xml,com/webank/wedatasphere/linkis/resourcemanager/external/dao/impl/ExternalResourceProviderDaoImpl.xml
+wds.linkis.server.mybatis.typeAliasesPackage=
+wds.linkis.server.mybatis.BasePackage=com.webank.wedatasphere.linkis.manager.dao,com.webank.wedatasphere.linkis.resourcemanager.external.dao

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/resources/log4j2.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration status="error" monitorInterval="30">
+    <appenders>
+        <RollingFile name="RollingFile" fileName="${env:SERVER_LOG_PATH}/linkis.log"
+                     filePattern="${env:SERVER_LOG_PATH}/$${date:yyyy-MM}/linkis-log-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-40t] %c{1.} (%L) [%M] - %msg%xEx%n"/>
+            <SizeBasedTriggeringPolicy size="100MB"/>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <appender-ref ref="RollingFile"/>
+        </root>
+    </loggers>
+</configuration>
+

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/conf/AMConfiguration.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/conf/AMConfiguration.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+
+/**
+  * @date 2020/7/3 21:17
+  */
+object AMConfiguration {
+
+  val ENGINE_START_MAX_TIME = CommonVars("wds.linkis.manager.am.engine.start.max.time", new TimeType("10m"))
+
+  val ENGINE_REUSE_MAX_TIME = CommonVars("wds.linkis.manager.am.engine.reuse.max.time", new TimeType("5m"))
+
+  val ENGINE_REUSE_COUNT_LIMIT = CommonVars("wds.linkis.manager.am.engine.reuse.count.limit", 10)
+
+  val NODE_STATUS_HEARTBEAT_TIME = CommonVars("wds.linkis.manager.am.node.heartbeat", new TimeType("3m"))
+
+
+  val NODE_HEARTBEAT_MAX_UPDATE_TIME = CommonVars("wds.linkis.manager.am.node.heartbeat", new TimeType("5m"))
+
+  val DEFAULT_NODE_OWNER = CommonVars("wds.linkis.manager.am.default.node.owner", "hadoop")
+
+  val STOP_ENGINE_WAIT = CommonVars("wds.linkis.manager.am.stop.engine.wait", new TimeType("5m"))
+
+  val STOP_EM_WAIT = CommonVars("wds.linkis.manager.am.stop.em.wait", new TimeType("5m"))
+
+  val EM_LABEL_INIT_WAIT = CommonVars("wds.linkis.manager.am.em.label.init.wait", new TimeType("5m"))
+
+  val CONSOLE_CONFIG_SPRING_APPLICATION_NAME = CommonVars("wds.linkis.console.config.application.name", "linkis-ps-publicservice")
+
+  val ENGINECONN_SPRING_APPLICATION_NAME = CommonVars("wds.linkis.engineconn.application.name", "linkis-cg-engineplugin")
+
+  val ENGINECONN_DEBUG_ENABLED = CommonVars("wds.linkis.engineconn.debug.mode.enable", false)
+
+  val MULTI_USER_ENGINE_TYPES = CommonVars("wds.linkis.multi.user.engine.types", "jdbc,es,presto")
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/conf/ConfigurationMapCache.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/conf/ConfigurationMapCache.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.conf
+
+import java.util
+
+import com.webank.wedatasphere.linkis.governance.common.protocol.conf.{RequestQueryEngineConfig, RequestQueryGlobalConfig, ResponseQueryConfig}
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import com.webank.wedatasphere.linkis.protocol.CacheableProtocol
+import com.webank.wedatasphere.linkis.rpc.RPCMapCache
+
+
+
+object ConfigurationMapCache {
+
+  val globalMapCache = new RPCMapCache[UserCreatorLabel, String, String](
+    AMConfiguration.CONSOLE_CONFIG_SPRING_APPLICATION_NAME.getValue) {
+    override protected def createRequest(userCreatorLabel: UserCreatorLabel): CacheableProtocol = RequestQueryGlobalConfig(userCreatorLabel.getUser)
+
+    override protected def createMap(any: Any): util.Map[String, String] = any match {
+      case response: ResponseQueryConfig => response.getKeyAndValue
+    }
+  }
+
+  val engineMapCache = new RPCMapCache[(UserCreatorLabel, EngineTypeLabel), String, String](
+    AMConfiguration.CONSOLE_CONFIG_SPRING_APPLICATION_NAME.getValue) {
+    override protected def createRequest(labelTuple: (UserCreatorLabel, EngineTypeLabel)): CacheableProtocol =
+      RequestQueryEngineConfig(labelTuple._1, labelTuple._2)
+
+    override protected def createMap(any: Any): util.Map[String, String] = any match {
+      case response: ResponseQueryConfig => response.getKeyAndValue
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/conf/EngineConnConfigurationService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/conf/EngineConnConfigurationService.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.conf
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import com.webank.wedatasphere.linkis.server.JMap
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.{Bean, Configuration}
+
+import scala.collection.JavaConversions._
+
+/**
+  * @date 2020/9/15 20:46
+  */
+trait EngineConnConfigurationService {
+
+  def getConsoleConfiguration(label: util.List[Label[_]]): util.Map[String, String]
+
+}
+
+class DefaultEngineConnConfigurationService extends EngineConnConfigurationService with Logging {
+
+  override def getConsoleConfiguration(label: util.List[Label[_]]): util.Map[String, String] = {
+    val properties = new JMap[String, String]
+    val userCreatorLabelOption = label.find(_.isInstanceOf[UserCreatorLabel])
+    val engineTypeLabelOption = label.find(_.isInstanceOf[EngineTypeLabel])
+    if (userCreatorLabelOption.isDefined) {
+      val userCreatorLabel = userCreatorLabelOption.get.asInstanceOf[UserCreatorLabel]
+      val globalConfig = Utils.tryAndWarn(ConfigurationMapCache.globalMapCache.getCacheMap(userCreatorLabel))
+      if (null != globalConfig) {
+        properties.putAll(globalConfig)
+      }
+      if (engineTypeLabelOption.isDefined) {
+        val engineTypeLabel = engineTypeLabelOption.get.asInstanceOf[EngineTypeLabel]
+        val engineConfig = Utils.tryAndWarn(ConfigurationMapCache.engineMapCache.getCacheMap((userCreatorLabel, engineTypeLabel)))
+        if (null != engineConfig) {
+          properties.putAll(engineConfig)
+        }
+      }
+    }
+    properties
+  }
+
+}
+
+
+@Configuration
+class ApplicationManagerSpringConfiguration{
+
+  @ConditionalOnMissingBean
+  @Bean
+  def getDefaultEngineConnConfigurationService:EngineConnConfigurationService ={
+    new DefaultEngineConnConfigurationService
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/converter/DefaultMetricsConverter.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/converter/DefaultMetricsConverter.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.converter
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.{NodeHealthyInfo, NodeMetrics, NodeOverLoadInfo, NodeTaskInfo}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.AMNode
+import com.webank.wedatasphere.linkis.manager.service.common.metrics.MetricsConverter
+import com.webank.wedatasphere.linkis.server.BDPJettyServerHelper
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/9 15:31
+  */
+@Component
+class DefaultMetricsConverter extends MetricsConverter with Logging {
+
+  override def parseTaskInfo(nodeMetrics: NodeMetrics): NodeTaskInfo = {
+    val msg = nodeMetrics.getHeartBeatMsg
+    if (StringUtils.isNotBlank(msg)) {
+      val jsonNode = BDPJettyServerHelper.jacksonJson.readTree(msg)
+      if (jsonNode != null && jsonNode.has("taskInfo")) {
+        val taskInfo = BDPJettyServerHelper.jacksonJson.readValue(jsonNode.get("taskInfo").asText(), classOf[NodeTaskInfo])
+        return taskInfo
+      }
+    }
+    null
+  }
+
+  override def parseHealthyInfo(nodeMetrics: NodeMetrics): NodeHealthyInfo = {
+    val healthyInfo = nodeMetrics.getHealthy
+    if (StringUtils.isNotBlank(healthyInfo)) {
+      BDPJettyServerHelper.jacksonJson.readValue(healthyInfo, classOf[NodeHealthyInfo])
+    } else {
+      null
+    }
+  }
+
+  override def parseOverLoadInfo(nodeMetrics: NodeMetrics): NodeOverLoadInfo = {
+    val overLoad = nodeMetrics.getOverLoad
+    if (StringUtils.isNotBlank(overLoad)) {
+      BDPJettyServerHelper.jacksonJson.readValue(overLoad, classOf[NodeOverLoadInfo])
+    } else {
+      null
+    }
+  }
+
+  override def parseStatus(nodeMetrics: NodeMetrics): NodeStatus = {
+    NodeStatus.values()(nodeMetrics.getStatus)
+  }
+
+
+  override def convertTaskInfo(nodeTaskInfo: NodeTaskInfo): String = {
+    BDPJettyServerHelper.jacksonJson.writeValueAsString(nodeTaskInfo)
+  }
+
+  override def convertHealthyInfo(nodeHealthyInfo: NodeHealthyInfo): String = {
+    BDPJettyServerHelper.jacksonJson.writeValueAsString(nodeHealthyInfo)
+  }
+
+  override def convertOverLoadInfo(nodeOverLoadInfo: NodeOverLoadInfo): String = {
+    BDPJettyServerHelper.jacksonJson.writeValueAsString(nodeOverLoadInfo)
+  }
+
+  override def convertStatus(nodeStatus: NodeStatus): Int = {
+    nodeStatus.ordinal()
+  }
+
+  override def fillMetricsToNode(amNode: AMNode, metrics: NodeMetrics): AMNode = {
+    if(metrics == null) return amNode
+    amNode.setNodeStatus(parseStatus(metrics))
+    amNode.setNodeTaskInfo(parseTaskInfo(metrics))
+    amNode.setNodeHealthyInfo(parseHealthyInfo(metrics))
+    amNode.setNodeOverLoadInfo(parseOverLoadInfo(metrics))
+    amNode
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/AMLabelChecker.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/AMLabelChecker.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.em.EMInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import com.webank.wedatasphere.linkis.manager.service.common.label.LabelChecker
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+/**
+  * @date 2020/8/6 11:38
+  */
+@Component
+class AMLabelChecker extends LabelChecker {
+
+  override def checkEngineLabel(labelList: util.List[Label[_]]): Boolean = {
+    checkCorrespondingLabel(labelList, classOf[EngineTypeLabel], classOf[UserCreatorLabel])
+  }
+
+  override def checkEMLabel(labelList: util.List[Label[_]]): Boolean = {
+    checkCorrespondingLabel(labelList, classOf[EMInstanceLabel])
+  }
+
+  override def checkCorrespondingLabel(labelList: util.List[Label[_]], clazz: Class[_]*): Boolean = {
+    // TODO: 是否需要做子类的判断
+    labelList.map(_.getClass).containsAll(clazz)
+  }
+}
+
+object AD{
+  def main(args: Array[String]): Unit = {
+    val label = new UserCreatorLabel
+    val checker = new AMLabelChecker
+    println(checker.checkCorrespondingLabel(util.Arrays.asList(label),classOf[UserCreatorLabel]))
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/AMLabelFilter.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/AMLabelFilter.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf._
+import com.webank.wedatasphere.linkis.manager.label.entity.node.AliasServiceInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.entity.{EMNodeLabel, EngineNodeLabel, Label}
+import com.webank.wedatasphere.linkis.manager.service.common.label.LabelFilter
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+/**
+ * @date 2020/8/9 21:17
+ */
+@Component
+class AMLabelFilter extends LabelFilter {
+
+  override def choseEngineLabel(labelList: util.List[Label[_]]): util.List[Label[_]] = {
+    labelList.filter {
+      case _: EngineNodeLabel => true
+      // TODO: magic
+      case label: AliasServiceInstanceLabel if label.getAlias.equals(ENGINE_CONN_SPRING_NAME.getValue) => true
+      case _ => false
+    }
+  }
+
+  override def choseEMLabel(labelList: util.List[Label[_]]): util.List[Label[_]] = {
+    labelList.filter {
+      case _: EMNodeLabel => true
+      // TODO: magic
+      case label: AliasServiceInstanceLabel if label.getAlias.equals(ENGINE_CONN_MANAGER_SPRING_NAME.getValue) => true
+      case _ => false
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/DefaultManagerLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/DefaultManagerLabelService.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.em.EMInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
+import com.webank.wedatasphere.linkis.manager.service.common.label.ManagerLabelService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+/**
+  * @date 2020/8/5 14:46
+  */
+@Service
+class DefaultManagerLabelService extends ManagerLabelService with Logging {
+
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+
+  override def isEngine(serviceInstance: ServiceInstance): Boolean = {
+    val list = nodeLabelService.getNodeLabels(serviceInstance)
+    isEngine(list)
+  }
+
+  override def isEM(serviceInstance: ServiceInstance): Boolean = {
+    val list = nodeLabelService.getNodeLabels(serviceInstance)
+    val isEngine = list.exists {
+      case _: EngineInstanceLabel =>
+        true
+      case _ => false
+    }
+    if (!isEngine) {
+      list.exists {
+        case _: EMInstanceLabel =>
+          true
+        case _ => false
+      }
+    } else {
+      false
+    }
+  }
+
+  override def isEngine(labels: util.List[Label[_]]): Boolean = {
+    labels.exists {
+      case _: EngineInstanceLabel =>
+        true
+      case _ => false
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/EngineReuseLabelRester.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/EngineReuseLabelRester.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+/**
+  * @date 2021/1/13 10:42
+  */
+trait EngineReuseLabelChooser {
+
+
+  def chooseLabels(labelList: util.List[Label[_]]): util.List[Label[_]]
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/MultiUserEngineReuseLabelChooser.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/label/MultiUserEngineReuseLabelChooser.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConverters._
+
+/**
+  * @date 2021/1/13 10:46
+  */
+@Component
+class MultiUserEngineReuseLabelChooser extends EngineReuseLabelChooser with Logging {
+
+  private val multiUserEngine = AMConfiguration.MULTI_USER_ENGINE_TYPES.getValue.split(",")
+
+  /**
+    * 过滤掉支持多用户引擎的UserCreator Label
+    *
+    * @param labelList
+    * @return
+    */
+  override def chooseLabels(labelList: util.List[Label[_]]): util.List[Label[_]] = {
+    val labels = labelList.asScala
+    val engineTypeLabelOption = labels.find(_.isInstanceOf[EngineTypeLabel])
+    if (engineTypeLabelOption.isDefined) {
+      val engineTypeLabel = engineTypeLabelOption.get.asInstanceOf[EngineTypeLabel]
+      val maybeString = multiUserEngine.find(_.equalsIgnoreCase(engineTypeLabel.getEngineType))
+      if (maybeString.isDefined) {
+        info("For multi user engine remove userCreatorLabel")
+        return labels.filterNot(_.isInstanceOf[UserCreatorLabel]).asJava
+      }
+    }
+    labelList
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/locker/DefaultEngineNodeLocker.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/locker/DefaultEngineNodeLocker.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.locker
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMEngineNode, EngineNode}
+import com.webank.wedatasphere.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock, RequestManagerUnlock}
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.NodePointerBuilder
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/16 21:05
+  */
+@Component
+class DefaultEngineNodeLocker extends EngineNodeLocker with Logging {
+
+  @Autowired
+  private var nodeBuilder: NodePointerBuilder = _
+
+  override def lockEngine(engineNode: EngineNode, timeout: Long): Option[String] = {
+    //TODO 判断engine需要的锁类型进行不同的实例化
+    nodeBuilder.buildEngineNodePointer(engineNode).lockEngine(RequestEngineLock(timeout))
+  }
+
+
+  override def releaseLock(engineNode: EngineNode, lock: String): Unit = {
+    nodeBuilder.buildEngineNodePointer(engineNode).releaseLock(RequestEngineUnlock(lock))
+  }
+
+  @Receiver
+  def releaseLock(requestManagerUnlock: RequestManagerUnlock): Unit = {
+    info(s"client${requestManagerUnlock.clientInstance} Start to unlock engine ${requestManagerUnlock.engineInstance}")
+    val engineNode = new AMEngineNode()
+    engineNode.setServiceInstance(requestManagerUnlock.engineInstance)
+    releaseLock(engineNode, requestManagerUnlock.lock)
+    info(s"client${requestManagerUnlock.clientInstance} Finished to unlock engine ${requestManagerUnlock.engineInstance}")
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/locker/EngineNodeLocker.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/locker/EngineNodeLocker.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.locker
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+
+/**
+  * @date 2020/7/4 22:05
+  */
+trait EngineNodeLocker {
+
+
+  def lockEngine(engineNode: EngineNode, timeout: Long): Option[String]
+
+
+  def releaseLock(engineNode: EngineNode, lock: String): Unit
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/DefaultEMNodeManager.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/DefaultEMNodeManager.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.manager
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.node._
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineStopRequest
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
+import com.webank.wedatasphere.linkis.manager.persistence.{NodeManagerPersistence, NodeMetricManagerPersistence}
+import com.webank.wedatasphere.linkis.manager.service.common.metrics.MetricsConverter
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.NodePointerBuilder
+import com.webank.wedatasphere.linkis.resourcemanager.service.ResourceManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+/**
+  * @date 2020/7/18 16:59
+  */
+@Component
+class DefaultEMNodeManager extends EMNodeManager with Logging {
+
+  @Autowired
+  private var nodeManagerPersistence: NodeManagerPersistence = _
+
+  @Autowired
+  private var nodeMetricManagerPersistence: NodeMetricManagerPersistence = _
+
+  @Autowired
+  private var metricsConverter: MetricsConverter = _
+
+  @Autowired
+  private var nodePointerBuilder: NodePointerBuilder = _
+
+  @Autowired
+  private var resourceManager: ResourceManager = _
+
+
+  override def emRegister(emNode: EMNode): Unit = {
+    nodeManagerPersistence.addNodeInstance(emNode)
+    // init metric
+    nodeMetricManagerPersistence.addOrupdateNodeMetrics(metricsConverter.getInitMetric(emNode.getServiceInstance))
+  }
+
+  override def addEMNodeInstance(emNode: EMNode):Unit = {
+    nodeManagerPersistence.addNodeInstance(emNode)
+  }
+
+  override def initEMNodeMetrics(emNode: EMNode): Unit = {
+    nodeMetricManagerPersistence.addOrupdateNodeMetrics(metricsConverter.getInitMetric(emNode.getServiceInstance))
+  }
+
+  override def listEngines(emNode: EMNode): util.List[EngineNode] = {
+    val nodes = nodeManagerPersistence.getEngineNodeByEM(emNode.getServiceInstance)
+    val metricses = nodeMetricManagerPersistence.getNodeMetrics(nodes).map(m => (m.getServiceInstance.toString,m)).toMap
+    nodes.map{ node =>
+      metricses.get(node.getServiceInstance.toString).foreach(metricsConverter.fillMetricsToNode(node,_))
+      node
+    }
+    nodes
+  }
+
+
+  override def listUserEngines(emNode: EMNode, user: String): util.List[EngineNode] = {
+    listEngines(emNode).filter(_.getOwner.equals(user))
+  }
+
+  def listUserNodes(user: String): java.util.List[Node] = {
+    nodeManagerPersistence.getNodes(user)
+  }
+
+  /**
+    * Get detailed em information from the persistence
+    * TODO add label to node ?
+    *
+    * @param scoreServiceInstances
+    * @return
+    */
+  override def getEMNodes(scoreServiceInstances: Array[ScoreServiceInstance]): Array[EMNode] = {
+
+    if (null == scoreServiceInstances || scoreServiceInstances.isEmpty) {
+      return null
+    }
+    val emNodes = scoreServiceInstances.map {
+      scoreServiceInstances =>
+        val emNode = new AMEMNode()
+        emNode.setScore(scoreServiceInstances.getScore)
+        emNode.setServiceInstance(scoreServiceInstances.getServiceInstance)
+        emNode
+    }
+    //1. 增加nodeMetrics  2 增加RM信息
+    val resourceInfo = resourceManager.getResourceInfo(scoreServiceInstances.map(_.getServiceInstance))
+    val nodeMetrics = nodeMetricManagerPersistence.getNodeMetrics(emNodes.toList)
+    emNodes.map { emNode =>
+      val optionMetrics = nodeMetrics.find(_.getServiceInstance.equals(emNode.getServiceInstance))
+      val optionRMNode = resourceInfo.resourceInfo.find(_.getServiceInstance.equals(emNode.getServiceInstance))
+      optionMetrics.foreach(metricsConverter.fillMetricsToNode(emNode, _))
+      optionRMNode.foreach(rmNode => emNode.setNodeResource(rmNode.getNodeResource))
+      emNode
+    }
+    emNodes.toArray
+  }
+
+  override def getEM(serviceInstance: ServiceInstance): EMNode = {
+    val node = nodeManagerPersistence.getNode(serviceInstance)
+    val emNode = new AMEMNode()
+    emNode.setOwner(node.getOwner)
+    emNode.setServiceInstance(node.getServiceInstance)
+    emNode.setMark(emNode.getMark)
+    metricsConverter.fillMetricsToNode(emNode, nodeMetricManagerPersistence.getNodeMetrics(emNode))
+    emNode
+  }
+
+  override def stopEM(emNode: EMNode): Unit = {
+    nodePointerBuilder.buildEMNodePointer(emNode).stopNode()
+  }
+
+  override def deleteEM(emNode: EMNode): Unit = {
+
+    nodeManagerPersistence.removeNodeInstance(emNode)
+    info("Finished to clear emNode instance info")
+    nodeMetricManagerPersistence.deleteNodeMetrics(emNode)
+    info("Finished to clear emNode metrics info")
+  }
+
+  override def pauseEM(serviceInstance: ServiceInstance): Unit = {
+
+  }
+
+  /**
+    * 1. request engineManager to launch engine
+    *
+    * @param engineBuildRequest
+    * @param emNode
+    * @return
+    */
+  override def createEngine(engineBuildRequest: EngineConnBuildRequest, emNode: EMNode): EngineNode = {
+    nodePointerBuilder.buildEMNodePointer(emNode).createEngine(engineBuildRequest)
+  }
+
+  override def stopEngine(engineStopRequest: EngineStopRequest, emNode: EMNode): Unit = {
+    nodePointerBuilder.buildEMNodePointer(emNode).stopEngine(engineStopRequest)
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/DefaultEngineNodeManager.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/DefaultEngineNodeManager.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.manager
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.am.locker.EngineNodeLocker
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMEngineNode, EngineNode, ScoreServiceInstance}
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineInstanceLabel
+import com.webank.wedatasphere.linkis.manager.persistence.{LabelManagerPersistence, NodeManagerPersistence, NodeMetricManagerPersistence}
+import com.webank.wedatasphere.linkis.manager.service.common.metrics.MetricsConverter
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.NodePointerBuilder
+import com.webank.wedatasphere.linkis.resourcemanager.service.ResourceManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+/**
+  * @date 2020/7/4 15:50
+  */
+@Service
+class DefaultEngineNodeManager extends EngineNodeManager with Logging {
+
+  @Autowired
+  private var engineLocker: EngineNodeLocker = _
+
+  @Autowired
+  private var nodeManagerPersistence: NodeManagerPersistence = _
+
+  @Autowired
+  private var nodeMetricManagerPersistence: NodeMetricManagerPersistence = _
+
+  @Autowired
+  private var metricsConverter: MetricsConverter = _
+
+  @Autowired
+  private var nodePointerBuilder: NodePointerBuilder = _
+
+
+  @Autowired
+  private var resourceManager: ResourceManager = _
+
+  @Autowired
+  private var labelManagerPersistence: LabelManagerPersistence = _
+
+  override def listEngines(user: String): util.List[EngineNode] = {
+    // TODO: user 应该是除了root，hadoop
+    val nodes = nodeManagerPersistence.getNodes(user).map(_.getServiceInstance).map(nodeManagerPersistence.getEngineNode)
+    val metricses = nodeMetricManagerPersistence.getNodeMetrics(nodes).map(m => (m.getServiceInstance.toString, m)).toMap
+    nodes.map { node =>
+      metricses.get(node.getServiceInstance.toString).foreach(metricsConverter.fillMetricsToNode(node, _))
+      node
+    }
+  }
+
+  override def getEngineNodeInfo(engineNode: EngineNode): EngineNode = {
+    /**
+      * 修改为实时请求对应的EngineNode
+      */
+    val engine = nodePointerBuilder.buildEngineNodePointer(engineNode)
+    val heartMsg = engine.getNodeHeartbeatMsg()
+    engineNode.setNodeHealthyInfo(heartMsg.getHealthyInfo)
+    engineNode.setNodeOverLoadInfo(heartMsg.getOverLoadInfo)
+    engineNode.setNodeResource(heartMsg.getNodeResource)
+    engineNode.setNodeStatus(heartMsg.getStatus)
+    engineNode
+  }
+
+  override def getEngineNodeInfoByDB(engineNode: EngineNode): EngineNode = {
+    //1. 从持久化器中获取EngineNode信息，需要获取Task信息和Status信息，方便后面使用
+    metricsConverter.fillMetricsToNode(engineNode, nodeMetricManagerPersistence.getNodeMetrics(engineNode))
+    engineNode
+  }
+
+  override def updateEngineStatus(serviceInstance: ServiceInstance, fromState: NodeStatus, toState: NodeStatus): Unit = {
+
+  }
+
+  override def updateEngine(engineNode: EngineNode): Unit = {
+
+  }
+
+  override def switchEngine(engineNode: EngineNode): EngineNode = {
+    null
+  }
+
+  override def reuseEngine(engineNode: EngineNode): EngineNode = {
+    useEngine(engineNode)
+  }
+
+  /**
+    * TODO use Engine需要考虑流式引擎的场景，后续需要通过Label加额外的处理
+    *
+    * @param engineNode
+    * @param timeout
+    * @return
+    */
+  override def useEngine(engineNode: EngineNode, timeout: Long): EngineNode = {
+    val node = getEngineNodeInfo(engineNode)
+    if (!NodeStatus.isAvailable(node.getNodeStatus)) {
+      return null
+    }
+    if (!NodeStatus.isLocked(node.getNodeStatus)) {
+      val lockStr = engineLocker.lockEngine(node, timeout)
+      if (lockStr.isEmpty) {
+        throw new DWCRetryException(AMConstant.ENGINE_ERROR_CODE, s"Failed to request lock from engine ${node.getServiceInstance}")
+      }
+      node.setLock(lockStr.get)
+    }
+    node
+  }
+
+
+  override def useEngine(engineNode: EngineNode): EngineNode = {
+    useEngine(engineNode, -1)
+  }
+
+
+  /**
+    * Get detailed engine information from the persistence
+    * //TODO 是否增加owner到node
+    *
+    * @param scoreServiceInstances
+    * @return
+    */
+  override def getEngineNodes(scoreServiceInstances: Array[ScoreServiceInstance]): Array[EngineNode] = {
+    if (null == scoreServiceInstances || scoreServiceInstances.isEmpty) {
+      return null
+    }
+    val engineNodes = scoreServiceInstances.map {
+      scoreServiceInstances =>
+        val engineNode = new AMEngineNode()
+        engineNode.setScore(scoreServiceInstances.getScore)
+        engineNode.setServiceInstance(scoreServiceInstances.getServiceInstance)
+        engineNode
+    }
+    //1. 增加nodeMetrics 2 增加RM信息
+    val resourceInfo = resourceManager.getResourceInfo(scoreServiceInstances.map(_.getServiceInstance))
+    val nodeMetrics = nodeMetricManagerPersistence.getNodeMetrics(engineNodes.toList)
+    engineNodes.map { engineNode =>
+      val optionMetrics = nodeMetrics.find(_.getServiceInstance.equals(engineNode.getServiceInstance))
+
+      val optionRMNode = resourceInfo.resourceInfo.find(_.getServiceInstance.equals(engineNode.getServiceInstance))
+
+      optionMetrics.foreach(metricsConverter.fillMetricsToNode(engineNode, _))
+      optionRMNode.foreach(rmNode => engineNode.setNodeResource(rmNode.getNodeResource))
+
+      engineNode
+    }
+  }
+
+
+  /*private def fillMetricsToNode(engineNode: EngineNode, metrics: NodeMetrics): EngineNode = {
+
+    engineNode.setNodeStatus(metricsConverter.parseStatus(metrics))
+    engineNode.setNodeTaskInfo(metricsConverter.parseTaskInfo(metrics))
+    engineNode.setNodeHealthyInfo(metricsConverter.parseHealthyInfo(metrics))
+    engineNode.setNodeOverLoadInfo(metricsConverter.parseOverLoadInfo(metrics))
+    engineNode
+  }*/
+
+  /* /**
+     * clear engine info from persistence
+     * invoke deleteNode
+     *
+     * @param stopEngineRequest
+     */
+   override def stopEngine(stopEngineRequest: EngineStopRequest): Unit = {
+     val instance = stopEngineRequest.getServiceInstance
+     val node = new AMEngineNode()
+     node.setServiceInstance(instance)
+     nodePointerBuilder.buildEngineNodePointer(node).stopNode()
+     deleteEngineNode(node)
+   }*/
+
+  /**
+    * add info to persistence
+    *
+    * @param engineNode
+    */
+  override def addEngineNode(engineNode: EngineNode): Unit = {
+    nodeManagerPersistence.addEngineNode(engineNode)
+    // init metric
+    nodeMetricManagerPersistence.addOrupdateNodeMetrics(metricsConverter.getInitMetric(engineNode.getServiceInstance))
+  }
+
+
+  /**
+    * delete info to persistence
+    *
+    * @param engineNode
+    */
+  override def deleteEngineNode(engineNode: EngineNode): Unit = {
+    nodeManagerPersistence.deleteEngineNode(engineNode)
+    nodeMetricManagerPersistence.deleteNodeMetrics(engineNode)
+  }
+
+  override def getEngineNode(serviceInstance: ServiceInstance): EngineNode = {
+    nodeManagerPersistence.getEngineNode(serviceInstance)
+  }
+
+  override def updateEngineNode(serviceInstance: ServiceInstance, engineNode: EngineNode): Unit = {
+    nodeManagerPersistence.updateEngineNode(serviceInstance, engineNode)
+    //1.serviceInstance中取出instance（实际是ticketId）
+    //2.update serviceInstance 表，包括 instance替换，替换mark，owner，updator，creator的空值，更新updateTime
+    //3.update engine_em关联表
+    //4.update label ticket_id ==> instance
+    val labelBuilderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
+    val engineLabel = labelBuilderFactory.createLabel(classOf[EngineInstanceLabel])
+    engineLabel.setInstance(engineNode.getServiceInstance.getInstance)
+    engineLabel.setServiceName(engineNode.getServiceInstance.getApplicationName)
+    val oldEngineLabel = labelBuilderFactory.createLabel(classOf[EngineInstanceLabel])
+    oldEngineLabel.setInstance(serviceInstance.getInstance)
+    oldEngineLabel.setServiceName(engineNode.getServiceInstance.getApplicationName)
+    val oldPersistenceLabel = labelBuilderFactory.convertLabel(oldEngineLabel, classOf[PersistenceLabel])
+    val label = labelManagerPersistence.getLabelByKeyValue(oldPersistenceLabel.getLabelKey, oldPersistenceLabel.getStringValue)
+    val persistenceLabel = labelBuilderFactory.convertLabel(engineLabel, classOf[PersistenceLabel])
+    persistenceLabel.setLabelValueSize(persistenceLabel.getValue.size())
+    labelManagerPersistence.updateLabel(label.getId, persistenceLabel)
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/EMNodeManager.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/EMNodeManager.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.manager
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode, Node, ScoreServiceInstance}
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineStopRequest
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
+
+/**
+  * @date 2020/6/12 15:46
+  */
+trait EMNodeManager {
+
+  def emRegister(emNode: EMNode): Unit
+
+  def listEngines(emNode: EMNode): java.util.List[EngineNode]
+
+  def listUserEngines(emNode: EMNode, user: String): java.util.List[EngineNode]
+
+  def listUserNodes(user: String): java.util.List[Node]
+
+  /**
+    * Get detailed em information from the persistence
+    *
+    * @param scoreServiceInstances
+    * @return
+    */
+  def getEMNodes(scoreServiceInstances: Array[ScoreServiceInstance]): Array[EMNode]
+
+  def getEM(serviceInstance: ServiceInstance): EMNode
+
+  def stopEM(emNode: EMNode): Unit
+
+  def deleteEM(emNode: EMNode): Unit
+
+  def pauseEM(serviceInstance: ServiceInstance): Unit
+
+  /**
+    * 1. request engineManager to launch engine
+    * 2. persist engine info
+    *
+    * @param engineBuildRequest
+    * @param emNode
+    * @return
+    */
+  def createEngine(engineBuildRequest: EngineConnBuildRequest, emNode: EMNode): EngineNode
+
+  def stopEngine(engineStopRequest: EngineStopRequest, emNode: EMNode): Unit
+
+
+  def addEMNodeInstance(emNode: EMNode): Unit
+
+  def initEMNodeMetrics(emNode: EMNode): Unit
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/EngineNodeManager.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/manager/EngineNodeManager.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.manager
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EngineNode, ScoreServiceInstance}
+
+/**
+  * @date 2020/6/12 15:44
+  */
+trait EngineNodeManager {
+
+
+  def listEngines(user: String): java.util.List[EngineNode]
+
+  def getEngineNode(serviceInstance: ServiceInstance): EngineNode
+
+  def getEngineNodeInfo(engineNode: EngineNode): EngineNode
+
+  def getEngineNodeInfoByDB(engineNode: EngineNode): EngineNode
+
+  /**
+    * Get detailed engine information from the persistence
+    *
+    * @param scoreServiceInstances
+    * @return
+    */
+  def getEngineNodes(scoreServiceInstances: Array[ScoreServiceInstance]): Array[EngineNode]
+
+  def updateEngineStatus(serviceInstance: ServiceInstance, fromState: NodeStatus, toState: NodeStatus): Unit
+
+  /**
+    * add info to persistence
+    *
+    * @param engineNode
+    */
+  def addEngineNode(engineNode: EngineNode): Unit
+
+  def updateEngineNode(serviceInstance: ServiceInstance, engineNode: EngineNode): Unit
+
+  def updateEngine(engineNode: EngineNode): Unit
+
+  /**
+    * delete info to persistence
+    *
+    * @param engineNode
+    */
+  def deleteEngineNode(engineNode: EngineNode): Unit
+
+  def switchEngine(engineNode: EngineNode): EngineNode
+
+  def reuseEngine(engineNode: EngineNode): EngineNode
+
+  def useEngine(engineNode: EngineNode): EngineNode
+
+  def useEngine(engineNode: EngineNode, timeout: Long): EngineNode
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/AbstractNodePointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/AbstractNodePointer.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.pointer
+
+import com.webank.wedatasphere.linkis.common.exception.WarnException
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.protocol.node._
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.NodePointer
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+/**
+  * @date 2020/7/16 20:19
+  */
+abstract class AbstractNodePointer extends NodePointer with Logging {
+
+
+  protected def getSender: Sender = {
+    Sender.getSender(getNode().getServiceInstance)
+  }
+
+  /**
+    * 向对应的Node发送请求获取节点状态
+    *
+    * @return
+    */
+  override def getNodeStatus(): NodeStatus = {
+    val sender = getSender
+    sender.ask(new RequestNodeStatus) match {
+      case responseStatus: ResponseNodeStatus =>
+        responseStatus.getNodeStatus
+      case warn: WarnException => throw warn
+    }
+  }
+
+  /**
+    * 向对应的Node发送请求获取节点心跳信息
+    *
+    * @return
+    */
+  override def getNodeHeartbeatMsg(): NodeHeartbeatMsg = {
+    val sender = getSender
+    sender.ask(new NodeHeartbeatRequest) match {
+      case heartbeatMsg: NodeHeartbeatMsg =>
+        heartbeatMsg
+      case warn: WarnException => throw warn
+    }
+  }
+
+  /**
+    * 向对应的Node发送Kill 请求
+    *
+    * @return
+    */
+  override def stopNode(): Unit = {
+    val sender = getSender
+    sender.send(new StopNodeRequest)
+  }
+
+  /**
+    * 向对应的Node Label 更新请求
+    *
+    * @return
+    */
+  override def updateLabels(labels: Array[Label[_]]): Unit = ???
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultEMNodPointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultEMNodPointer.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.pointer
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.manager.am.exception.AMErrorException
+import com.webank.wedatasphere.linkis.manager.am.service.engine.EngineStopService
+import com.webank.wedatasphere.linkis.manager.am.utils.AMUtils
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EngineNode, Node}
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineStopRequest, EngineStopResponse, EngineSuicideRequest}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.EMNodPointer
+
+/**
+  * @date 2020/7/13 20:12
+  */
+class DefaultEMNodPointer(val node: Node) extends AbstractNodePointer with EMNodPointer {
+
+
+  /**
+    * 与该远程指针关联的node信息
+    *
+    * @return
+    */
+  override def getNode(): Node = node
+
+  override def createEngine(engineBuildRequest: EngineConnBuildRequest): EngineNode = {
+    info(s"Start to createEngine ask em ${getNode().getServiceInstance}")
+    getSender.ask(engineBuildRequest) match {
+      case engineNode: EngineNode =>
+        info(s"Succeed to createEngine ask em ${getNode().getServiceInstance}, engineNode $engineNode ")
+        engineNode
+      case _ => throw new AMErrorException(AMConstant.ENGINE_ERROR_CODE, s"Failed to ask engine")
+    }
+  }
+
+  override def stopEngine(engineStopRequest: EngineStopRequest): Unit = {
+    Utils.tryAndWarn {
+      getSender.ask(engineStopRequest) match {
+        case engineStopResponse: EngineStopResponse =>
+          if (!engineStopResponse.getStopStatus) {
+            info(s"Kill engine : ${engineStopRequest.getServiceInstance.toString} failed, because ${engineStopResponse.getMsg} . Will ask engine to suicide.")
+            val engineSuicideRequest = new EngineSuicideRequest(engineStopRequest.getServiceInstance, engineStopRequest.getUser)
+            EngineStopService.askEngineToSuicide(engineSuicideRequest)
+          } else {
+            info(s"Succeed to kill engine ${engineStopRequest.getServiceInstance.toString}.")
+          }
+        case o: AnyRef =>
+          warn(s"Ask em : ${getNode().getServiceInstance.toString} to kill engine : ${engineStopRequest.getServiceInstance.toString} failed, response is : ${AMUtils.GSON.toJson(o)}. ")
+      }
+    }
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultEngineConnPluginPointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultEngineConnPluginPointer.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.pointer
+
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.am.exception.AMErrorException
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.EngineResourceRequest
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/9/17 20:17
+  */
+@Component
+class DefaultEngineConnPluginPointer extends EngineConnPluginPointer {
+
+  private def getEngineConnPluginSender: Sender = Sender.getSender(AMConfiguration.ENGINECONN_SPRING_APPLICATION_NAME.getValue)
+
+  override def createEngineResource(engineResourceRequest: EngineResourceRequest): NodeResource = {
+    getEngineConnPluginSender.ask(engineResourceRequest) match {
+      case nodeResource: NodeResource =>
+        nodeResource
+      case _ =>
+        throw new AMErrorException(AMConstant.ENGINE_ERROR_CODE, s"Failed to create engineResource")
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultEngineNodPointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultEngineNodPointer.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node
+import com.webank.wedatasphere.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock, ResponseEngineLock}
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.EngineNodePointer
+
+/**
+  * @date 2020/7/13 20:12
+  */
+class DefaultEngineNodPointer(val node: Node) extends AbstractNodePointer with EngineNodePointer {
+
+
+  /**
+    * 与该远程指针关联的node信息
+    *
+    * @return
+    */
+  override def getNode(): Node = node
+
+  override def lockEngine(requestEngineLock: RequestEngineLock): Option[String] = {
+    getSender.ask(requestEngineLock) match {
+      case ResponseEngineLock(lockStatus, lock, msg) =>
+        if (lockStatus) {
+          Some(lock)
+        } else {
+          error("Failed to get locker: " + msg)
+          None
+        }
+      case _ => None
+    }
+  }
+
+  override def releaseLock(requestEngineUnlock: RequestEngineUnlock): Unit = {
+    getSender.send(requestEngineUnlock)
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultNodePointerBuilder.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/DefaultNodePointerBuilder.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode}
+import com.webank.wedatasphere.linkis.manager.service.common.pointer.{EMNodPointer, EngineNodePointer, NodePointerBuilder}
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/13 20:09
+  */
+@Component
+class DefaultNodePointerBuilder extends NodePointerBuilder {
+
+
+  override def buildEMNodePointer(node: EMNode): EMNodPointer = {
+    new DefaultEMNodPointer(node)
+  }
+
+  override def buildEngineNodePointer(node: EngineNode): EngineNodePointer = {
+    new DefaultEngineNodPointer(node)
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/EngineConnPluginPointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/pointer/EngineConnPluginPointer.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.EngineResourceRequest
+
+/**
+  * @date 2020/9/17 20:15
+  */
+trait EngineConnPluginPointer {
+
+  def createEngineResource(engineResourceRequest: EngineResourceRequest): NodeResource
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/recycle/AssignNodeRuleExecutor.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/recycle/AssignNodeRuleExecutor.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.recycle
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.recycle.{AssignNodeRule, RecyclingRule}
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/12 17:48
+  */
+@Component
+class AssignNodeRuleExecutor extends RecyclingRuleExecutor {
+
+  override def ifAccept(recyclingRule: RecyclingRule): Boolean = recyclingRule.isInstanceOf[AssignNodeRule]
+
+  override def executeRule(recyclingRule: RecyclingRule): Array[ServiceInstance] = recyclingRule match {
+    case AssignNodeRule(serviceInstance, user) =>
+      Array(serviceInstance)
+    case _ => null
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/recycle/RecyclingRuleExecutor.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/recycle/RecyclingRuleExecutor.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.recycle
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.recycle.RecyclingRule
+
+/**
+  * @date 2020/7/10 15:21
+  */
+trait RecyclingRuleExecutor {
+
+  def ifAccept(recyclingRule: RecyclingRule): Boolean
+
+  def executeRule(recyclingRule: RecyclingRule): Array[ServiceInstance]
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/rpc/ManagerRPCFormats.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/rpc/ManagerRPCFormats.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.rpc
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.ResourceSerializer
+import com.webank.wedatasphere.linkis.manager.common.serializer.NodeResourceSerializer
+import com.webank.wedatasphere.linkis.resourcemanager.ResultResourceSerializer
+import com.webank.wedatasphere.linkis.rpc.transform.RPCFormats
+import org.json4s.Serializer
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/8/27 17:29
+  */
+@Component
+class ManagerRPCFormats extends RPCFormats {
+
+  override def getSerializers: Array[Serializer[_]] = Array(ResultResourceSerializer, ResourceSerializer, NodeResourceSerializer)
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/DefaultNodeSelector.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/DefaultNodeSelector.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.am.selector.rule.NodeSelectRule
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+/**
+  * @date 2020/7/2 14:42
+  */
+@Service
+class DefaultNodeSelector extends NodeSelector with Logging {
+
+  @Autowired
+  private var ruleList: util.List[NodeSelectRule] = _
+
+
+  /**
+    * Select the most suitable node from a series of nodes through selection rules
+    * 1. Rule processing logic, defaults to the last priority
+    *
+    * @param nodes
+    * @return
+    */
+  override def choseNode(nodes: Array[Node]): Option[Node] = {
+    if (null == nodes || nodes.isEmpty){
+      None
+    } else if (null == ruleList ) {
+      Some(nodes(0))
+    } else {
+      var resultNodes = nodes
+      Utils.tryAndWarnMsg {
+        ruleList.foreach { rule =>
+          resultNodes = rule.ruleFiltering(resultNodes)
+        }
+      }("Failed to execute select rule")
+      if (resultNodes.isEmpty) {
+        None
+      } else {
+        Some(resultNodes(0))
+      }
+    }
+  }
+
+  override def getNodeSelectRules(): Array[NodeSelectRule] = {
+    if (null != ruleList) ruleList.toList.toArray
+    else Array.empty[NodeSelectRule]
+  }
+
+  override def addNodeSelectRule(nodeSelectRule: NodeSelectRule): Unit = {
+    if (null != nodeSelectRule) {
+      this.ruleList.add(nodeSelectRule)
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/NodeSelector.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/NodeSelector.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector
+
+import com.webank.wedatasphere.linkis.manager.am.selector.rule.NodeSelectRule
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node
+
+/**
+  * @date 2020/6/30 22:44
+  */
+trait NodeSelector {
+
+  def choseNode(nodes: Array[Node]): Option[Node]
+
+  def getNodeSelectRules(): Array[NodeSelectRule]
+
+  def addNodeSelectRule(nodeSelectRule: NodeSelectRule): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/AvailableNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/AvailableNodeSelectRule.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMNode, Node}
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+  * require node state are idle or busy
+  *
+  * @date 2020/7/4 22:54
+  */
+@Component
+@Order(2)
+class AvailableNodeSelectRule extends NodeSelectRule {
+
+  override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
+    if (null != nodes) {
+      nodes.filter {
+        case amNode: AMNode =>
+          !NodeStatus.isLocked(amNode.getNodeStatus) // && NodeHealthy.isAvailable(amNode.getNodeHealthyInfo.getNodeHealthy)
+        case node: Node => NodeStatus.isAvailable(node.getNodeStatus)
+      }
+    } else {
+      nodes
+    }
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/ConcurrencyNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/ConcurrencyNodeSelectRule.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/4 22:54
+  */
+@Component
+@Order(1)
+class ConcurrencyNodeSelectRule extends NodeSelectRule {
+
+  override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
+    nodes
+    //1. 并发选择规则只对Engine有效
+    //2. TODO 通过标签判断engine是否支持并发，如果Engine为io,状态，当支持并发engine需要进行保留
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/NodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/NodeSelectRule.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node
+
+/**
+  * @date 2020/6/30 22:48
+  */
+trait NodeSelectRule {
+
+  def ruleFiltering(nodes: Array[Node]): Array[Node]
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/OverLoadNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/OverLoadNodeSelectRule.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMNode, Node}
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/15 16:51
+  */
+@Component
+@Order(3)
+class OverLoadNodeSelectRule extends NodeSelectRule with Logging {
+
+  override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
+    if (null != nodes)
+      nodes.sortWith(sortByOverload)
+    else
+      nodes
+  }
+
+  /**
+    * sort by sortByOverload
+    *
+    * @param nodeA
+    * @param nodeB
+    * @return
+    */
+  private def sortByOverload(nodeA: Node, nodeB: Node): Boolean = {
+    nodeA match {
+      case node: AMNode if nodeB.isInstanceOf[AMNode] =>
+        Utils.tryCatch(getOverload(node.getNodeOverLoadInfo) < getOverload(nodeB.asInstanceOf[AMNode].getNodeOverLoadInfo)) {
+          t: Throwable =>
+            warn("Failed to Compare resource ", t)
+            true
+        }
+
+      case _ => false
+    }
+  }
+
+  private def getOverload(overloadInfo: NodeOverLoadInfo): Float = {
+    if (overloadInfo == null) 0f else overloadInfo.getUsedMemory * 1f / overloadInfo.getMaxMemory
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/ResourceNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/ResourceNodeSelectRule.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{Node, RMNode}
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/4 22:54
+  */
+@Component
+@Order(5)
+class ResourceNodeSelectRule extends NodeSelectRule with Logging {
+
+  override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
+    if (null != nodes)
+      nodes.sortWith(sortByResource)
+    else
+      nodes
+  }
+
+  /**
+    * sort by label score
+    *
+    * @param nodeA
+    * @param nodeB
+    * @return
+    */
+  private def sortByResource(nodeA: Node, nodeB: Node): Boolean = {
+    nodeA match {
+      case node: RMNode if nodeB.isInstanceOf[RMNode] =>
+        Utils.tryCatch(node.getNodeResource.getLeftResource > nodeB.asInstanceOf[RMNode].getNodeResource.getLeftResource) {
+          t: Throwable =>
+            warn("Failed to Compare resource ", t)
+            true
+        }
+      case _ => false
+    }
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/ScoreNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/ScoreNodeSelectRule.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{Node, ScoreServiceInstance}
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/4 22:54
+  */
+@Component
+@Order(0)
+class ScoreNodeSelectRule extends NodeSelectRule with Logging {
+
+  override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
+    if (null != nodes)
+      nodes.sortWith(sortByScore)
+    else
+      nodes
+  }
+
+  /**
+    * sort by label score
+    *
+    * @param nodeA
+    * @param nodeB
+    * @return
+    */
+  private def sortByScore(nodeA: Node, nodeB: Node): Boolean = {
+    nodeA match {
+      case instance: ScoreServiceInstance if nodeB.isInstanceOf[ScoreServiceInstance] =>
+        Utils.tryCatch(instance.getScore > nodeB.asInstanceOf[ScoreServiceInstance].getScore) {
+          t: Throwable =>
+            warn("Failed to Compare resource ", t)
+            true
+        }
+
+      case _ => false
+    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/TaskInfoNodeSelectRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/selector/rule/TaskInfoNodeSelectRule.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.selector.rule
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeTaskInfo
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMNode, Node}
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+  * @date 2020/7/4 22:54
+  */
+@Component
+@Order(4)
+class TaskInfoNodeSelectRule extends NodeSelectRule with Logging {
+
+  override def ruleFiltering(nodes: Array[Node]): Array[Node] = {
+    if (null != nodes)
+      nodes.sortWith(sortByTaskInfo)
+    else
+      nodes
+  }
+
+  /**
+    * sort by label score
+    *
+    * @param nodeA
+    * @param nodeB
+    * @return
+    */
+  private def sortByTaskInfo(nodeA: Node, nodeB: Node): Boolean = {
+    nodeA match {
+      case node: AMNode if nodeB.isInstanceOf[AMNode] =>
+        Utils.tryCatch(getTasks(node.getNodeTaskInfo) < getTasks(nodeB.asInstanceOf[AMNode].getNodeTaskInfo)) {
+          t: Throwable =>
+            warn("Failed to Compare resource ", t)
+            true
+        }
+      case _ => false
+    }
+  }
+
+  private def getTasks(nodeTaskInfo: NodeTaskInfo): Int = {
+    if (nodeTaskInfo == null)  0 else nodeTaskInfo.getTasks
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/EMEngineService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/EMEngineService.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode, ScoreServiceInstance}
+import com.webank.wedatasphere.linkis.manager.common.protocol.em._
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+/**
+  * @date 2020/6/12 15:26
+  */
+trait EMEngineService {
+
+
+  def listEngines(getEMEnginesRequest: GetEMEnginesRequest): util.List[EngineNode]
+
+  def createEngine(engineBuildRequest: EngineConnBuildRequest, emNode: EMNode): EngineNode
+
+  def stopEngine(engineNode: EngineNode, EMNode: EMNode): Unit
+
+  def getEMNodes(scoreServiceInstances: Array[ScoreServiceInstance]): Array[EMNode]
+
+  def getEMNodes(labels: util.List[Label[_]]): Array[EMNode]
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/EngineService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/EngineService.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service
+
+import com.webank.wedatasphere.linkis.manager.am.manager.EngineNodeManager
+
+/**
+  * @date 2020/6/12 15:26
+  */
+trait EngineService {
+
+
+
+  def getEngineNodeManager:EngineNodeManager
+
+  def getEMService(): EMEngineService
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/HeartbeatService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/HeartbeatService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.NodeHeartbeatMsg
+
+/**
+  * @date 2020/7/9 16:42
+  */
+trait HeartbeatService {
+
+  def heartbeatEventDeal(nodeHeartbeatMsg: NodeHeartbeatMsg): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMEngineService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMEngineService.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.am.exception.AMErrorException
+import com.webank.wedatasphere.linkis.manager.am.manager.{EMNodeManager, EngineNodeManager}
+import com.webank.wedatasphere.linkis.manager.am.service.EMEngineService
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.node._
+import com.webank.wedatasphere.linkis.manager.common.protocol.em._
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineStopRequest
+import com.webank.wedatasphere.linkis.manager.common.utils.ManagerUtils
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
+import com.webank.wedatasphere.linkis.manager.label.entity.{EngineNodeLabel, Label}
+import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
+import com.webank.wedatasphere.linkis.manager.service.common.label.LabelFilter
+import org.apache.commons.collections.MapUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+
+/**
+  * @date 2020/7/16 14:59
+  */
+@Service
+class DefaultEMEngineService extends EMEngineService with Logging {
+
+  @Autowired
+  private var emNodeManager: EMNodeManager = _
+
+  @Autowired
+  private var engineNodeManager: EngineNodeManager = _
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Autowired
+  private var labelFilter: LabelFilter = _
+
+  override def listEngines(getEMEnginesRequest: GetEMEnginesRequest): util.List[EngineNode] = {
+    val emNode = new AMEMNode()
+    emNode.setServiceInstance(getEMEnginesRequest.getEm)
+    emNodeManager.listEngines(emNode)
+  }
+
+
+  override def createEngine(engineBuildRequest: EngineConnBuildRequest, emNode: EMNode): EngineNode = {
+
+    info(s"EM ${emNode.getServiceInstance} start to create Engine ${engineBuildRequest}")
+    val engineNode = emNodeManager.createEngine(engineBuildRequest, emNode)
+    info(s"EM ${emNode.getServiceInstance} Finished to create Engine ${engineBuildRequest}")
+    engineNode.setLabels(emNode.getLabels.filter(_.isInstanceOf[EngineNodeLabel]))
+    engineNode.setEMNode(emNode)
+    engineNode
+
+  }
+
+  override def stopEngine(engineNode: EngineNode, emNode: EMNode): Unit = {
+    info(s"EM ${emNode.getServiceInstance} start to stop Engine ${engineNode.getServiceInstance}")
+    val engineStopRequest = new EngineStopRequest
+    engineStopRequest.setServiceInstance(engineNode.getServiceInstance)
+    emNodeManager.stopEngine(engineStopRequest, emNode)
+    //engineNodeManager.deleteEngineNode(engineNode)
+    info(s"EM ${emNode.getServiceInstance} finished to stop Engine ${engineNode.getServiceInstance}")
+  }
+
+  override def getEMNodes(scoreServiceInstances: Array[ScoreServiceInstance]): Array[EMNode] = {
+    emNodeManager.getEMNodes(scoreServiceInstances)
+  }
+
+  override def getEMNodes(labels: util.List[Label[_]]): Array[EMNode] = {
+    val instanceAndLabels = nodeLabelService.getScoredNodeMapsByLabels(labelFilter.choseEMLabel(labels))
+    if (MapUtils.isEmpty(instanceAndLabels)) {
+      new AMErrorException(AMConstant.EM_ERROR_CODE, "No corresponding EM")
+    }
+    val nodes = getEMNodes(instanceAndLabels.keys.toArray)
+    if (null == nodes) {
+      return null
+    }
+    nodes.foreach { node =>
+      val persistenceLabel = instanceAndLabels.find(_._1.getServiceInstance.equals(node.getServiceInstance)).map(_._2)
+      persistenceLabel.foreach(labelList => node.setLabels(labelList.map(ManagerUtils.persistenceLabelToRealLabel)))
+    }
+    nodes
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMInfoService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMInfoService.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.am.manager.EMNodeManager
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EMNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.GetEMInfoRequest
+import com.webank.wedatasphere.linkis.manager.label.entity.node.AliasServiceInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.resourcemanager.service.ResourceManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+/**
+ * @date 2020/8/4 21:17
+ */
+
+@Service
+class DefaultEMInfoService extends EMInfoService with Logging {
+
+  @Autowired
+  private var emNodeManager: EMNodeManager = _
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Autowired
+  private var resourceManager: ResourceManager = _
+
+  @Receiver
+  override def getEM(getEMInfoRequest: GetEMInfoRequest): EMNode = {
+    emNodeManager.getEM(getEMInfoRequest.getEm)
+  }
+
+  /**
+   * 通过Label去拿，AliasServiceInstanceLabel 指定type为EM
+   *
+   * @return
+   */
+  override def getAllEM(): Array[EMNode] = {
+    val label = new AliasServiceInstanceLabel
+    label.setAlias("em")
+    val instances = nodeLabelService.getNodesByLabel(label)
+    val resourceInfo = resourceManager.getResourceInfo(instances.toSeq.toArray).resourceInfo
+    val resourceInfoMap = resourceInfo.map(r => (r.getServiceInstance.toString, r)).toMap
+    instances.map(emNodeManager.getEM).map { node =>
+      node.setLabels(nodeLabelService.getNodeLabels(node.getServiceInstance))
+      resourceInfoMap.get(node.getServiceInstance.toString).map(_.getNodeResource).foreach(node.setNodeResource)
+      node
+    }.toArray[EMNode]
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMRegisterService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMRegisterService.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.am.manager.EMNodeManager
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{AMEMNode, EMNode}
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.RegisterEMRequest
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.em.EMInstanceLabel
+import com.webank.wedatasphere.linkis.message.annotation.{Order, Receiver}
+import com.webank.wedatasphere.linkis.message.publisher.MessagePublisher
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelAddRequest
+import org.apache.commons.lang.StringUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2020/8/4 20:14
+  */
+@Service
+class DefaultEMRegisterService extends EMRegisterService with Logging {
+
+
+  @Autowired
+  private var emNodeManager: EMNodeManager = _
+
+  @Autowired
+  private var publisher: MessagePublisher = _
+
+  def registerEMRequest2EMNode(emRegister: RegisterEMRequest): EMNode = {
+    val emNode = new AMEMNode()
+    emNode.setServiceInstance(emRegister.getServiceInstance)
+    val owner = if (StringUtils.isNotBlank(emRegister.getUser)) emRegister.getUser else AMConfiguration.DEFAULT_NODE_OWNER.getValue
+    emNode.setOwner(owner)
+    emNode.setMark(AMConstant.PROCESS_MARK)
+    emNode
+  }
+
+
+  /**
+    * EM注册请求的第一个处理的请求，用于插入Instance信息
+    *
+    * @param emRegister
+    */
+  @Receiver
+  @Order(1)
+  override def addEMNodeInstance(emRegister: RegisterEMRequest): Unit = {
+    info(s"Start to save em{${emRegister.getServiceInstance}}  in persistence")
+    emNodeManager.addEMNodeInstance(registerEMRequest2EMNode(emRegister))
+    info(s"Finished to save em{${emRegister.getServiceInstance}}  in persistence")
+    val eMInstanceLabel = LabelBuilderFactoryContext.getLabelBuilderFactory.createLabel(classOf[EMInstanceLabel])
+    eMInstanceLabel.setServiceName(emRegister.getServiceInstance.getApplicationName)
+    eMInstanceLabel.setInstance(emRegister.getServiceInstance.getInstance)
+    if (null == emRegister.getLabels) {
+      emRegister.setLabels(new util.HashMap[String, Object]())
+    }
+    emRegister.getLabels.put(eMInstanceLabel.getLabelKey, eMInstanceLabel.getValue)
+    val instanceLabelAddRequest = new NodeLabelAddRequest(emRegister.getServiceInstance, emRegister.getLabels)
+    info(s"Start to publish em{${emRegister.getServiceInstance}} label request to Label ")
+    val job = publisher.publish(instanceLabelAddRequest)
+    Utils.tryAndWarn(job.get(AMConfiguration.EM_LABEL_INIT_WAIT.getValue.toLong, TimeUnit.MILLISECONDS))
+    info(s"Finished to deal em{${emRegister.getServiceInstance}} label ")
+  }
+
+  /**
+    * EM注册插入的初始Metrics信息
+    *
+    * @param emRegister
+    */
+  @Receiver
+  override def addEMNodeMetrics(emRegister: RegisterEMRequest): Unit = {
+    info(s"Start to init em{${emRegister.getServiceInstance}}  metrics")
+    emNodeManager.initEMNodeMetrics(registerEMRequest2EMNode(emRegister))
+    info(s"Finished to init em{${emRegister.getServiceInstance}}  metrics")
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMUnregisterService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/DefaultEMUnregisterService.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.am.manager.EMNodeManager
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.{EMInfoClearRequest, StopEMRequest}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelRemoveRequest
+import com.webank.wedatasphere.linkis.rpc.utils.RPCUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2020/8/4 20:27
+  */
+@Service
+class DefaultEMUnregisterService extends EMUnregisterService with Logging {
+
+  @Autowired
+  private var emNodeManager: EMNodeManager = _
+
+  @Receiver
+  override def stopEM(stopEMRequest: StopEMRequest, smc: ServiceMethodContext): Unit = {
+    info(s" user ${stopEMRequest.getUser} prepare to stop em ${stopEMRequest.getEm}")
+    val node = emNodeManager.getEM(stopEMRequest.getEm)
+    if (node.getOwner != stopEMRequest.getUser) {
+      info(s" ${stopEMRequest.getUser}  are not owner, will not to stopEM")
+    }
+    if (!RPCUtils.getServiceInstanceFromSender(smc.getSender).equals(stopEMRequest.getEm)) {
+      emNodeManager.stopEM(node)
+    }
+    info(s" user ${stopEMRequest.getUser} Finished to stop em process ${stopEMRequest.getEm}")
+    //clear RM info
+    val emClearRequest = new EMInfoClearRequest
+    emClearRequest.setEm(node)
+    emClearRequest.setUser(stopEMRequest.getUser)
+    val job = smc.publish(emClearRequest)
+    // clear Label
+    val instanceLabelRemoveRequest = new NodeLabelRemoveRequest(node.getServiceInstance, false)
+    val labelJob = smc.publish(instanceLabelRemoveRequest)
+    Utils.tryAndWarn(job.get(AMConfiguration.STOP_ENGINE_WAIT.getValue.toLong, TimeUnit.MILLISECONDS))
+    Utils.tryAndWarn(labelJob.get(AMConfiguration.STOP_ENGINE_WAIT.getValue.toLong, TimeUnit.MILLISECONDS))
+    clearEMInstanceInfo(emClearRequest)
+    info(s" user ${stopEMRequest.getUser} finished to stop em ${stopEMRequest.getEm}")
+  }
+
+  override def clearEMInstanceInfo(emClearRequest: EMInfoClearRequest): Unit = {
+    info(s" user ${emClearRequest.getUser} prepare to clear em info ${emClearRequest.getEm.getServiceInstance}")
+    emNodeManager.deleteEM(emClearRequest.getEm)
+    info(s" user ${emClearRequest.getUser} Finished to clear em info ${emClearRequest.getEm.getServiceInstance}")
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/EMInfoService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/EMInfoService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EMNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.GetEMInfoRequest
+
+
+trait EMInfoService {
+
+  def getEM(getEMInfoRequest: GetEMInfoRequest): EMNode
+
+  def getAllEM(): Array[EMNode]
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/EMRegisterService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/EMRegisterService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.RegisterEMRequest
+
+/**
+  * @date 2020/8/4 19:52
+  */
+trait EMRegisterService {
+
+
+  /**
+    * EM注册请求的第一个处理的请求，用于插入Instance信息
+    *
+    * @param emRegister
+    */
+  def addEMNodeInstance(emRegister: RegisterEMRequest): Unit
+
+  /**
+    * EM注册插入的初始Metrics信息
+    *
+    * @param emRegister
+    */
+  def addEMNodeMetrics(emRegister: RegisterEMRequest): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/EMUnregisterService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/em/EMUnregisterService.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.em
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.{EMInfoClearRequest, StopEMRequest}
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+
+/**
+  * @date 2020/8/4 20:04
+  */
+trait EMUnregisterService {
+
+  def stopEM(stopEMRequest: StopEMRequest, smc: ServiceMethodContext): Unit
+
+  def clearEMInstanceInfo(emClearRequest: EMInfoClearRequest): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/AbstractEngineService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/AbstractEngineService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.manager.am.manager.EngineNodeManager
+import com.webank.wedatasphere.linkis.manager.am.service.{EMEngineService, EngineService}
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+  * @date 2020/7/1 17:01
+  */
+abstract class AbstractEngineService extends EngineService {
+
+  @Autowired
+  private var emService: EMEngineService = _
+
+  @Autowired
+  private var engineNodeManager:EngineNodeManager = _
+
+  override def getEMService(): EMEngineService = {
+    this.emService
+  }
+
+  override def getEngineNodeManager: EngineNodeManager = {
+    this.engineNodeManager
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineAskEngineService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineAskEngineService.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine._
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.rpc.Sender
+import org.apache.commons.lang.exception.ExceptionUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.util.{Failure, Success}
+
+/**
+  * @date 2020/6/14 18:21
+  */
+@Service
+class DefaultEngineAskEngineService extends AbstractEngineService with EngineAskEngineService with Logging {
+
+  @Autowired
+  private var engineCreateService: EngineCreateService = _
+
+  @Autowired
+  private var engineReuseService: EngineReuseService = _
+
+  @Autowired
+  private var engineSwitchService: EngineSwitchService = _
+
+  private val idCreator = new AtomicInteger()
+
+  private val idPrefix = Sender.getThisServiceInstance.getInstance
+
+  @Receiver
+  override def askEngine(engineAskRequest: EngineAskRequest, smc: ServiceMethodContext): Any = {
+
+    val engineReuseRequest = new EngineReuseRequest()
+    engineReuseRequest.setLabels(engineAskRequest.getLabels)
+    engineReuseRequest.setTimeOut(engineAskRequest.getTimeOut)
+    engineReuseRequest.setUser(engineAskRequest.getUser)
+
+    val reuseNode = Utils.tryAndWarn(engineReuseService.reuseEngine(engineReuseRequest))
+    if (null != reuseNode) {
+      info(s"Finished to ask engine for user ${engineAskRequest.getUser} by reuse node $reuseNode")
+      return reuseNode
+    }
+
+    val createNodeThread = Future {
+      //如果原来的labels含engineInstance ，先去掉
+      engineAskRequest.getLabels.remove("engineInstance")
+      val engineCreateRequest = new EngineCreateRequest
+      engineCreateRequest.setLabels(engineAskRequest.getLabels)
+      engineCreateRequest.setTimeOut(engineAskRequest.getTimeOut)
+      engineCreateRequest.setUser(engineAskRequest.getUser)
+      engineCreateRequest.setProperties(engineAskRequest.getProperties)
+
+      val createNode = engineCreateService.createEngine(engineCreateRequest, smc)
+      val timeout = if (engineCreateRequest.getTimeOut <= 0) AMConfiguration.ENGINE_START_MAX_TIME.getValue.toLong else engineCreateRequest.getTimeOut
+      //useEngine 需要加上超时
+      val createEngineNode = getEngineNodeManager.useEngine(createNode, timeout)
+      info(s"Finished to ask engine for user ${engineAskRequest.getUser} by create node $createEngineNode")
+      createEngineNode
+    }
+
+    val engineAskAsyncId = getAsyncId
+    createNodeThread.onComplete {
+      case Success(engineNode) =>
+        info(s"Success to async($engineAskAsyncId) createEngine $engineNode")
+        smc.getSender.send(EngineCreateSuccess(engineAskAsyncId, engineNode))
+      case Failure(exception) =>
+        info(s"Failed  to async($engineAskAsyncId) createEngine ", exception)
+        smc.getSender.send(EngineCreateError(engineAskAsyncId, ExceptionUtils.getRootCauseMessage(exception)))
+    }
+
+    EngineAskAsyncResponse(engineAskAsyncId, Sender.getThisServiceInstance)
+  }
+
+  private def getAsyncId: String = {
+    idPrefix + "_" + idCreator.getAndIncrement()
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineConnStatusCallbackService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineConnStatusCallbackService.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.AMNodeMetrics
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnStatusCallbackToAM
+import com.webank.wedatasphere.linkis.manager.persistence.NodeMetricManagerPersistence
+import com.webank.wedatasphere.linkis.manager.service.common.metrics.MetricsConverter
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.server.BDPJettyServerHelper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2021/1/1 20:58
+  */
+@Service
+class DefaultEngineConnStatusCallbackService extends EngineConnStatusCallbackService with Logging {
+
+  @Autowired
+  private var nodeMetricManagerPersistence: NodeMetricManagerPersistence = _
+
+  @Autowired
+  private var metricsConverter: MetricsConverter = _
+
+  @Receiver
+  override def dealEngineConnStatusCallback(engineConnStatusCallbackToAM: EngineConnStatusCallbackToAM): Unit = {
+
+    info(s"Start to deal engineConnStatusCallbackToAM $engineConnStatusCallbackToAM")
+    val nodeMetrics = new AMNodeMetrics
+    val heartBeatMsg: java.util.Map[String, String] = new util.HashMap[String, String]()
+    heartBeatMsg.put(AMConstant.START_REASON, engineConnStatusCallbackToAM.initErrorMsg)
+    nodeMetrics.setHeartBeatMsg(BDPJettyServerHelper.jacksonJson.writeValueAsString(heartBeatMsg))
+    nodeMetrics.setServiceInstance(engineConnStatusCallbackToAM.serviceInstance)
+    nodeMetrics.setStatus(metricsConverter.convertStatus(engineConnStatusCallbackToAM.status))
+    nodeMetricManagerPersistence.addOrupdateNodeMetrics(nodeMetrics)
+    info(s"Finished to deal engineConnStatusCallbackToAM $engineConnStatusCallbackToAM")
+
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+
+import java.util
+import java.util.concurrent.{TimeUnit, TimeoutException}
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf.ENGINE_CONN_MANAGER_SPRING_NAME
+import com.webank.wedatasphere.linkis.manager.am.conf.{AMConfiguration, EngineConnConfigurationService}
+import com.webank.wedatasphere.linkis.manager.am.exception.AMErrorException
+import com.webank.wedatasphere.linkis.manager.am.pointer.EngineConnPluginPointer
+import com.webank.wedatasphere.linkis.manager.am.selector.NodeSelector
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode}
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineCreateRequest, EngineStopRequest}
+import com.webank.wedatasphere.linkis.manager.common.utils.ManagerUtils
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.{EngineConnBuildRequestImpl, EngineConnCreationDescImpl}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.resource.TimeoutEngineResourceRequest
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineTypeLabel
+import com.webank.wedatasphere.linkis.manager.label.entity.node.AliasServiceInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.entity.{EngineNodeLabel, Label}
+import com.webank.wedatasphere.linkis.manager.label.service.{NodeLabelService, UserLabelService}
+import com.webank.wedatasphere.linkis.manager.label.utils.LabelUtils
+import com.webank.wedatasphere.linkis.manager.persistence.NodeMetricManagerPersistence
+import com.webank.wedatasphere.linkis.manager.service.common.label.{LabelChecker, LabelFilter}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.resourcemanager.service.ResourceManager
+import com.webank.wedatasphere.linkis.resourcemanager.{AvailableResource, NotEnoughResource}
+import com.webank.wedatasphere.linkis.server.BDPJettyServerHelper
+import org.apache.commons.lang.StringUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration.Duration
+
+
+/**
+  * @date 2020/6/30 22:40
+  */
+@Service
+class DefaultEngineCreateService extends AbstractEngineService with EngineCreateService with Logging {
+
+
+  @Autowired
+  private var nodeSelector: NodeSelector = _
+
+  @Autowired
+  private var engineRecycleService: EngineRecycleService = _
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Autowired
+  private var resourceManager: ResourceManager = _
+
+  @Autowired
+  private var labelCheckerList: util.List[LabelChecker] = _
+
+  @Autowired
+  private var labelFilter: LabelFilter = _
+
+  @Autowired
+  private var userLabelService: UserLabelService = _
+
+  @Autowired
+  private var engineConnConfigurationService: EngineConnConfigurationService = _
+
+  @Autowired
+  private var engineConnPluginPointer: EngineConnPluginPointer = _
+
+
+  @Autowired
+  private var nodeMetricManagerPersistence: NodeMetricManagerPersistence = _
+
+  @Receiver
+  @throws[DWCRetryException]
+  override def createEngine(engineCreateRequest: EngineCreateRequest, smc: ServiceMethodContext): EngineNode = {
+
+    info(s"Start to create Engine for request: $engineCreateRequest")
+    val labelBuilderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
+    val timeout = if (engineCreateRequest.getTimeOut <= 0) AMConfiguration.ENGINE_START_MAX_TIME.getValue.toLong else engineCreateRequest.getTimeOut
+
+    //1. 检查Label是否合法
+    val labelList: util.List[Label[_]] = LabelUtils.distinctLabel(labelBuilderFactory.getLabels(engineCreateRequest.getLabels),
+      userLabelService.getUserLabels(engineCreateRequest.getUser))
+
+    for (labelChecker <- labelCheckerList) {
+      if (!labelChecker.checkEngineLabel(labelList)) {
+        throw new AMErrorException(AMConstant.EM_ERROR_CODE, "Need to specify engineType and userCreator label")
+      }
+    }
+
+    val emLabelList = new util.ArrayList[Label[_]](labelList)
+    val emInstanceLabel = labelBuilderFactory.createLabel(classOf[AliasServiceInstanceLabel])
+    emInstanceLabel.setAlias(ENGINE_CONN_MANAGER_SPRING_NAME.getValue)
+    emLabelList.add(emInstanceLabel)
+    //2. NodeLabelService getNodesByLabel  获取EMNodeList
+    val emScoreNodeList = getEMService().getEMNodes(emLabelList.filter(!_.isInstanceOf[EngineTypeLabel]))
+
+    //3. 执行Select  比如负载过高，返回没有负载低的EM，每个规则如果返回为空就抛出异常
+    val choseNode = if (null == emScoreNodeList || emScoreNodeList.isEmpty) null else nodeSelector.choseNode(emScoreNodeList.toArray)
+    if (null == choseNode || choseNode.isEmpty) {
+      throw new DWCRetryException(AMConstant.EM_ERROR_CODE, s"The em of labels${engineCreateRequest.getLabels} not found")
+    }
+    val emNode = choseNode.get.asInstanceOf[EMNode]
+    //4. 请求资源
+    val (resourceTicketId, resource) = requestResource(engineCreateRequest, labelList, emNode, timeout)
+
+    //5. 封装engineBuildRequest对象,并发送给EM进行执行
+    val engineBuildRequest = EngineConnBuildRequestImpl(
+      resourceTicketId,
+      labelFilter.choseEngineLabel(labelList),
+      resource,
+      EngineConnCreationDescImpl(engineCreateRequest.getCreateService, engineCreateRequest.getDescription, engineCreateRequest.getProperties))
+
+    //6. 调用EM发送引擎启动请求调用ASK TODO 异常和等待时间处理
+    info("start to request ecm create engineConn")
+    val engineNode = getEMService().createEngine(engineBuildRequest, emNode)
+    info(s"Finished to create engineConn $engineNode")
+    //7. 更新持久化信息：包括插入engine/metrics
+    //AM会更新serviceInstance表  需要将ticketID进行替换,并更新 EngineConn的Label 需要修改EngineInstanceLabel 中的id为Instance信息
+    val oldServiceInstance = new ServiceInstance
+    oldServiceInstance.setApplicationName(engineNode.getServiceInstance.getApplicationName)
+    oldServiceInstance.setInstance(resourceTicketId)
+    getEngineNodeManager.updateEngineNode(oldServiceInstance, engineNode)
+
+    //8. 新增 EngineConn的Label,添加engineConn的Alias
+    val engineConnAliasLabel = new AliasServiceInstanceLabel
+    engineConnAliasLabel.setAlias("EngineConn")
+    labelList.add(engineConnAliasLabel)
+    nodeLabelService.addLabelsToNode(engineNode.getServiceInstance, LabelUtils.distinctLabel(labelList, fromEMGetEngineLabels(emNode.getLabels)))
+    try {
+      info(s"Start to wait idle status of engineConn($engineNode) ")
+      //9 获取启动的引擎信息，并等待引擎的状态变为IDLE，如果等待超时则返回给用户，并抛出异常
+      Utils.waitUntil(() => ensuresIdle(engineNode), Duration(timeout, TimeUnit.MILLISECONDS))
+    } catch {
+      case e: TimeoutException =>
+        info(s"Waiting for $engineNode initialization failure , now stop it")
+        val stopEngineRequest = new EngineStopRequest(engineNode.getServiceInstance, ManagerUtils.getAdminUser)
+        smc.publish(stopEngineRequest)
+        throw new DWCRetryException(AMConstant.ENGINE_ERROR_CODE, s"Waiting for Engine initialization failure, already waiting $timeout ms")
+    }
+    info(s"Finished to create Engine for request: $engineCreateRequest and get engineNode $engineNode")
+    engineNode
+  }
+
+  private def requestResource(engineCreateRequest: EngineCreateRequest, labelList: util.List[Label[_]], emNode: EMNode, timeout: Long): (String, NodeResource) = {
+    //4.  向RM申请对应EM和用户的资源, 抛出资源不足异常：RetryException
+    // 4.1 TODO 如果EM资源不足，触发EM回收空闲的engine
+    // 4.2 TODO 如果用户资源不足，触发用户空闲的engine回收
+    //读取管理台的的配置
+    if(engineCreateRequest.getProperties == null) engineCreateRequest.setProperties(new util.HashMap[String,String]())
+    engineCreateRequest.getProperties.putAll(engineConnConfigurationService.getConsoleConfiguration(labelList))
+    val timeoutEngineResourceRequest = TimeoutEngineResourceRequest(timeout, engineCreateRequest.getUser, labelList, engineCreateRequest.getProperties)
+    val resource = engineConnPluginPointer.createEngineResource(timeoutEngineResourceRequest)
+    /*  emNode.setLabels(nodeLabelService.getNodeLabels(emNode.getServiceInstance))*/
+
+    resourceManager.requestResource(LabelUtils.distinctLabel(labelList, emNode.getLabels), resource, timeout) match {
+      case AvailableResource(ticketId) =>
+        (ticketId, resource)
+      case NotEnoughResource(reason) =>
+        throw new DWCRetryException(AMConstant.EM_ERROR_CODE, s"用户资源不足，请重试: $reason")
+    }
+  }
+
+  private def fromEMGetEngineLabels(emLabels: util.List[Label[_]]): util.List[Label[_]] = {
+    emLabels.filter { label =>
+      label.isInstanceOf[EngineNodeLabel] && !label.isInstanceOf[EngineTypeLabel]
+    }
+  }
+
+  private def ensuresIdle(engineNode: EngineNode): Boolean = {
+    //TODO 逻辑需要修改，修改为engineConn主动上报
+    val engineNodeInfo = Utils.tryAndWarn(getEngineNodeManager.getEngineNodeInfoByDB(engineNode))
+    if (NodeStatus.isCompleted(engineNodeInfo.getNodeStatus)) {
+      val metrics = nodeMetricManagerPersistence.getNodeMetrics(engineNodeInfo)
+      val reason = getStartErrorInfo(metrics.getHeartBeatMsg)
+      throw new AMErrorException(AMConstant.EM_ERROR_CODE, s"初始化引擎失败,原因: ${reason}")
+    }
+    NodeStatus.isAvailable(engineNodeInfo.getNodeStatus)
+  }
+
+  private def getStartErrorInfo(msg: String): String = {
+
+    if (StringUtils.isNotBlank(msg)) {
+      val jsonNode = BDPJettyServerHelper.jacksonJson.readTree(msg)
+      if (jsonNode != null && jsonNode.has(AMConstant.START_REASON)) {
+        val startReason = jsonNode.get(AMConstant.START_REASON).asText()
+        return startReason
+      }
+    }
+    null
+  }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineInfoService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineInfoService.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.governance.common.entity.NodeExistStatus
+import com.webank.wedatasphere.linkis.governance.common.protocol.engineconn.{RequestEngineStatusBatch, ResponseEngineStatusBatch}
+import com.webank.wedatasphere.linkis.governance.common.utils.GovernanceConstant
+import com.webank.wedatasphere.linkis.manager.am.manager.{EMNodeManager, EngineNodeManager}
+import com.webank.wedatasphere.linkis.manager.am.utils.AMUtils
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode}
+import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.resourcemanager.service.ResourceManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters.asScalaBufferConverter
+import java.util
+
+/**
+ *
+ */
+@Service
+class DefaultEngineInfoService extends AbstractEngineService with EngineInfoService with Logging {
+
+  @Autowired
+  private var engineNodeManager: EngineNodeManager = _
+
+  @Autowired
+  private var emNodeManager: EMNodeManager = _
+
+  @Autowired
+  private var resourceManager: ResourceManager = _
+
+  @Autowired
+  private var labelService: NodeLabelService = _
+
+  /**
+   * 通过user获取EngineNode 的基本信息，含metric,resourceInfo
+   *
+   * @param user
+   * @return
+   */
+  override def listUserEngines(user: String): java.util.List[EngineNode] = {
+    //1.获取node 和metric信息
+    val nodes = engineNodeManager.listEngines(user)
+    val resourceInfo = resourceManager.getResourceInfo(nodes.map(_.getServiceInstance).toArray).resourceInfo
+    val resourceInfoMap = resourceInfo.map(r => (r.getServiceInstance.toString, r)).toMap
+    nodes.map { node =>
+      resourceInfoMap.get(node.getServiceInstance.toString).map(_.getNodeResource).foreach(node.setNodeResource)
+      node.setLabels(labelService.getNodeLabels(node.getServiceInstance))
+      node
+    }
+    nodes
+  }
+
+  /**
+   * 通过em（主要是instance信息） 获取engine的基本信息，含metric
+   *
+   * @param em
+   * @return
+   */
+  override def listEMEngines(em: EMNode): java.util.List[EngineNode] = {
+    val nodes = emNodeManager.listEngines(em)
+    val resourceInfo = resourceManager.getResourceInfo(nodes.map(_.getServiceInstance).toArray).resourceInfo
+    val resourceInfoMap = resourceInfo.map(r => (r.getServiceInstance.toString, r)).toMap
+    nodes.map { node =>
+      resourceInfoMap.get(node.getServiceInstance.toString).map(_.getNodeResource).foreach(node.setNodeResource)
+      node.setLabels(labelService.getNodeLabels(node.getServiceInstance))
+      node
+    }
+    nodes
+  }
+
+  @Receiver
+  override def dealBatchGetEngineStatus(request: RequestEngineStatusBatch): ResponseEngineStatusBatch = {
+    if (request.engineList.size() > GovernanceConstant.REQUEST_ENGINE_STATUS_BATCH_LIMIT) {
+      return ResponseEngineStatusBatch(null, s"Engines size ${request.engineList.size()} in request cannot excceed the batch limit of ${GovernanceConstant.REQUEST_ENGINE_STATUS_BATCH_LIMIT}")
+    }
+    val map = new util.HashMap[ServiceInstance, NodeExistStatus]
+    request.engineList.asScala.foreach(e => {
+      var engineNode: EngineNode = null
+      Utils.tryCatch {
+        engineNode = engineNodeManager.getEngineNode(e)
+        if (null == engineNode) {
+          map.put(e, NodeExistStatus.UnExist)
+        } else {
+          map.put(e, NodeExistStatus.Exist)
+        }
+      } {
+        case t : Throwable =>
+          error(s"Get engineNode of ${e.toString} error. ", t)
+          map.put(e, NodeExistStatus.Unknown)
+      }
+    })
+    ResponseEngineStatusBatch(map, null)
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineKillService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineKillService.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineConnReleaseRequest, EngineInfoClearRequest}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2020/8/4 21:39
+  */
+@Service
+class DefaultEngineKillService extends AbstractEngineService with EngineKillService with Logging {
+
+  @Receiver
+  override def killEngine(engineInfoClearRequest: EngineInfoClearRequest): Unit = {
+    info(s"Start to kill engine invoke enginePointer ${engineInfoClearRequest.getEngineNode.getServiceInstance}")
+    getEMService().stopEngine(engineInfoClearRequest.getEngineNode, engineInfoClearRequest.getEngineNode.getEMNode)
+    info(s"Finished to kill engine invoke enginePointer ${engineInfoClearRequest.getEngineNode.getServiceInstance}")
+  }
+
+  @Receiver
+  override def dealEngineRelease(engineConnReleaseRequest: EngineConnReleaseRequest): Unit = {
+    info(s"Start to kill engine , with msg : ${engineConnReleaseRequest.getMsg}")
+    if (null == engineConnReleaseRequest.getServiceInstance) {
+      warn(s"Invalid empty serviceInstance, will not kill engine.")
+      return
+    }
+    val engineNode = getEngineNodeManager.getEngineNode(engineConnReleaseRequest.getServiceInstance)
+    if (null != engineNode) {
+      getEMService().stopEngine(engineNode, engineNode.getEMNode)
+      info(s"Finished to kill engine.")
+    } else {
+      warn(s"Cannot find valid engineNode from serviceInstance : ${engineConnReleaseRequest.getServiceInstance.toString}")
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineRecycleService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineRecycleService.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.am.recycle.RecyclingRuleExecutor
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineRecyclingRequest, EngineStopRequest}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.publisher.MessagePublisher
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+
+/**
+  * @date 2020/7/10 15:59
+  */
+@Service
+class DefaultEngineRecycleService extends AbstractEngineService with EngineRecycleService with Logging {
+
+  @Autowired
+  private var ruleExecutorList: util.List[RecyclingRuleExecutor] = _
+
+  @Autowired
+  private var publisher: MessagePublisher = _
+
+  @Receiver
+  override def recycleEngine(engineRecyclingRequest: EngineRecyclingRequest): Array[ServiceInstance] = {
+    if (null == ruleExecutorList) {
+      error("has not recycling rule")
+      return null
+    }
+    info(s"start to recycle engine by ${engineRecyclingRequest.getUser}")
+    //1. 规则解析
+    val ruleList = engineRecyclingRequest.getRecyclingRuleList
+    //2. 返回一系列待回收Engine，
+    val recyclingNodeSet = ruleList.flatMap { rule =>
+      val ruleExecutorOption = ruleExecutorList.find(_.ifAccept(rule))
+      if (ruleExecutorOption.isDefined) {
+        ruleExecutorOption.get.executeRule(rule)
+      } else {
+        Nil
+      }
+    }.filter(null != _).toSet
+    if (null == recyclingNodeSet) {
+      return null
+    }
+    info(s"The list of engines recycled this time is as follows:${recyclingNodeSet}")
+    //3. 调用EMService stopEngine
+    recyclingNodeSet.foreach { serviceInstance =>
+      val stopEngineRequest = new EngineStopRequest(serviceInstance, engineRecyclingRequest.getUser)
+      publisher.publish(stopEngineRequest)
+    }
+    info(s"Finished to recycle engine ,num ${recyclingNodeSet.size}")
+    recyclingNodeSet.toArray
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineReuseService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineReuseService.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import java.util
+import java.util.concurrent.{TimeUnit, TimeoutException}
+
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.am.label.EngineReuseLabelChooser
+import com.webank.wedatasphere.linkis.manager.am.selector.NodeSelector
+import com.webank.wedatasphere.linkis.manager.am.utils.AMUtils
+import com.webank.wedatasphere.linkis.manager.common.constant.AMConstant
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineReuseRequest
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.node.AliasServiceInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.service.{NodeLabelService, UserLabelService}
+import com.webank.wedatasphere.linkis.manager.label.utils.LabelUtils
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration.Duration
+
+/**
+  * @date 2020/7/5 17:15
+  */
+@Service
+class DefaultEngineReuseService extends AbstractEngineService with EngineReuseService with Logging {
+
+  @Autowired
+  private var nodeSelector: NodeSelector = _
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Autowired
+  private var userLabelService: UserLabelService = _
+
+  @Autowired
+  private var engineReuseLabelChoosers: util.List[EngineReuseLabelChooser] = _
+
+  @Receiver
+  @throws[DWCRetryException]
+  override def reuseEngine(engineReuseRequest: EngineReuseRequest): EngineNode = {
+    info(s"Start to reuse Engine for request: $engineReuseRequest")
+    //TODO Label Factory And builder
+    val labelBuilderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
+    //Label:传入的Label和用户默认的Label 去重
+    var labelList: util.List[Label[_]] = LabelUtils.distinctLabel(labelBuilderFactory.getLabels(engineReuseRequest.getLabels),
+      userLabelService.getUserLabels(engineReuseRequest.getUser))
+    val engineConnAliasLabel = labelBuilderFactory.createLabel(classOf[AliasServiceInstanceLabel])
+    engineConnAliasLabel.setAlias(GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue)
+    labelList.add(engineConnAliasLabel)
+
+    //label chooser
+    if (null != engineReuseLabelChoosers) {
+      engineReuseLabelChoosers.foreach { chooser =>
+        labelList = chooser.chooseLabels(labelList)
+      }
+    }
+    val instances = nodeLabelService.getScoredNodeMapsByLabels(labelList)
+    if (null == instances || instances.isEmpty) {
+      throw new DWCRetryException(AMConstant.ENGINE_ERROR_CODE, s"No engine can be reused")
+    }
+    var engineScoreList = getEngineNodeManager.getEngineNodes(instances.map(_._1).toSeq.toArray)
+
+    var engine: EngineNode = null
+    var count = 1
+    val timeout = if (engineReuseRequest.getTimeOut <= 0) AMConfiguration.ENGINE_REUSE_MAX_TIME.getValue.toLong else engineReuseRequest.getTimeOut
+    val reuseLimit = if (engineReuseRequest.getReuseCount <= 0) AMConfiguration.ENGINE_REUSE_COUNT_LIMIT.getValue else engineReuseRequest.getReuseCount
+
+    def selectEngineToReuse: Boolean = {
+      if (count > reuseLimit) {
+        throw new DWCRetryException(AMConstant.ENGINE_ERROR_CODE, s"Engine reuse exceeds limit: $reuseLimit")
+      }
+      //3. 执行Select 判断label分数、判断是否可用、判断负载
+      val choseNode = nodeSelector.choseNode(engineScoreList.toArray)
+      //4. 获取Select后排在第一的engine，修改EngineNode的Label为新标签，并调用EngineNodeManager的reuse请求
+      if (choseNode.isEmpty) {
+        throw new DWCRetryException(AMConstant.ENGINE_ERROR_CODE, "No engine can be reused")
+      }
+      //TODO 需要加上Label不匹配判断？如果
+      //5. 调用EngineNodeManager 进行reuse 如果reuse失败，则去掉该engine进行重新reuse走3和4
+      engine = Utils.tryAndWarn(getEngineNodeManager.reuseEngine(choseNode.get.asInstanceOf[EngineNode]))
+      if (null == engine) {
+        count = count + 1
+        engineScoreList = engineScoreList.filter(!_.equals(choseNode.get))
+      }
+      null != engine
+    }
+
+    val startTime = System.currentTimeMillis()
+    try {
+      Utils.waitUntil(() => selectEngineToReuse, Duration(timeout, TimeUnit.MILLISECONDS))
+    } catch {
+      case e: TimeoutException =>
+        throw new DWCRetryException(AMConstant.ENGINE_ERROR_CODE, s"Waiting for Engine initialization failure, already waiting $timeout ms")
+      case t: Throwable =>
+        info(s"Failed to reuse engineConn time taken ${System.currentTimeMillis() - startTime}")
+        throw t
+    }
+    info(s"Finished to reuse Engine for request: $engineReuseRequest get EngineNode $engine, time taken ${System.currentTimeMillis() - startTime}")
+    val engineServiceLabelList = instances.filter(kv => kv._1.getServiceInstance.equals(engine.getServiceInstance))
+    if (null != engineServiceLabelList && engineServiceLabelList.nonEmpty) {
+      engine.setLabels(engineServiceLabelList.head._2)
+    } else {
+      error("Get choosen engineNode : " + AMUtils.GSON.toJson(engine) + " from engineLabelMap : " + AMUtils.GSON.toJson(instances))
+    }
+    engine
+  }
+
+
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineStopService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineStopService.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineInfoClearRequest, EngineStopRequest, EngineSuicideRequest}
+import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelRemoveRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2020/8/4 17:33
+  */
+@Service
+class DefaultEngineStopService extends AbstractEngineService with EngineStopService with Logging {
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Receiver
+  override def stopEngine(engineStopRequest: EngineStopRequest, smc: ServiceMethodContext): Unit = {
+    info(s" user ${engineStopRequest.getUser} prepare to stop engine ${engineStopRequest.getServiceInstance}")
+    val node = getEngineNodeManager.getEngineNode(engineStopRequest.getServiceInstance)
+    if (null == node) {
+      info(s" engineConn is not exists in db: $engineStopRequest ")
+      return
+    }
+    node.setLabels(nodeLabelService.getNodeLabels(engineStopRequest.getServiceInstance))
+    //clear RM and AM info
+    val engineInfoClearRequest = new EngineInfoClearRequest
+    engineInfoClearRequest.setEngineNode(node)
+    engineInfoClearRequest.setUser(engineStopRequest.getUser)
+    val job = smc.publish(engineInfoClearRequest)
+    Utils.tryAndWarn(job.get(AMConfiguration.STOP_ENGINE_WAIT.getValue.toLong, TimeUnit.MILLISECONDS))
+    info(s"Finished to clear RM info and stop Engine")
+    // clear Label
+    val instanceLabelRemoveRequest = new NodeLabelRemoveRequest(node.getServiceInstance, true)
+    val labelJob = smc.publish(instanceLabelRemoveRequest)
+
+    Utils.tryAndWarn(labelJob.get(AMConfiguration.STOP_ENGINE_WAIT.getValue.toLong, TimeUnit.MILLISECONDS))
+    info(s"Finished to clear Label info")
+    getEngineNodeManager.deleteEngineNode(node)
+    info(s" user ${engineStopRequest.getUser} finished to stop engine ${engineStopRequest.getServiceInstance}")
+  }
+
+  @Receiver
+  override def engineSuicide(engineSuicideRequest: EngineSuicideRequest, smc: ServiceMethodContext): Unit = {
+    info(s"Will ask engine : ${engineSuicideRequest.getServiceInstance.toString} of user : ${engineSuicideRequest.getUser} to suicide.")
+    EngineStopService.askEngineToSuicide(engineSuicideRequest)
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineSwitchService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineSwitchService.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineSwitchRequest
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2020/7/13 21:04
+  */
+@Service
+class DefaultEngineSwitchService extends EngineSwitchService {
+
+  @Receiver
+  override def switchEngine(engineSwitchRequest: EngineSwitchRequest): EngineNode = ???
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineAskEngineService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineAskEngineService.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineAskRequest
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+
+/**
+  * @date 2020/6/12 15:58
+  */
+trait EngineAskEngineService {
+
+  def askEngine(engineAskRequest: EngineAskRequest, smc: ServiceMethodContext): Any
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineConnStatusCallbackService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineConnStatusCallbackService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineConnStatusCallbackToAM
+
+/**
+  * @date 2021/1/1 20:56
+  */
+trait EngineConnStatusCallbackService {
+
+  def dealEngineConnStatusCallback(engineConnStatusCallbackToAM: EngineConnStatusCallbackToAM): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineCreateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineCreateService.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineCreateRequest
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+
+/**
+  * @date 2020/6/12 15:52
+  */
+trait EngineCreateService {
+
+  @throws[DWCRetryException]
+  def createEngine(engineCreateRequest: EngineCreateRequest, smc: ServiceMethodContext): EngineNode
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineInfoService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineInfoService.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.governance.common.protocol.engineconn.{RequestEngineStatusBatch, ResponseEngineStatusBatch}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode}
+
+/**
+ *
+ */
+trait EngineInfoService {
+  /**
+   * 通过user获取EngineNode 的基本信息，含metric
+   *
+   * @param user
+   * @return
+   */
+  def listUserEngines(user: String): java.util.List[EngineNode]
+
+  /**
+   * 通过em（主要是instance信息） 获取engine的基本信息，含metric
+   *
+   * @param em
+   * @return
+   */
+  def listEMEngines(em: EMNode): java.util.List[EngineNode]
+
+  def dealBatchGetEngineStatus(request: RequestEngineStatusBatch): ResponseEngineStatusBatch = ResponseEngineStatusBatch(null, "Please implements method")
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineKillService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineKillService.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineConnReleaseRequest, EngineInfoClearRequest}
+
+/**
+  * @date 2020/8/4 21:36
+  */
+trait EngineKillService {
+
+  def killEngine(engineInfoClearRequest: EngineInfoClearRequest): Unit
+
+  def dealEngineRelease(engineConnReleaseRequest: EngineConnReleaseRequest): Unit
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineRecycleService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineRecycleService.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineRecyclingRequest
+
+/**
+  * @date 2020/6/12 16:07
+  */
+trait EngineRecycleService {
+
+  @throws[DWCRetryException]
+  def recycleEngine(engineRecyclingRequest: EngineRecyclingRequest): Array[ServiceInstance]
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineReuseService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineReuseService.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineReuseRequest
+
+/**
+  * @date 2020/6/12 16:05
+  */
+trait EngineReuseService {
+
+  @throws[DWCRetryException]
+  def reuseEngine(engineReuseRequest: EngineReuseRequest): EngineNode
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineStopService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineStopService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineStopRequest, EngineSuicideRequest}
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext
+import com.webank.wedatasphere.linkis.rpc.Sender
+
+/**
+  * @date 2020/8/4 17:41
+  */
+trait EngineStopService {
+
+
+  def stopEngine(engineStopRequest: EngineStopRequest, smc: ServiceMethodContext): Unit
+
+  def engineSuicide(engineSuicideRequest: EngineSuicideRequest, smc: ServiceMethodContext): Unit
+
+}
+
+
+object EngineStopService {
+  def askEngineToSuicide(engineSuicideRequest: EngineSuicideRequest): Unit = {
+    if (null == engineSuicideRequest.getServiceInstance) return
+    Sender.getSender(engineSuicideRequest.getServiceInstance).send(engineSuicideRequest)
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineSwitchService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/EngineSwitchService.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.engine
+
+import com.webank.wedatasphere.linkis.common.exception.DWCRetryException
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineSwitchRequest
+
+/**
+  * @date 2020/6/12 16:00
+  */
+trait EngineSwitchService {
+
+  @throws[DWCRetryException]
+  def switchEngine(engineSwitchRequest: EngineSwitchRequest): EngineNode
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/heartbeat/AMHeartbeatService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/heartbeat/AMHeartbeatService.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.service.heartbeat
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.am.service.HeartbeatService
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.AMNodeMetrics
+import com.webank.wedatasphere.linkis.manager.common.monitor.ManagerMonitor
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.NodeHeartbeatMsg
+import com.webank.wedatasphere.linkis.manager.persistence.{NodeManagerPersistence, NodeMetricManagerPersistence}
+import com.webank.wedatasphere.linkis.manager.service.common.metrics.MetricsConverter
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.resourcemanager.utils.RMConfiguration
+import javax.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+/**
+  * @date 2020/7/18 22:59
+  */
+@Service
+class AMHeartbeatService extends HeartbeatService with Logging {
+
+  @Autowired
+  private var nodeManagerPersistence: NodeManagerPersistence = _
+
+  @Autowired
+  private var nodeMetricManagerPersistence: NodeMetricManagerPersistence = _
+
+  @Autowired
+  private var metricsConverter: MetricsConverter = _
+
+
+  @Autowired(required = false)
+  private var managerMonitor: ManagerMonitor = _
+
+
+  @PostConstruct
+  def init(): Unit = {
+    if (null != managerMonitor) {
+      info("start init AMHeartbeatService monitor")
+      Utils.defaultScheduler.scheduleAtFixedRate(managerMonitor, 1000, RMConfiguration.RM_ENGINE_SCAN_INTERVAL.getValue.toLong, TimeUnit.MILLISECONDS)
+
+    }
+  }
+
+
+  @Receiver
+  override def heartbeatEventDeal(nodeHeartbeatMsg: NodeHeartbeatMsg): Unit = {
+    val nodeMetrics = new AMNodeMetrics
+    info(s"Am deal nodeHeartbeatMsg $nodeHeartbeatMsg")
+    nodeMetrics.setHealthy(metricsConverter.convertHealthyInfo(nodeHeartbeatMsg.getHealthyInfo))
+    nodeMetrics.setHeartBeatMsg(nodeHeartbeatMsg.getHeartBeatMsg)
+    nodeMetrics.setOverLoad(metricsConverter.convertOverLoadInfo(nodeHeartbeatMsg.getOverLoadInfo))
+    nodeMetrics.setServiceInstance(nodeHeartbeatMsg.getServiceInstance)
+    nodeMetrics.setStatus(metricsConverter.convertStatus(nodeHeartbeatMsg.getStatus))
+    nodeMetricManagerPersistence.addOrupdateNodeMetrics(nodeMetrics)
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/utils/AMUtils.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/utils/AMUtils.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.am.utils
+
+import com.google.gson.Gson
+
+/**
+  * @date 2020/7/14 21:42
+  */
+object AMUtils {
+
+  lazy val GSON = new Gson()
+}

--- a/linkis-computation-governance/linkis-manager/pom.xml
+++ b/linkis-computation-governance/linkis-manager/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <packaging>pom</packaging>
+    <artifactId>linkis-manager</artifactId>
+
+    <modules>
+        <module>label-common</module>
+        <module>label-manager</module>
+        <module>linkis-manager-commons/linkis-manager-common</module>
+        <module>linkis-manager-commons/linkis-manager-service-common</module>
+        <module>linkis-manager-commons/linkis-resource-manager-common</module>
+        <module>linkis-manager-persistence</module>
+        <module>linkis-manager-client</module>
+        <module>linkis-manager-monitor</module>
+        <module>linkis-resource-manager</module>
+        <module>linkis-application-manager</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>


### PR DESCRIPTION
###  What is the purpose of the change
closed #567 
Add the Linkis AppManager module to manage the life cycle of EC and ECM.

### Brief change log
1. Add the Linkis AppManager module to support the operations of EngineConn, including: creation, reuse, recycling, preheating, switching and other functions
2. Integrating with Manager module to provide EngineConn management functions: including EngineConn status maintenance, engine list maintenance, engine information, etc.
3. AM is responsible for EM service management, completing ECM registration and forwarding the resource registration request to the RM module.
4. Add the Linkis AppManager moduleto integrate with Label module, including notifiying label manager to update labels when ECM/EC is added or deleted. 
5.  Add the Linkis AppManager module to integrate with Label module to realize label analysis and then use a series of labels to obtain the rated serviceInstance lists. 