### PR TITLE
Enhance the processing capacity of Linkis RPC, and maintain the backward compatibility with Linkis0.x RPC

### DIFF
--- a/linkis-commons/linkis-message-scheduler/pom.xml
+++ b/linkis-commons/linkis-message-scheduler/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-message-scheduler</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-rpc</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-scheduler</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>**/*.properties</exclude>
+                    <exclude>**/application.yml</exclude>
+                    <exclude>**/bootstrap.yml</exclude>
+                    <exclude>**/log4j2.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Chain.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Chain.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @date 2020/8/4
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Chain {
+
+    String value() default "default";
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Implicit.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Implicit.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @date 2020/7/28
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Implicit {
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Method.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Method.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @date 2020/7/14
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Method {
+    String value() default "";
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/NotImplicit.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/NotImplicit.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @date 2020/8/4
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotImplicit {
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Order.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Order.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @date 2020/7/14
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Order {
+    int value() default 2147483647;
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Receiver.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/annotation/Receiver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @date 2020/7/14
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Receiver {
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/DefaultMessageJob.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/DefaultMessageJob.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.scheduler.MethodExecuteWrapper;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+import com.webank.wedatasphere.linkis.scheduler.executer.ExecuteRequest;
+import com.webank.wedatasphere.linkis.scheduler.queue.Job;
+import com.webank.wedatasphere.linkis.scheduler.queue.JobInfo;
+import com.webank.wedatasphere.linkis.scheduler.queue.SchedulerEventState;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * @date 2020/7/17
+ */
+public class DefaultMessageJob extends Job implements MessageJob {
+
+    private RequestProtocol requestProtocol;
+
+    private Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers;
+
+    private ServiceMethodContext smc;
+
+    private AbstractMessageSchedulerContext context;
+
+    //implements of MessageJob
+
+    @Override
+    public RequestProtocol getRequestProtocol() {
+        return this.requestProtocol;
+    }
+
+    @Override
+    public void setRequestProtocol(RequestProtocol requestProtocol) {
+        this.requestProtocol = requestProtocol;
+    }
+
+    @Override
+    public Map<String, List<MethodExecuteWrapper>> getMethodExecuteWrappers() {
+        return this.methodExecuteWrappers;
+    }
+
+    @Override
+    public void setMethodExecuteWrappers(Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers) {
+        this.methodExecuteWrappers = methodExecuteWrappers;
+    }
+
+    @Override
+    public ServiceMethodContext getMethodContext() {
+        return this.smc;
+    }
+
+    @Override
+    public void setMethodContext(ServiceMethodContext smc) {
+        this.smc = smc;
+    }
+
+    @Override
+    public AbstractMessageSchedulerContext getContext() {
+        return this.context;
+    }
+
+    @Override
+    public void setContext(AbstractMessageSchedulerContext context) {
+        this.context = context;
+    }
+
+    //implements of Job
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public ExecuteRequest jobToExecuteRequest() {
+        return () -> null;
+    }
+
+    @Override
+    public String getName() {
+        return getId();
+    }
+
+    @Override
+    public JobInfo getJobInfo() {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    // implements of Future
+
+    // TODO: 2020/8/3 state 和blockThread的cas化
+
+    Thread blockThread = null;
+
+
+    public Thread getBlockThread() {
+        return this.blockThread;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (mayInterruptIfRunning) {
+            cancel();
+        }
+        return true;
+    }
+
+    @Override
+    public Object get() throws ExecutionException, InterruptedException {
+        if (!this.isCompleted()) {
+            waitComplete(false, -1L);
+        }
+        return handleResult();
+    }
+
+    @Override
+    public Object getPartial() {
+        return this.getMethodContext().getResult();
+    }
+
+    public Object handleResult() throws ExecutionException {
+        if (this.isSucceed()) {
+            return this.getMethodContext().getResult();
+        }
+        // TODO: 2020/8/3  cancel逻辑加入
+        throw new ExecutionException(this.getErrorResponse().t());
+    }
+
+    @Override
+    public Object get(long timeout, TimeUnit unit) throws ExecutionException, InterruptedException, TimeoutException {
+        if (unit == null) unit = TimeUnit.NANOSECONDS;
+        if (!this.isCompleted()
+                && !SchedulerEventState.isCompleted(SchedulerEventState.apply(waitComplete(true, unit.toNanos(timeout))))) {
+            throw new TimeoutException();
+        }
+        return handleResult();
+    }
+
+    private int waitComplete(boolean timed, long nanos) throws InterruptedException {
+        long endTime = timed ? System.nanoTime() + nanos : -1L;
+        for (; ; ) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+            if (this.isCompleted()) {
+                return this.getState().id();
+            } else if (blockThread == null)
+                blockThread = Thread.currentThread();
+            else if (timed) {
+                nanos = endTime - System.nanoTime();
+                if (nanos <= 0) {
+                    return this.getState().id();
+                }
+                LockSupport.parkNanos(this, nanos);
+            } else
+                LockSupport.park(this);
+        }
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/DefaultMessageJobBuilder.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/DefaultMessageJobBuilder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.scheduler.MethodExecuteWrapper;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @date 2020/7/17
+ */
+public class DefaultMessageJobBuilder implements MessageJobBuilder {
+
+    private RequestProtocol requestProtocol;
+
+    private Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers;
+
+    private ServiceMethodContext smc;
+
+    private AbstractMessageSchedulerContext context;
+
+    @Override
+    public MessageJobBuilder of() {
+        return new DefaultMessageJobBuilder();
+    }
+
+    @Override
+    public MessageJobBuilder with(RequestProtocol requestProtocol) {
+        this.requestProtocol = requestProtocol;
+        return this;
+    }
+
+    @Override
+    public MessageJobBuilder with(Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers) {
+        this.methodExecuteWrappers = methodExecuteWrappers;
+        return this;
+    }
+
+
+    @Override
+    public MessageJobBuilder with(ServiceMethodContext smc) {
+        this.smc = smc;
+        return this;
+    }
+
+    @Override
+    public MessageJobBuilder with(AbstractMessageSchedulerContext context) {
+        this.context = context;
+        return this;
+    }
+
+    @Override
+    public MessageJob build() {
+        DefaultMessageJob messageJob = new DefaultMessageJob();
+        messageJob.setMethodExecuteWrappers(this.methodExecuteWrappers);
+        messageJob.setRequestProtocol(this.requestProtocol);
+        messageJob.setMethodContext(this.smc);
+        messageJob.setContext(context);
+        return messageJob;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/DefaultServiceMethodContext.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/DefaultServiceMethodContext.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import com.webank.wedatasphere.linkis.message.context.MessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.exception.MessageWarnException;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+import com.webank.wedatasphere.linkis.rpc.Sender;
+import com.webank.wedatasphere.linkis.scheduler.queue.Job;
+import com.webank.wedatasphere.linkis.scheduler.queue.SchedulerEventState;
+import scala.concurrent.duration.Duration;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf.*;
+
+/**
+ * @date 2020/7/14
+ */
+public class DefaultServiceMethodContext implements ServiceMethodContext {
+
+    private final Map<String, Object> attributes = new ConcurrentHashMap<>();
+
+    private final ThreadLocal<Set<Integer>> skips = new ThreadLocal<>();
+
+    private final ThreadLocal<Job> job = new ThreadLocal<>();
+
+    @Override
+    public void putAttribute(String key, Object value) {
+        this.attributes.put(key, value);
+    }
+
+    @Override
+    public void putIfAbsent(String key, Object value) {
+        if (!notNull(key)) {
+            putAttribute(key, value);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getAttribute(String key) {
+        return (T) this.attributes.get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getAttributeOrDefault(String key, T defaultValue) {
+        return (T) this.attributes.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public String getUser() {
+        return getAttribute(USER_KEY);
+    }
+
+    @Override
+    public HttpServletRequest getRequest() {
+        return getAttribute(REQUEST_KEY);
+    }
+
+    @Override
+    public boolean notNull(String key) {
+        return this.attributes.get(key) != null;
+    }
+
+    @Override
+    public MessageJob publish(RequestProtocol requestProtocol) throws MessageWarnException {
+        MessageSchedulerContext context = getAttribute(CONTEXT_KEY);
+        return context.getPublisher().publish(requestProtocol, this);
+    }
+
+    @Override
+    public void send(Object message) {
+        Sender sender = getAttribute(SENDER_KEY);
+        sender.send(message);
+    }
+
+    @Override
+    public Object ask(Object message) {
+        Sender sender = getAttribute(SENDER_KEY);
+        return sender.ask(message);
+    }
+
+    @Override
+    public Object ask(Object message, Duration timeout) {
+        Sender sender = getAttribute(SENDER_KEY);
+        return sender.ask(message, timeout);
+    }
+
+    @Override
+    public Sender getSender() {
+        return getAttribute(SENDER_KEY);
+    }
+
+    @Override
+    public void setTimeoutPolicy(MessageJobTimeoutPolicy policy) {
+        putAttribute(TIMEOUT_POLICY, policy);
+    }
+
+    @Override
+    public void setResult(Object result) {
+        putAttribute(RESULT_KEY, result);
+    }
+
+    @Override
+    public <T> T getResult() {
+        return getAttribute(RESULT_KEY);
+    }
+
+    @Override
+    public boolean isInterrupted() {
+        //linkis-shceduler 没有isInterrupted状态
+        return SchedulerEventState.Cancelled() == this.job.get().getState();
+    }
+
+    @Override
+    public boolean isCancel() {
+        //linkis-shceduler只有cancel
+        return SchedulerEventState.Cancelled() == this.job.get().getState();
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return SchedulerEventState.Succeed() == this.job.get().getState();
+    }
+
+    public void setJob(Job job) {
+        this.job.set(job);
+    }
+
+    public void removeJob() {
+        this.job.remove();
+    }
+
+    public void setSkips(Integer... orders) {
+        Set<Integer> oldOrders = skips.get();
+        if (oldOrders == null) {
+            Set<Integer> newOrders = new HashSet<Integer>(Arrays.asList(orders));
+            skips.set(newOrders);
+        } else {
+            oldOrders.addAll(Arrays.asList(orders));
+        }
+    }
+
+    public void removeSkips() {
+        this.skips.remove();
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/Future.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/Future.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @date 2020/8/4
+ */
+public interface Future<V> {
+
+    boolean cancel(boolean mayInterruptIfRunning);
+
+    V get() throws InterruptedException, ExecutionException;
+
+    V getPartial();
+
+    V get(long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException;
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJob.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJob.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.scheduler.MethodExecuteWrapper;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * @date 2020/7/14
+ */
+public interface MessageJob extends Runnable, Future<Object> {
+
+    RequestProtocol getRequestProtocol();
+
+    void setRequestProtocol(RequestProtocol requestProtocol);
+
+    Map<String, List<MethodExecuteWrapper>> getMethodExecuteWrappers();
+
+    void setMethodExecuteWrappers(Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers);
+
+    ServiceMethodContext getMethodContext();
+
+    void setMethodContext(ServiceMethodContext smc);
+
+    AbstractMessageSchedulerContext getContext();
+
+    void setContext(AbstractMessageSchedulerContext context);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJobBuilder.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJobBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.scheduler.MethodExecuteWrapper;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @date 2020/7/17
+ */
+public interface MessageJobBuilder {
+
+    MessageJobBuilder of();
+
+    MessageJobBuilder with(RequestProtocol requestProtocol);
+
+    MessageJobBuilder with(Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers);
+
+    MessageJobBuilder with(ServiceMethodContext smc);
+
+    MessageJobBuilder with(AbstractMessageSchedulerContext context);
+
+    MessageJob build();
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJobListener.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJobListener.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+import com.webank.wedatasphere.linkis.common.utils.JavaLog;
+import com.webank.wedatasphere.linkis.scheduler.listener.JobListener;
+import com.webank.wedatasphere.linkis.scheduler.queue.Job;
+
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * @date 2020/7/17
+ */
+public class MessageJobListener extends JavaLog implements JobListener {
+
+    @Override
+    public void onJobScheduled(Job job) {
+
+    }
+
+    @Override
+    public void onJobInited(Job job) {
+
+    }
+
+    @Override
+    public void onJobWaitForRetry(Job job) {
+
+    }
+
+    @Override
+    public void onJobRunning(Job job) {
+
+    }
+
+    @Override
+    public void onJobCompleted(Job job) {
+        if (job instanceof DefaultMessageJob) {
+            LockSupport.unpark(((DefaultMessageJob) job).getBlockThread());
+        }
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJobTimeoutPolicy.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/MessageJobTimeoutPolicy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+/**
+ * @date 2020/7/27
+ */
+public enum MessageJobTimeoutPolicy {
+    /**
+     * 取消，但是不打断
+     */
+    CANCEL,
+    /**
+     * 打断
+     */
+    INTERRUPT,
+    /**
+     * 部分返回
+     */
+    PARTIAL
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/ServiceMethodContext.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/builder/ServiceMethodContext.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.builder;
+
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+import com.webank.wedatasphere.linkis.rpc.Sender;
+import scala.concurrent.duration.Duration;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @date 2020/7/14
+ */
+public interface ServiceMethodContext {
+
+    void putAttribute(String key, Object value);
+
+    void putIfAbsent(String key, Object value);
+
+    <T> T getAttribute(String key);
+
+    <T> T getAttributeOrDefault(String key, T defaultValue);
+
+    String getUser();
+
+    HttpServletRequest getRequest();
+
+    boolean notNull(String key);
+
+    MessageJob publish(RequestProtocol requestProtocol);
+
+    void send(Object message);
+
+    Object ask(Object message);
+
+    Object ask(Object message, Duration timeout);
+
+    Sender getSender();
+
+    void setTimeoutPolicy(MessageJobTimeoutPolicy policy);
+
+    void setResult(Object result);
+
+    <T> T getResult();
+
+    /**
+     * interrupted 状态
+     * messageJob执行失败，messageJob 被cancel，并且mayInterruptIfRunning 为true的情况
+     *
+     * @return
+     */
+    boolean isInterrupted();
+
+    boolean isCancel();
+
+    boolean isSuccess();
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/conf/MessageSchedulerConf.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/conf/MessageSchedulerConf.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.conf;
+
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars;
+import org.reflections.Reflections;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+
+/**
+ * @date 2020/7/14
+ */
+public class MessageSchedulerConf {
+
+    public final static String SERVICE_SCAN_PACKAGE = CommonVars.apply("wds.linkis.ms.service.scan.package", "com.webank.wedatasphere").getValue();
+
+    public final static Reflections REFLECTIONS = new Reflections(SERVICE_SCAN_PACKAGE, new MethodAnnotationsScanner(), new TypeAnnotationsScanner(), new SubTypesScanner());
+
+    public final static String USER_KEY = "_username_";
+    public final static String REQUEST_KEY = "_req_";
+    public final static String RESULT_KEY = "_result_";
+    public final static String CONTEXT_KEY = "_context_";
+    public final static String SENDER_KEY = "_sender_";
+    public final static String TIMEOUT_POLICY = "_timeout_policy_";
+    public final static String DURATION_KEY = "_duration_";
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/AbstractMessageSchedulerContext.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/AbstractMessageSchedulerContext.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.context;
+
+import com.webank.wedatasphere.linkis.message.builder.MessageJobBuilder;
+import com.webank.wedatasphere.linkis.message.parser.ImplicitParser;
+import com.webank.wedatasphere.linkis.message.parser.ServiceParser;
+import com.webank.wedatasphere.linkis.message.publisher.MessagePublisher;
+import com.webank.wedatasphere.linkis.message.registry.AbstractImplicitRegistry;
+import com.webank.wedatasphere.linkis.message.registry.AbstractServiceRegistry;
+import com.webank.wedatasphere.linkis.message.scheduler.MessageScheduler;
+import com.webank.wedatasphere.linkis.message.tx.TransactionManager;
+
+/**
+ * @date 2020/7/15
+ */
+public abstract class AbstractMessageSchedulerContext implements MessageSchedulerContext {
+
+    private AbstractServiceRegistry serviceRegistry;
+
+    private MessagePublisher messagePublisher;
+
+    private ServiceParser serviceParser;
+
+    private MessageScheduler messageScheduler;
+
+    private MessageJobBuilder messageJobBuilder;
+
+    private TransactionManager txManager;
+
+    private AbstractImplicitRegistry implicitRegistry;
+
+    private ImplicitParser implicitParser;
+
+    @Override
+    public MessagePublisher getPublisher() {
+        return this.messagePublisher;
+    }
+
+    public void setPublisher(MessagePublisher messagePublisher) {
+        this.messagePublisher = messagePublisher;
+    }
+
+    @Override
+    public AbstractServiceRegistry getServiceRegistry() {
+        return this.serviceRegistry;
+    }
+
+    public void setServiceRegistry(AbstractServiceRegistry serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    public void setserviceParser(ServiceParser serviceParser) {
+        this.serviceParser = serviceParser;
+    }
+
+    public void setImplicitRegistry(AbstractImplicitRegistry implicitRegistry) {
+        this.implicitRegistry = implicitRegistry;
+    }
+
+    public ImplicitParser getImplicitParser() {
+        return implicitParser;
+    }
+
+    public void setImplicitParser(ImplicitParser implicitParser) {
+        this.implicitParser = implicitParser;
+    }
+
+    public AbstractImplicitRegistry getImplicitRegistry() {
+        return this.implicitRegistry;
+    }
+
+    public ServiceParser getservieParser() {
+        return this.serviceParser;
+    }
+
+    public void setScheduler(MessageScheduler messageScheduler) {
+        this.messageScheduler = messageScheduler;
+    }
+
+    public MessageScheduler getScheduler() {
+        return this.messageScheduler;
+    }
+
+    public void setJobBuilder(MessageJobBuilder messageJobBuilder) {
+        this.messageJobBuilder = messageJobBuilder;
+    }
+
+    public MessageJobBuilder getJobBuilder() {
+        return this.messageJobBuilder;
+    }
+
+    public TransactionManager getTxManager() {
+        return this.txManager;
+    }
+
+    public void setTxManager(TransactionManager txManager) {
+        this.txManager = txManager;
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/DefaultMessageSchedulerContext.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/DefaultMessageSchedulerContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.context;
+
+import com.webank.wedatasphere.linkis.message.builder.DefaultMessageJobBuilder;
+import com.webank.wedatasphere.linkis.message.parser.DefaultImplicitParser;
+import com.webank.wedatasphere.linkis.message.parser.DefaultServiceParser;
+import com.webank.wedatasphere.linkis.message.publisher.DefaultMessagePublisher;
+import com.webank.wedatasphere.linkis.message.registry.AbstractImplicitRegistry;
+import com.webank.wedatasphere.linkis.message.registry.AbstractServiceRegistry;
+import com.webank.wedatasphere.linkis.message.scheduler.DefaultMessageScheduler;
+import com.webank.wedatasphere.linkis.message.tx.TransactionManager;
+
+/**
+ * @date 2020/7/15
+ */
+public class DefaultMessageSchedulerContext extends AbstractMessageSchedulerContext {
+
+    {
+        setImplicitParser(new DefaultImplicitParser());
+        setImplicitRegistry(new AbstractImplicitRegistry(this){});
+        setserviceParser(new DefaultServiceParser());
+        setPublisher(new DefaultMessagePublisher(this));
+        setServiceRegistry(new AbstractServiceRegistry(this) {
+        });
+        setScheduler(new DefaultMessageScheduler());
+        setJobBuilder(new DefaultMessageJobBuilder());
+        setTxManager(new TransactionManager() {
+        });
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/MSContextInstance.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/MSContextInstance.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.context;
+
+import com.webank.wedatasphere.linkis.message.utils.MessageUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @date 2020/9/17
+ */
+public class MSContextInstance {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MSContextInstance.class);
+
+    private static volatile MessageSchedulerContext context = null;
+
+    public static MessageSchedulerContext get() {
+        if (context == null) {
+            synchronized (MSContextInstance.class) {
+                if (context != null) {
+                    try {
+                        MessageSchedulerContext bean = MessageUtils.getBean(MessageSchedulerContext.class);
+                        if (bean != null)
+                            context = bean;
+                        else
+                            context = new DefaultMessageSchedulerContext();
+                    } catch (Throwable e) {
+                        LOGGER.warn("can not load message context from ioc container");
+                        context = new DefaultMessageSchedulerContext();
+                    }
+                }
+
+            }
+        }
+        return context;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/MessageSchedulerContext.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/MessageSchedulerContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.context;
+
+import com.webank.wedatasphere.linkis.message.publisher.MessagePublisher;
+import com.webank.wedatasphere.linkis.message.registry.ImplicitRegistry;
+import com.webank.wedatasphere.linkis.message.registry.ServiceRegistry;
+
+/**
+ * @date 2020/7/14
+ */
+public interface MessageSchedulerContext {
+
+    MessagePublisher getPublisher();
+
+    ServiceRegistry getServiceRegistry();
+
+    ImplicitRegistry getImplicitRegistry();
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/SpringMessageSchedulerContext.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/context/SpringMessageSchedulerContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.context;
+
+import com.webank.wedatasphere.linkis.message.builder.DefaultMessageJobBuilder;
+import com.webank.wedatasphere.linkis.message.parser.DefaultImplicitParser;
+import com.webank.wedatasphere.linkis.message.parser.DefaultServiceParser;
+import com.webank.wedatasphere.linkis.message.publisher.DefaultMessagePublisher;
+import com.webank.wedatasphere.linkis.message.registry.SpringImplicitRegistry;
+import com.webank.wedatasphere.linkis.message.registry.SpringServiceRegistry;
+import com.webank.wedatasphere.linkis.message.scheduler.DefaultMessageScheduler;
+import com.webank.wedatasphere.linkis.message.tx.SpringTransactionManager;
+
+/**
+ * @date 2020/9/11
+ */
+public class SpringMessageSchedulerContext extends AbstractMessageSchedulerContext {
+
+    {
+        setImplicitParser(new DefaultImplicitParser());
+        setImplicitRegistry(new SpringImplicitRegistry(this));
+        setserviceParser(new DefaultServiceParser());
+        setPublisher(new DefaultMessagePublisher(this));
+        setServiceRegistry(new SpringServiceRegistry(this));
+        setScheduler(new DefaultMessageScheduler());
+        setJobBuilder(new DefaultMessageJobBuilder());
+        setTxManager(new SpringTransactionManager());
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/exception/MessageErrorException.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/exception/MessageErrorException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException;
+
+/**
+ * @date 2020/7/15
+ */
+public class MessageErrorException extends ErrorException {
+
+    public MessageErrorException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public MessageErrorException(int errCode, String desc, Throwable t) {
+        super(errCode, desc);
+        initCause(t);
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/exception/MessageWarnException.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/exception/MessageWarnException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.WarnException;
+
+/**
+ * @date 2020/6/10 17:43
+ */
+public class MessageWarnException extends WarnException {
+
+    public MessageWarnException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public MessageWarnException(int errCode, String desc, Throwable t) {
+        super(errCode, desc);
+        initCause(t);
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/DefaultImplicitParser.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/DefaultImplicitParser.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.parser;
+
+import com.webank.wedatasphere.linkis.message.annotation.Implicit;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @date 2020/7/28
+ */
+public class DefaultImplicitParser implements ImplicitParser {
+    @Override
+    public Map<String, List<ImplicitMethod>> parse(Object implicitObject) {
+        Method[] methods = implicitObject.getClass().getMethods();
+        return Arrays.stream(methods)
+                .filter(this::methodFilterPredicate)
+                .map(m -> this.getImplicitMethod(m, implicitObject))
+                .collect(Collectors.groupingBy(ImplicitMethod::getOutput));
+    }
+
+    private ImplicitMethod getImplicitMethod(Method method, Object implicitObject) {
+        ImplicitMethod implicitMethod = new ImplicitMethod();
+        implicitMethod.setMethod(method);
+        implicitMethod.setImplicitObject(implicitObject);
+        implicitMethod.setInput(method.getParameterTypes()[0].getName());
+        implicitMethod.setOutput(method.getReturnType().getName());
+        return implicitMethod;
+    }
+
+    /**
+     * 标注了@implicit注解
+     * 入参数量只有一个，返回值不为void
+     * 入参需要是RequestProtocol 的子类
+     * 排除出参是入参的父类的情况
+     *
+     * @param method
+     * @return
+     */
+    private boolean methodFilterPredicate(Method method) {
+        if (method.getAnnotation(Implicit.class) != null
+                && method.getParameterCount() == 1
+                && !void.class.equals(method.getReturnType())) {
+            // TODO: 2020/8/4 返回值支持集合 ，参数也可以不用是RequestProtocol的子类
+            Class<?> input = method.getParameterTypes()[0];
+            return RequestProtocol.class.isAssignableFrom(input) && !method.getReturnType().isAssignableFrom(input);
+        }
+        return false;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/DefaultServiceParser.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/DefaultServiceParser.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.parser;
+
+import com.webank.wedatasphere.linkis.message.annotation.Chain;
+import com.webank.wedatasphere.linkis.message.annotation.NotImplicit;
+import com.webank.wedatasphere.linkis.message.annotation.Order;
+import com.webank.wedatasphere.linkis.message.annotation.Receiver;
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @date 2020/7/15
+ */
+public class DefaultServiceParser implements ServiceParser {
+
+    @Override
+    public Map<String, List<ServiceMethod>> parse(Object service) {
+        // TODO: 2020/7/15 more analysis
+        Method[] methods = service.getClass().getMethods();
+        return Arrays.stream(methods)
+                .filter(this::methodFilterPredicate)
+                .map(m -> getServiceMethod(m, service))
+                .collect(Collectors.groupingBy(ServiceMethod::getProtocolName));
+    }
+
+    private ServiceMethod getServiceMethod(Method method, Object service) {
+        ServiceMethod serviceMethod = new ServiceMethod();
+        serviceMethod.setMethod(method);
+        serviceMethod.setService(service);
+        serviceMethod.setAlias(String.format("%s.%s", service.getClass().getName(), method.getName()));
+        Order order = method.getAnnotation(Order.class);
+        if (order != null) {
+            serviceMethod.setOrder(order.value());
+        }
+        Chain chain = method.getAnnotation(Chain.class);
+        if (chain != null) serviceMethod.setChainName(chain.value());
+        Parameter[] parameters = method.getParameters();
+        if (parameters.length == 2) {
+            serviceMethod.setHasMethodContext(true);
+            if (ServiceMethodContext.class.isAssignableFrom(parameters[0].getType()))
+                serviceMethod.setMethodContextOnLeft(true);
+        }
+        @SuppressWarnings("all")
+        Parameter parameter = Arrays.stream(parameters)
+                .filter(p -> !ServiceMethodContext.class.isAssignableFrom(p.getType())).findFirst().get();
+        NotImplicit annotation = parameter.getAnnotation(NotImplicit.class);
+        if (annotation != null) serviceMethod.setAllowImplicit(false);
+        serviceMethod.setProtocolName(parameter.getType().getName());
+        return serviceMethod;
+    }
+
+    /**
+     * 标注了@Receiver注解，方法至少一个参数
+     * 1个参数：非ServiceMethodContext 子类即可
+     * 2个参数 其中一个需要是ServiceMethodContext 的子类 && 2个参数都非ServiceMethodContext 子类即可
+     *
+     * @param method
+     * @return
+     */
+    private boolean methodFilterPredicate(Method method) {
+        if (method.getAnnotation(Receiver.class) != null) {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            if (method.getParameterCount() == 1) {
+                return !ServiceMethodContext.class.isAssignableFrom(parameterTypes[0]);
+            } else if (method.getParameterCount() == 2) {
+                boolean hasContext = Arrays.stream(parameterTypes).anyMatch(ServiceMethodContext.class::isAssignableFrom);
+                boolean allContext = Arrays.stream(parameterTypes).allMatch(ServiceMethodContext.class::isAssignableFrom);
+                return hasContext && !allContext;
+            }
+        }
+        return false;
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ImplicitMethod.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ImplicitMethod.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.parser;
+
+import java.lang.reflect.Method;
+
+/**
+ * @date 2020/7/28
+ */
+public class ImplicitMethod {
+
+    private Object implicitObject;
+
+    private Method method;
+
+    private String input;
+
+    private String output;
+
+    public Object getImplicitObject() {
+        return implicitObject;
+    }
+
+    public void setImplicitObject(Object implicitObject) {
+        this.implicitObject = implicitObject;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ImplicitParser.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ImplicitParser.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.parser;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @date 2020/7/28
+ */
+public interface ImplicitParser {
+
+    Map<String, List<ImplicitMethod>> parse(Object implicitObject);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ServiceMethod.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ServiceMethod.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.parser;
+
+import java.lang.reflect.Method;
+
+/**
+ * @date 2020/7/15
+ */
+public class ServiceMethod {
+
+    private Object service;
+
+    private Method method;
+
+    private String alias;
+
+    private String protocolName;
+
+    private int order = 2147483647;
+
+    private boolean allowImplicit = true;
+
+    private boolean hasMethodContext;
+
+    private ImplicitMethod implicitMethod;
+
+    private boolean methodContextOnLeft;
+
+    private String chainName = "default";
+
+    public String getChainName() {
+        return chainName;
+    }
+
+    public void setChainName(String chainName) {
+        this.chainName = chainName;
+    }
+
+    public ImplicitMethod getImplicitMethod() {
+        return implicitMethod;
+    }
+
+    public void setImplicitMethod(ImplicitMethod implicitMethod) {
+        this.implicitMethod = implicitMethod;
+    }
+
+    public boolean isHasMethodContext() {
+        return hasMethodContext;
+    }
+
+    public void setHasMethodContext(boolean hasMethodContext) {
+        this.hasMethodContext = hasMethodContext;
+    }
+
+    public boolean isAllowImplicit() {
+        return allowImplicit;
+    }
+
+    public void setAllowImplicit(boolean allowImplicit) {
+        this.allowImplicit = allowImplicit;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    public Object getService() {
+        return service;
+    }
+
+    public void setService(Object service) {
+        this.service = service;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getProtocolName() {
+        return protocolName;
+    }
+
+    public void setProtocolName(String protocolName) {
+        this.protocolName = protocolName;
+    }
+
+    public boolean isMethodContextOnLeft() {
+        return methodContextOnLeft;
+    }
+
+    public void setMethodContextOnLeft(boolean methodContextOnLeft) {
+        this.methodContextOnLeft = methodContextOnLeft;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ServiceParser.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/parser/ServiceParser.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.parser;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @date 2020/7/15
+ */
+public interface ServiceParser {
+
+    Map<String, List<ServiceMethod>> parse(Object service);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/publisher/AbstractMessagePublisher.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/publisher/AbstractMessagePublisher.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.publisher;
+
+import com.webank.wedatasphere.linkis.common.utils.JavaLog;
+import com.webank.wedatasphere.linkis.message.builder.DefaultServiceMethodContext;
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext;
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.exception.MessageWarnException;
+import com.webank.wedatasphere.linkis.message.parser.ImplicitMethod;
+import com.webank.wedatasphere.linkis.message.parser.ServiceMethod;
+import com.webank.wedatasphere.linkis.message.scheduler.MethodExecuteWrapper;
+import com.webank.wedatasphere.linkis.message.utils.MessageUtils;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf.CONTEXT_KEY;
+
+/**
+ * @date 2020/7/15
+ */
+public abstract class AbstractMessagePublisher extends JavaLog implements MessagePublisher {
+
+    private AbstractMessageSchedulerContext context;
+
+    public AbstractMessagePublisher(AbstractMessageSchedulerContext context) {
+        this.context = context;
+    }
+
+    public void setContext(AbstractMessageSchedulerContext context) {
+        this.context = context;
+    }
+
+    /**
+     * key是requestProtocol的全类名，Map中，key是groupName
+     */
+    private final Map<String, Map<String, List<ServiceMethod>>> protocolServiceMethodCache = new ConcurrentHashMap<>();
+
+
+    @Override
+    public MessageJob publish(RequestProtocol requestProtocol) {
+        return publish(requestProtocol, new DefaultServiceMethodContext());
+    }
+
+    @Override
+    public MessageJob publish(RequestProtocol requestProtocol, ServiceMethodContext serviceMethodContext) {
+        logger().debug(String.format("receive request:%s", requestProtocol.getClass().getName()));
+        serviceMethodContext.putIfAbsent(CONTEXT_KEY, this.context);
+        Map<String, List<MethodExecuteWrapper>> methodExecuteWrappers = getMethodExecuteWrappers(requestProtocol);
+        MessageJob messageJob = this.context.getJobBuilder().of()
+                .with(serviceMethodContext).with(requestProtocol).with(this.context)
+                .with(methodExecuteWrappers).build();
+        this.context.getScheduler().submit(messageJob);
+        return messageJob;
+    }
+
+    private Map<String, List<MethodExecuteWrapper>> getMethodExecuteWrappers(RequestProtocol requestProtocol) {
+        String protocolName = requestProtocol.getClass().getName();
+        Map<String, List<ServiceMethod>> protocolServiceMethods = this.protocolServiceMethodCache.get(protocolName);
+        //静态信息，无需加锁
+        if (protocolServiceMethods == null) {
+            Map<String, List<ServiceMethod>> serviceMethodCache = this.context.getServiceRegistry().getServiceMethodCache();
+            Map<String, List<ImplicitMethod>> implicitMethodCache = this.context.getImplicitRegistry().getImplicitMethodCache();
+            //找出注册方法中，参数是当前请求的父类的
+            Map<String, List<ServiceMethod>> serviceMatchs = serviceMethodCache.entrySet().stream()
+                    .filter(e -> MessageUtils.isAssignableFrom(e.getKey(), protocolName))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            //找出implicit方法中，参数是当前请求父类的，根据注册规则，implicit的出参必然和上面的servicematchKeys 不会重复
+            Map<String, List<ServiceMethod>> implicitMatchs = new HashMap<>();
+            for (Map.Entry<String, List<ImplicitMethod>> implicitEntry : implicitMethodCache.entrySet()) {
+                //当前implicitMehtod中，input需要是protocolName 的父类or同类
+                String implicitEntryKey = implicitEntry.getKey();
+                List<ImplicitMethod> implicitEntryValue = implicitEntry.getValue();
+                // 支持隐式 返回值 和service之间的接口继承关系
+                Map<String, List<ServiceMethod>> implicitServiceMethods = serviceMethodCache.entrySet().stream()
+                        .filter(e -> MessageUtils.isAssignableFrom(e.getKey(), implicitEntryKey))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                //排除implicit返回值是protocolName的父类，可能存在另外一个不相干protocol的转换方法的返回值是当前protocol的父类
+                if (!MessageUtils.isAssignableFrom(implicitEntryKey, protocolName) && !implicitServiceMethods.isEmpty()) {
+                    for (Map.Entry<String, List<ServiceMethod>> implicitServiceMethodEntry : implicitServiceMethods.entrySet()) {
+                        String implicitServiceMethodEntryKey = implicitServiceMethodEntry.getKey();
+                        List<ServiceMethod> implicitServiceMethodEntryValue = implicitServiceMethodEntry.getValue();
+                        //参数中要支持implicit的
+                        List<ServiceMethod> filteredServiceMethods = implicitServiceMethodEntryValue.stream()
+                                .filter(ServiceMethod::isAllowImplicit)
+                                .collect(Collectors.toList());
+                        //隐式方法中参数需要是当前请求protocol的本类或子类
+                        List<ImplicitMethod> filteredImplicitMethods = implicitEntryValue.stream()
+                                .filter(v -> MessageUtils.isAssignableFrom(v.getInput(), protocolName))
+                                .collect(Collectors.toList());
+                        if (!filteredServiceMethods.isEmpty() && !filteredImplicitMethods.isEmpty()) {
+                            //针对每个ServiceMethod 选择，因为可能他们处于不同的service之间
+                            for (ServiceMethod filteredServiceMethod : filteredServiceMethods) {
+                                Object service = filteredServiceMethod.getService();
+                                //同service优先
+                                Optional<ImplicitMethod> first = filteredImplicitMethods.stream()
+                                        .filter(m -> m.getImplicitObject() == service).findFirst();
+                                if (first.isPresent()) {
+                                    filteredServiceMethod.setImplicitMethod(first.get());
+                                } else {
+                                    // TODO: 2020/7/30  入参父子类的判断优先级，和scala一致
+                                    //简单的只取第一个
+                                    filteredServiceMethod.setImplicitMethod(filteredImplicitMethods.get(0));
+                                }
+                            }
+                            //添加到缓存中
+                            implicitMatchs.put(implicitServiceMethodEntryKey, filteredServiceMethods);
+                        }
+                    }
+                }
+            }
+            //merge
+            serviceMatchs.putAll(implicitMatchs);
+            //group by chain name 扁平化后再group，这时protocol的父类可能和转换的处于同一个chain中
+            serviceMatchs = serviceMatchs.values().stream().flatMap(Collection::stream).collect(Collectors.groupingBy(ServiceMethod::getChainName));
+            //order判断
+            for (List<ServiceMethod> value : serviceMatchs.values()) {
+                Integer repeatOrder = MessageUtils.repeatOrder(value);
+                if (repeatOrder != null && !MessageUtils.orderIsLast(repeatOrder, value)) {
+                    throw new MessageWarnException(10000, String.format("repeat order : %s for request %s", repeatOrder, protocolName));
+                }
+            }
+            this.protocolServiceMethodCache.put(protocolName, serviceMatchs);
+        }
+        //clone 对象并返回
+        return serviceMethod2Wrapper(this.protocolServiceMethodCache.get(protocolName));
+    }
+
+    private Map<String, List<MethodExecuteWrapper>> serviceMethod2Wrapper(Map<String, List<ServiceMethod>> source) {
+        HashMap<String, List<MethodExecuteWrapper>> target = new HashMap<>();
+        source.forEach((k, v) -> target.put(k, v.stream().map(MethodExecuteWrapper::new).collect(Collectors.toList())));
+        return target;
+    }
+
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/publisher/DefaultMessagePublisher.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/publisher/DefaultMessagePublisher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.publisher;
+
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+
+/**
+ * @date 2020/7/15
+ */
+public class DefaultMessagePublisher extends AbstractMessagePublisher {
+
+    public DefaultMessagePublisher(AbstractMessageSchedulerContext context) {
+        super(context);
+    }
+
+    public DefaultMessagePublisher() {
+        this(null);
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/publisher/MessagePublisher.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/publisher/MessagePublisher.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.publisher;
+
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+/**
+ * @date 2020/7/14
+ */
+public interface MessagePublisher {
+
+    MessageJob publish(RequestProtocol requestProtocol);
+
+    MessageJob publish(RequestProtocol requestProtocol, ServiceMethodContext serviceMethodContext);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/AbstractImplicitRegistry.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/AbstractImplicitRegistry.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.registry;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import com.webank.wedatasphere.linkis.common.utils.JavaLog;
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.parser.ImplicitMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @date 2020/7/28
+ */
+public abstract class AbstractImplicitRegistry extends JavaLog implements ImplicitRegistry {
+
+    private final AbstractMessageSchedulerContext context;
+    /**
+     * key: output
+     */
+    private final Map<String, List<ImplicitMethod>> implicitMethodCache = new ConcurrentHashMap<>();
+
+    public AbstractImplicitRegistry(AbstractMessageSchedulerContext context) {
+        this.context = context;
+    }
+
+    @SuppressWarnings("all")
+    public final Interner<String> lock = Interners.<String>newWeakInterner();
+
+    private final Map<String, Object> registedImplicitObjectMap = new ConcurrentHashMap<>();
+
+
+    @Override
+    @SuppressWarnings("all")
+    public void register(Object implicitObject) {
+        String implicitObjectName = implicitObject.getClass().getName();
+        synchronized (this.lock.intern(implicitObjectName)) {
+            //1.是否解析过
+            Object o = this.registedImplicitObjectMap.get(implicitObjectName);
+            if (o != null) return;
+            Map<String, List<ImplicitMethod>> implicitMethods = this.context.getImplicitParser().parse(implicitObject);
+            implicitMethods.forEach(this::refreshImplicitMethodCache);
+            this.registedImplicitObjectMap.put(implicitObjectName, implicitObject);
+        }
+    }
+
+    @SuppressWarnings("all")
+    private void refreshImplicitMethodCache(String key, List<ImplicitMethod> implicitMethods) {
+        synchronized (this.lock.intern(key)) {
+            //同一个implicitObject 下的入参，出参相同的implit,会被过滤掉
+            List<ImplicitMethod> implicitMethodsOld = this.implicitMethodCache.computeIfAbsent(key, k -> new ArrayList<>());
+            for (ImplicitMethod implicitMethod : implicitMethods) {
+                if (isImplicitRepeat(new ArrayList<>(implicitMethodsOld), implicitMethod)) {
+                    // TODO: 2020/7/29 logging
+                    continue;
+                }
+                implicitMethodsOld.add(implicitMethod);
+            }
+        }
+    }
+
+    private boolean isImplicitRepeat(List<ImplicitMethod> implicitMethodsOld, ImplicitMethod implicitMethod) {
+        return implicitMethodsOld.stream().
+                anyMatch(im -> im.getImplicitObject() == implicitMethod.getImplicitObject() && im.getInput().equals(implicitMethod.getInput()));
+    }
+
+    public Map<String, List<ImplicitMethod>> getImplicitMethodCache() {
+        return this.implicitMethodCache;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/AbstractServiceRegistry.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/AbstractServiceRegistry.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.registry;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import com.webank.wedatasphere.linkis.common.utils.JavaLog;
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.exception.MessageWarnException;
+import com.webank.wedatasphere.linkis.message.parser.ServiceMethod;
+import com.webank.wedatasphere.linkis.message.parser.ServiceParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @date 2020/7/15
+ */
+public abstract class AbstractServiceRegistry extends JavaLog implements ServiceRegistry {
+
+    @SuppressWarnings("all")
+    public final Interner<String> lock = Interners.<String>newWeakInterner();
+    /**
+     * key:requestprotocol or custom implicit object class name
+     */
+    private final Map<String, List<ServiceMethod>> serviceMethodCache = new ConcurrentHashMap<>();
+
+    private final Map<String, Object> registedServieMap = new ConcurrentHashMap<>();
+
+    private final AbstractMessageSchedulerContext context;
+
+    public AbstractServiceRegistry(AbstractMessageSchedulerContext context) {
+        this.context = context;
+    }
+
+    @SuppressWarnings("all")
+    @Override
+    public void register(Object service) {
+        //防止不同方式注册时候的并发，比如spring和手动注册,同时防止不同包名下类名一样的service
+        String serviceName = service.getClass().getName();
+        synchronized (this.lock.intern(serviceName)) {
+            //1.是否注册过
+            Object o = this.registedServieMap.get(serviceName);
+            if (o != null) return;
+            //2..解析
+            ServiceParser serviceParser = this.context.getservieParser();
+            Map<String, List<ServiceMethod>> serviceMethods = serviceParser.parse(service);
+            //3.注册
+            serviceMethods.forEach(this::register);
+            this.registedServieMap.put(serviceName, service);
+        }
+    }
+
+    /**
+     * @param key
+     * @param value
+     * @throws MessageWarnException
+     */
+    @SuppressWarnings("all")
+    private void register(String key, List<ServiceMethod> serviceMethods) {
+        //防止相同key在不同service的并发注册
+        synchronized (this.lock.intern(key)) {
+            //1.添加cache
+            refreshServiceMethodCache(key, serviceMethods);
+        }
+    }
+
+    private void refreshServiceMethodCache(String key, List<ServiceMethod> serviceMethods) {
+        this.serviceMethodCache.computeIfAbsent(key, k -> new ArrayList<>()).addAll(serviceMethods);
+    }
+
+    public Map<String, List<ServiceMethod>> getServiceMethodCache() {
+        return this.serviceMethodCache;
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/ImplicitRegistry.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/ImplicitRegistry.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.registry;
+
+/**
+ * @date 2020/7/28
+ */
+public interface ImplicitRegistry {
+
+    void register(Object implicitObject);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/ServiceRegistry.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/ServiceRegistry.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.registry;
+
+/**
+ * @date 2020/7/14
+ */
+public interface ServiceRegistry {
+
+    void register(Object service);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/SpringImplicitRegistry.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/SpringImplicitRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.registry;
+
+
+import com.webank.wedatasphere.linkis.message.annotation.Implicit;
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.utils.MessageUtils;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf.REFLECTIONS;
+
+/**
+ * @date 2020/7/28
+ */
+public class SpringImplicitRegistry extends AbstractImplicitRegistry {
+
+    public SpringImplicitRegistry(AbstractMessageSchedulerContext context) {
+        super(context);
+        Set<Method> implicitMethods = REFLECTIONS.getMethodsAnnotatedWith(Implicit.class);
+        Set<? extends Class<?>> implicitClasses = implicitMethods.stream().map(Method::getDeclaringClass).collect(Collectors.toSet());
+        //区分出 bean中的方法，和其他，其他使用反射创建方法对象
+        for (Class<?> implicitClass : implicitClasses) {
+            Object bean = MessageUtils.getBean(implicitClass);
+            if (bean == null) {
+                try {
+                    bean = implicitClass.newInstance();
+                } catch (Throwable t) {
+                    logger().warn(String.format("reflection failed to create object %s", implicitClass.getName()));
+                }
+            }
+            if (bean != null) this.register(bean);
+        }
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/SpringServiceRegistry.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/registry/SpringServiceRegistry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.registry;
+
+import com.webank.wedatasphere.linkis.message.annotation.Receiver;
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.utils.MessageUtils;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf.REFLECTIONS;
+
+/**
+ * @date 2020/7/15
+ */
+public class SpringServiceRegistry extends AbstractServiceRegistry {
+
+    public SpringServiceRegistry(AbstractMessageSchedulerContext context) {
+        super(context);
+        Set<? extends Class<?>> services = REFLECTIONS.getMethodsAnnotatedWith(Receiver.class).stream()
+                .map(Method::getDeclaringClass).collect(Collectors.toSet());
+        services.stream().map(MessageUtils::getBean).filter(Objects::nonNull).forEach(this::register);
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/AbstractMessageExecutor.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/AbstractMessageExecutor.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.common.utils.JavaLog;
+import com.webank.wedatasphere.linkis.message.builder.DefaultServiceMethodContext;
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext;
+import com.webank.wedatasphere.linkis.message.exception.MessageWarnException;
+import com.webank.wedatasphere.linkis.message.parser.ImplicitMethod;
+import com.webank.wedatasphere.linkis.message.utils.MessageUtils;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+import com.webank.wedatasphere.linkis.scheduler.queue.Job;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+/**
+ * @date 2020/7/21
+ */
+public abstract class AbstractMessageExecutor extends JavaLog implements MessageExecutor {
+
+    private Throwable t;
+
+    private void methodErrorHandle(Throwable t) {
+        if (t.getCause() != null) {
+            this.t = t;
+        } else {
+            this.t = t;
+            logger().debug("unexpected error occur");
+        }
+    }
+
+    private List<MethodExecuteWrapper> getMinOrderMethodWrapper(Map<String, List<MethodExecuteWrapper>> methodWrappers) {
+        //获取所有key中order最小的
+        List<MethodExecuteWrapper> minOrderMethodWrapper = new ArrayList<>();
+        methodWrappers.forEach((k, v) -> v.forEach(m -> {
+            if (MessageUtils.orderIsMin(m, v)) minOrderMethodWrapper.add(m);
+        }));
+        return minOrderMethodWrapper;
+    }
+
+    private List<MethodExecuteWrapper> getMinOrderMethodWrapper(List<MethodExecuteWrapper> methodWrappers) {
+        //获取单个key中order最小的，一般是一个，尾链可能有多个
+        return methodWrappers.stream().filter(m -> MessageUtils.orderIsMin(m, methodWrappers)).collect(Collectors.toList());
+    }
+
+    private boolean shouldBreak(Map<String, List<MethodExecuteWrapper>> methodWrappers) {
+        return methodWrappers.values().stream().allMatch(List::isEmpty);
+    }
+
+    private void cleanMethodContextThreadLocal(ServiceMethodContext methodContext) {
+        if (methodContext instanceof DefaultServiceMethodContext) {
+            ((DefaultServiceMethodContext) methodContext).removeJob();
+            ((DefaultServiceMethodContext) methodContext).removeSkips();
+        }
+    }
+
+    private void setMethodContextThreadLocal(ServiceMethodContext methodContext, MessageJob job) {
+        if (methodContext instanceof DefaultServiceMethodContext && job instanceof Job) {
+            ((DefaultServiceMethodContext) methodContext).setJob((Job) job);
+        }
+    }
+
+    @Override
+    public void run(MessageJob job) throws InterruptedException {
+        RequestProtocol requestProtocol = job.getRequestProtocol();
+        ServiceMethodContext methodContext = job.getMethodContext();
+        // TODO: 2020/7/22 data structure optimization of variable methodWrappers
+        Map<String, List<MethodExecuteWrapper>> methodWrappers = job.getMethodExecuteWrappers();
+        Integer count = methodWrappers.values().stream().map(List::size).reduce(0, Integer::sum);
+        LinkedBlockingDeque<MethodExecuteWrapper> queue = new LinkedBlockingDeque<>(16);
+        CopyOnWriteArrayList<Future<?>> methodFutures = new CopyOnWriteArrayList<>();
+        CountDownLatch countDownLatch = new CountDownLatch(count);
+        getMinOrderMethodWrapper(methodWrappers).forEach(queue::offer);
+        try {
+            while (!Thread.interrupted()) {
+                if (shouldBreak(methodWrappers)) {
+                    break;
+                }
+                MethodExecuteWrapper methodWrapper = queue.poll(10, TimeUnit.MILLISECONDS);
+                if (methodWrapper == null) continue;
+                methodWrappers.get(methodWrapper.getChainName()).remove(methodWrapper);
+                Future<?> methodFuture = getExecutorService().submit(() -> {
+                    Object result = null;
+                    try {
+                        // TODO: 2020/7/31 判断逻辑挪走
+                        if (!methodWrapper.shouldSkip) {
+                            //放置job状态
+                            setMethodContextThreadLocal(methodContext, job);
+                            Method method = methodWrapper.getMethod();
+                            Object service = methodWrapper.getService();
+                            info(String.format("message scheduler executor ===> service: %s,method: %s", service.getClass().getName(), method.getName()));
+                            Object implicit;
+                            // TODO: 2020/8/4 implicit 的结果应该复用下
+                            ImplicitMethod implicitMethod = methodWrapper.getImplicitMethod();
+                            if (implicitMethod != null) {
+                                implicit = implicitMethod.getMethod().invoke(implicitMethod.getImplicitObject(), requestProtocol);
+                            } else {
+                                implicit = requestProtocol;
+                            }
+                            if (methodWrapper.isHasMethodContext()) {
+                                if (methodWrapper.isMethodContextOnLeft()) {
+                                    result = method.invoke(service, methodContext, implicit);
+                                } else {
+                                    result = method.invoke(service, implicit, methodContext);
+                                }
+                            } else {
+                                result = method.invoke(service, implicit);
+                            }
+                            // TODO: 2020/8/5  执行完成后判断service是否有主动skip的逻辑
+                        }
+                    } catch (Throwable t) {
+                        logger().error(String.format("method %s call failed", methodWrapper.getAlias()), t);
+                        methodWrappers.forEach((k, v) -> v.forEach(m -> m.setShouldSkip(true)));
+                        methodErrorHandle(t);
+                    } finally {
+                        if (result != null) {
+                            methodContext.setResult(result);
+                        }
+                        //末链并发的时候，小概率可能会有重复的method被offer到queue中，但是在poll前循环就break了，无影响
+                        getMinOrderMethodWrapper(methodWrappers.get(methodWrapper.getChainName())).forEach(queue::offer);
+                        //移除state和skips的状态
+                        cleanMethodContextThreadLocal(methodContext);
+                        countDownLatch.countDown();
+                    }
+                });
+                methodFutures.add(methodFuture);
+            }
+            countDownLatch.await();
+        } catch (InterruptedException ie) {
+            methodFutures.forEach(f -> f.cancel(true));
+            throw ie;
+        }
+        if (this.t != null) {
+            throw new MessageWarnException(10000, "method call failed", t);
+        }
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/DefaultMessageExecutor.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/DefaultMessageExecutor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+import com.webank.wedatasphere.linkis.message.exception.MessageWarnException;
+import com.webank.wedatasphere.linkis.message.tx.TransactionManager;
+import com.webank.wedatasphere.linkis.protocol.engine.EngineState;
+import com.webank.wedatasphere.linkis.scheduler.executer.*;
+import com.webank.wedatasphere.linkis.scheduler.queue.SchedulerEvent;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * @date 2020/7/29
+ */
+public class DefaultMessageExecutor extends AbstractMessageExecutor implements Executor {
+
+    private final ExecutorService executorService;
+
+    private final SchedulerEvent event;
+
+    public DefaultMessageExecutor(SchedulerEvent event, ExecutorService executorService) {
+        this.event = event;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return this.executorService;
+    }
+
+    @Override
+    public long getId() {
+        return 0;
+    }
+
+    /**
+     * @param executeRequest
+     * @return
+     */
+    @Override
+    public ExecuteResponse execute(ExecuteRequest executeRequest) {
+        if (event instanceof MessageJob) {
+            TransactionManager txManager = ((MessageJob) event).getContext().getTxManager();
+            Object o = txManager.begin();
+            try {
+                run((MessageJob) event);
+                txManager.commit(o);
+                return new SuccessExecuteResponse();
+            } catch (InterruptedException ie) {
+                //handle InterruptedException
+                logger().error("message job execution interrupted", ie);
+                txManager.rollback(o);
+                return new ErrorExecuteResponse("message job execution interrupted", ie);
+            } catch (MessageWarnException mwe) {
+                //handle method call failed
+                logger().error("method call normal error return");
+                txManager.rollback(o);
+                return new ErrorExecuteResponse("method call failed", mwe);
+            } catch (Throwable t) {
+                logger().debug("unexpected error occur", t);
+                txManager.rollback(o);
+                return new ErrorExecuteResponse("unexpected error", t);
+            }
+        }
+        MessageWarnException eventNotMatchError = new MessageWarnException(10000, "event is not instance of MessageJob");
+        return new ErrorExecuteResponse("event is not instance of MessageJob", eventNotMatchError);
+
+    }
+
+    @Override
+    public EngineState state() {
+        return null;
+    }
+
+    @Override
+    public ExecutorInfo getExecutorInfo() {
+        return new ExecutorInfo(0, null);
+    }
+
+
+
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/DefaultMessageScheduler.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/DefaultMessageScheduler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+import com.webank.wedatasphere.linkis.message.builder.MessageJobListener;
+import com.webank.wedatasphere.linkis.scheduler.Scheduler;
+import com.webank.wedatasphere.linkis.scheduler.executer.ExecutorManager;
+import com.webank.wedatasphere.linkis.scheduler.queue.Group;
+import com.webank.wedatasphere.linkis.scheduler.queue.GroupFactory;
+import com.webank.wedatasphere.linkis.scheduler.queue.Job;
+import com.webank.wedatasphere.linkis.scheduler.queue.parallelqueue.ParallelGroup;
+import com.webank.wedatasphere.linkis.scheduler.queue.parallelqueue.ParallelScheduler;
+import com.webank.wedatasphere.linkis.scheduler.queue.parallelqueue.ParallelSchedulerContextImpl;
+
+/**
+ * @date 2020/7/17
+ */
+public class DefaultMessageScheduler implements MessageScheduler {
+
+    // TODO: 2020/7/22 configuration
+    private static final int MAX_RUNING_JOB = Runtime.getRuntime().availableProcessors() * 2;
+
+    private static final int MAX_PARALLELISM_USERS = Runtime.getRuntime().availableProcessors();
+
+    private static final int MAX_ASK_EXECUTOR_TIMES = 1000;
+
+    private static final String GROUP_NAME = "message-scheduler";
+
+    private final Scheduler linkisScheduler;
+
+    {
+        MessageExecutorExecutionManager messageExecutorManager = new MessageExecutorExecutionManager();
+        linkisScheduler = new ParallelScheduler(
+                new ParallelSchedulerContextImpl(MAX_PARALLELISM_USERS) {
+                    @Override
+                    public ExecutorManager getOrCreateExecutorManager() {
+                        return messageExecutorManager;
+                    }
+                });
+        linkisScheduler.init();
+        GroupFactory groupFactory = linkisScheduler.getSchedulerContext().getOrCreateGroupFactory();
+        //one consumer group is enough
+        Group group = groupFactory.getOrCreateGroup(GROUP_NAME);
+        if (group instanceof ParallelGroup) {
+            ParallelGroup parallelGroup = (ParallelGroup) group;
+            if (parallelGroup.getMaxRunningJobs() == 0) {
+                parallelGroup.setMaxRunningJobs(MAX_RUNING_JOB);
+            }
+            if (parallelGroup.getMaxAskExecutorTimes() == 0) {
+                parallelGroup.setMaxAskExecutorTimes(MAX_ASK_EXECUTOR_TIMES);
+            }
+        }
+    }
+
+    @Override
+    public void submit(MessageJob messageJob) {
+        if (messageJob instanceof Job) {
+            ((Job) messageJob).setId(GROUP_NAME);
+            ((Job) messageJob).setJobListener(new MessageJobListener());
+            linkisScheduler.submit((Job) messageJob);
+        }
+    }
+
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MessageExecutor.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MessageExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * @date 2020/7/20
+ */
+public interface MessageExecutor {
+
+    void run(MessageJob job) throws InterruptedException;
+
+    ExecutorService getExecutorService();
+
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MessageExecutorExecutionManager.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MessageExecutorExecutionManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.common.utils.Utils;
+import com.webank.wedatasphere.linkis.scheduler.executer.Executor;
+import com.webank.wedatasphere.linkis.scheduler.executer.ExecutorManager;
+import com.webank.wedatasphere.linkis.scheduler.listener.ExecutorListener;
+import com.webank.wedatasphere.linkis.scheduler.queue.SchedulerEvent;
+import scala.Option;
+import scala.Some;
+import scala.concurrent.duration.Duration;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * @date 2020/7/17
+ */
+public class MessageExecutorExecutionManager extends ExecutorManager {
+
+    private final ExecutorService executorService = Utils.newCachedThreadPool(
+            Runtime.getRuntime().availableProcessors() * 2, "message-executor_", false);
+
+    @Override
+    public void setExecutorListener(ExecutorListener executorListener) {
+
+    }
+
+    @Override
+    public Executor createExecutor(SchedulerEvent event) {
+        return new DefaultMessageExecutor(event, executorService);
+    }
+
+    @Override
+    public Option<Executor> askExecutor(SchedulerEvent event) {
+        return new Some<>(createExecutor(event));
+    }
+
+    @Override
+    public Option<Executor> askExecutor(SchedulerEvent event, Duration wait) {
+        return askExecutor(event);
+    }
+
+    @Override
+    public Option<Executor> getById(long id) {
+        return new Some<>(null);
+    }
+
+    @Override
+    public Executor[] getByGroup(String groupName) {
+        return new Executor[0];
+    }
+
+    @Override
+    public void delete(Executor executor) {
+
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MessageScheduler.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MessageScheduler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+
+/**
+ * @date 2020/7/14
+ */
+public interface MessageScheduler {
+
+    void submit(MessageJob messageJob);
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MethodExecuteWrapper.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/scheduler/MethodExecuteWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.scheduler;
+
+import com.webank.wedatasphere.linkis.message.parser.ImplicitMethod;
+import com.webank.wedatasphere.linkis.message.parser.ServiceMethod;
+
+import java.lang.reflect.Method;
+
+/**
+ * @date 2020/7/21
+ */
+public class MethodExecuteWrapper {
+
+    public MethodExecuteWrapper(ServiceMethod serviceMethod) {
+        this.serviceMethod = serviceMethod;
+    }
+
+    private final ServiceMethod serviceMethod;
+
+    public boolean shouldSkip;
+
+    public boolean isShouldSkip() {
+        return shouldSkip;
+    }
+
+    public void setShouldSkip(boolean shouldSkip) {
+        this.shouldSkip = shouldSkip;
+    }
+
+    public Method getMethod() {
+        return this.serviceMethod.getMethod();
+    }
+
+    public Object getService() {
+        return this.serviceMethod.getService();
+    }
+
+
+    public String getAlias() {
+        return this.serviceMethod.getAlias();
+    }
+
+    public int getOrder() {
+        return this.serviceMethod.getOrder();
+    }
+
+    public String getChainName() {
+        return this.serviceMethod.getChainName();
+    }
+
+    public boolean isHasMethodContext() {
+        return this.serviceMethod.isHasMethodContext();
+    }
+
+    public ImplicitMethod getImplicitMethod() {
+        return this.serviceMethod.getImplicitMethod();
+    }
+
+    public boolean isMethodContextOnLeft() {
+        return this.serviceMethod.isMethodContextOnLeft();
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/tx/SpringTransactionManager.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/tx/SpringTransactionManager.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.tx;
+
+import com.webank.wedatasphere.linkis.common.utils.JavaLog;
+import com.webank.wedatasphere.linkis.message.utils.MessageUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+
+/**
+ * @date 2020/7/23
+ */
+public class SpringTransactionManager extends JavaLog implements TransactionManager {
+
+    private final PlatformTransactionManager platformTransactionManager;
+
+    public SpringTransactionManager() {
+        platformTransactionManager = MessageUtils.getBean(PlatformTransactionManager.class);
+    }
+
+
+    @Override
+    public Object begin() {
+        if (platformTransactionManager != null) {
+            return platformTransactionManager.getTransaction(new DefaultTransactionAttribute());
+        }
+        return null;
+    }
+
+    @Override
+    public void commit(Object o) {
+        if (o instanceof TransactionStatus && platformTransactionManager != null) {
+            platformTransactionManager.commit((TransactionStatus) o);
+        }
+    }
+
+    @Override
+    public void rollback(Object o) {
+        if (o instanceof TransactionStatus && platformTransactionManager != null) {
+            platformTransactionManager.rollback((TransactionStatus) o);
+        }
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/tx/TransactionManager.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/tx/TransactionManager.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.tx;
+
+/**
+ * @date 2020/7/23
+ */
+public interface TransactionManager {
+
+    default Object begin() {
+        return null;
+    }
+
+    default void commit(Object o) {
+    }
+
+    default void rollback(Object o) {
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/utils/MessageUtils.java
+++ b/linkis-commons/linkis-message-scheduler/src/main/java/com/webank/wedatasphere/linkis/message/utils/MessageUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message.utils;
+
+import com.webank.wedatasphere.linkis.DataWorkCloudApplication;
+import com.webank.wedatasphere.linkis.message.parser.ServiceMethod;
+import com.webank.wedatasphere.linkis.message.scheduler.MethodExecuteWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @date 2020/7/28
+ */
+public class MessageUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageUtils.class);
+
+    public static <T> T getBean(Class<T> tClass) {
+        T t = null;
+        ApplicationContext applicationContext = DataWorkCloudApplication.getApplicationContext();
+        if (applicationContext != null) {
+            try {
+                t = applicationContext.getBean(tClass);
+            } catch (NoSuchBeanDefinitionException e) {
+                LOGGER.warn(String.format("can not get bean from spring ioc:%s", tClass.getName()));
+            }
+        }
+        return t;
+    }
+
+    public static boolean isAssignableFrom(String supperClassName, String className) {
+        try {
+            return Class.forName(supperClassName).isAssignableFrom(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            LOGGER.error("class not found", e);
+            return false;
+        }
+    }
+
+    public static boolean orderIsMin(MethodExecuteWrapper methodExecuteWrapper, List<MethodExecuteWrapper> methodExecuteWrappers) {
+        for (MethodExecuteWrapper tmp : methodExecuteWrappers) {
+            if (tmp.getOrder() < methodExecuteWrapper.getOrder()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean orderIsLast(int order, List<ServiceMethod> serviceMethods) {
+        // TODO: 2020/8/5 方法判断修改为重复的order 支持头部
+        if (order == 2147483647) return true;
+        for (ServiceMethod serviceMethod : serviceMethods) {
+            if (serviceMethod.getOrder() > order) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public static Integer repeatOrder(List<ServiceMethod> serviceMethods) {
+        Map<Integer, Integer> tmp = new HashMap<>();
+        for (ServiceMethod serviceMethod : serviceMethods) {
+            int order = serviceMethod.getOrder();
+            if (tmp.get(order) == null) {
+                tmp.put(order, order);
+            } else {
+                return order;
+            }
+        }
+        return null;
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/resources/META-INF/spring.factories
+++ b/linkis-commons/linkis-message-scheduler/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.webank.wedatasphere.linkis.rpc.MessageRPCSpringConfiguration

--- a/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageConverter.scala
+++ b/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageConverter.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.rpc
+
+import java.lang.reflect.Modifier
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.message.annotation.Method
+import com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf.{REFLECTIONS, _}
+import com.webank.wedatasphere.linkis.message.exception.MessageErrorException
+import com.webank.wedatasphere.linkis.protocol.message.RequestMethod
+import com.webank.wedatasphere.linkis.rpc.exception.DWCURIException
+import com.webank.wedatasphere.linkis.server.{BDPJettyServerHelper, Message}
+
+import scala.collection.JavaConversions._
+
+/**
+ * @date 2020/8/6
+ *
+ */
+class MessageConverter {
+
+  private val protocolNameCache = new util.HashMap[String, String]
+
+  REFLECTIONS.getTypesAnnotatedWith(classOf[Method]).foreach { t =>
+    val method = t.getAnnotation(classOf[Method])
+    protocolNameCache.put(method.value(), t.getName)
+  }
+
+  REFLECTIONS.getSubTypesOf(classOf[RequestMethod]).filter(!_.isInterface).filter(c => !Modifier.isAbstract(c.getModifiers)).foreach { t =>
+    val protocol = try {
+      t.newInstance()
+    } catch {
+      case e: Throwable =>
+        throw new RuntimeException(s"Failed to create new instance of class ${t.getName}", e)
+    }
+    val method = t.getMethod("method").invoke(protocol).toString
+    protocolNameCache.put(method, t.getName)
+  }
+
+  @throws[MessageErrorException]
+  def convert(message: Message): util.Map[String, Object] = {
+    val methodUrl = message.getMethod
+    val protocolStr = protocolNameCache.get(methodUrl)
+    if (protocolStr == null) throw new MessageErrorException(10000, s"no suitable protocol was found for method:${methodUrl}")
+    val returnType = new util.HashMap[String, Object]()
+    val data = message.getData
+    returnType += REQUEST_KEY -> data.remove(REQUEST_KEY)
+    val protocol = Utils.tryThrow(Class.forName(protocolStr)) {
+      case _: ClassNotFoundException =>
+        new DWCURIException(10003, s"The corresponding anti-sequence class $protocolStr was not found.(找不到对应的反序列类$protocolStr.)")
+      case t: ExceptionInInitializerError =>
+        val exception = new DWCURIException(10004, s"The corresponding anti-sequence class ${protocolStr} failed to initialize.(对应的反序列类${protocolStr}初始化失败.)")
+        exception.initCause(t)
+        exception
+      case t: Throwable => t
+    }
+    returnType += "_request_protocol_" -> BDPJettyServerHelper.gson.fromJson(BDPJettyServerHelper.gson.toJson(data), protocol)
+    //设置一个restful请求的客户端
+    // TODO:  req中获取到ip和地址
+    data.clear()
+    data.put("name", "")
+    data.put("instance", "")
+    returnType
+  }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageRPCConsumer.scala
+++ b/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageRPCConsumer.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.rpc
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.exception.ExceptionManager
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.rpc.exception.DWCURIException
+import com.webank.wedatasphere.linkis.rpc.serializer.ProtostuffSerializeUtil
+import com.webank.wedatasphere.linkis.rpc.transform.RPCProduct.{CLASS_VALUE, OBJECT_VALUE}
+import com.webank.wedatasphere.linkis.server.{EXCEPTION_MSG, JMap, Message}
+
+import scala.runtime.BoxedUnit
+
+/**
+ * @date 2020/8/6
+ *
+ */
+
+class MessageRPCConsumer {
+
+  private val messageConverter: MessageConverter = new MessageConverter
+
+  def overrideToObject(message: Message): Any = {
+    message.getStatus match {
+      case 0 =>
+        val data = message.getData
+        if (data.isEmpty) return BoxedUnit.UNIT
+        if (isRPCRequest(data)) {
+          val objectStr = data.get(OBJECT_VALUE).toString
+          val objectClass = data.get(CLASS_VALUE).toString
+          val clazz = Utils.tryThrow(Class.forName(objectClass)) {
+            case _: ClassNotFoundException =>
+              new DWCURIException(10003, s"The corresponding anti-sequence class $objectClass was not found.(找不到对应的反序列类$objectClass.)")
+            case t: ExceptionInInitializerError =>
+              val exception = new DWCURIException(10004, s"The corresponding anti-sequence class ${objectClass} failed to initialize.(对应的反序列类${objectClass}初始化失败.)")
+              exception.initCause(t)
+              exception
+            case t: Throwable => t
+          }
+//          if (null != data.get(IS_REQUEST_PROTOCOL_CLASS) && data.get(IS_REQUEST_PROTOCOL_CLASS).toString.toBoolean) {
+            ProtostuffSerializeUtil.deserialize(objectStr, clazz)
+//          } else if (data.get(IS_SCALA_CLASS).toString.toBoolean) {
+//            val realClass = getSerializableScalaClass(clazz)
+//            Serialization.read(objectStr)(formats, ManifestFactory.classType(realClass))
+//          } else {
+//            BDPJettyServerHelper.gson.fromJson(objectStr, clazz)
+//          }
+        } else {
+          messageConverter.convert(message)
+        }
+      case 4 =>
+        val errorMsg = message.getData.get(EXCEPTION_MSG).asInstanceOf[JMap[String, Object]]
+        ExceptionManager.generateException(errorMsg)
+      case _ =>
+        val errorMsg = message.getData.get(EXCEPTION_MSG)
+        if (errorMsg == null) throw new DWCURIException(10005, message.getMessage)
+        val realError = ExceptionManager.generateException(errorMsg.asInstanceOf[JMap[String, Object]])
+        throw realError;
+    }
+  }
+
+  def isRPCRequest(data: util.HashMap[String, Object]): Boolean = {
+    data.containsKey(OBJECT_VALUE)
+  }
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageRPCReceiveRestful.scala
+++ b/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageRPCReceiveRestful.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.rpc
+
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf._
+import com.webank.wedatasphere.linkis.rpc.exception.DWCURIException
+import com.webank.wedatasphere.linkis.rpc.transform.{RPCConsumer, RPCProduct}
+import com.webank.wedatasphere.linkis.server.{Message, catchIt}
+import javax.annotation.PostConstruct
+import javax.servlet.http.HttpServletRequest
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.{Consumes, POST, Path, Produces}
+import org.apache.commons.lang.StringUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.{Import, Primary}
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.{RequestContextHolder, ServletRequestAttributes}
+
+import scala.concurrent.duration.Duration
+import scala.runtime.BoxedUnit
+
+/**
+ * @date 2020/8/3
+ *
+ */
+@Component
+@Path("/rpc")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+@Primary
+@Import(Array(classOf[MessageRPCConsumer]))
+class MessageRPCReceiveRestful extends RPCReceiveRestful {
+
+  @Autowired(required = false)
+  private var receiverChoosers: Array[ReceiverChooser] = Array.empty
+  @Autowired(required = false)
+  private var receiverSenderBuilders: Array[ReceiverSenderBuilder] = Array.empty
+  @Autowired
+  private var messageRPCConsumer: MessageRPCConsumer = _
+
+  private def getFirst[K, T](buildArray: Array[K], buildObj: K => Option[T]): Option[T] = {
+    var obj: Option[T] = None
+    for (builder <- buildArray if obj.isEmpty) obj = buildObj(builder)
+    obj
+  }
+
+  //广播功能去掉，messageScheduler可以提供这种功能，目前只有entrance有此类方法，后续调整
+
+  private implicit def getReceiver(event: RPCMessageEvent): Option[Receiver] = getFirst[ReceiverChooser, Receiver](receiverChoosers, _.chooseReceiver(event))
+
+  private implicit def getSender(event: RPCMessageEvent): Sender = getFirst[ReceiverSenderBuilder, Sender](receiverSenderBuilders, _.build(event)).get
+
+  private implicit def getMessageRPCConsumer(rpcConsumer: RPCConsumer): MessageRPCConsumer = messageRPCConsumer
+
+  override def registerReceiverChooser(receiverChooser: ReceiverChooser): Unit = {
+    info("register a new ReceiverChooser " + receiverChooser)
+    receiverChoosers = receiverChooser +: receiverChoosers
+  }
+
+  @PostConstruct
+  def init(): Unit = {
+    if (!receiverChoosers.exists(_.isInstanceOf[CommonReceiverChooser]))
+      receiverChoosers = receiverChoosers :+ new CommonReceiverChooser
+    info("init all receiverChoosers in spring beans, list => " + receiverChoosers.toList)
+    if (!receiverSenderBuilders.exists(_.isInstanceOf[CommonReceiverSenderBuilder]))
+      receiverSenderBuilders = receiverSenderBuilders :+ new CommonReceiverSenderBuilder
+    receiverSenderBuilders = receiverSenderBuilders.sortBy(_.order)
+    info("init all receiverSenderBuilders in spring beans, list => " + receiverSenderBuilders.toList)
+  }
+
+  private implicit def toMessage(obj: Any): Message = obj match {
+    case Unit | () =>
+      RPCProduct.getRPCProduct.ok()
+    case _: BoxedUnit => RPCProduct.getRPCProduct.ok()
+    case _ =>
+      RPCProduct.getRPCProduct.toMessage(obj)
+  }
+
+  private implicit def getReq: HttpServletRequest = {
+    RequestContextHolder.getRequestAttributes.asInstanceOf[ServletRequestAttributes].getRequest
+  }
+
+  @Path("receive")
+  @POST
+  override def receive(message: Message): Message = invokeReceiver(message, _.receive(_, _))
+
+  private def invokeReceiver(message: Message, opEvent: (Receiver, Any, Sender) => Message)(implicit req: HttpServletRequest): Message = catchIt {
+    message.getData.put(REQUEST_KEY, req)
+    val obj = RPCConsumer.getRPCConsumer.overrideToObject(message)
+    val serviceInstance = BaseRPCSender.getInstanceInfo(message.getData)
+    val event = RPCMessageEvent(obj, serviceInstance)
+    event.map(opEvent(_, obj, event)).getOrElse(RPCProduct.getRPCProduct.notFound())
+  }
+
+  @Path("receiveAndReply")
+  @POST
+  override def receiveAndReply(message: Message): Message = invokeReceiver(message, _.receiveAndReply(_, _))
+
+  @Path("replyInMills")
+  @POST
+  override def receiveAndReplyInMills(message: Message): Message = catchIt {
+    val duration = message.getData.get("duration")
+    if (duration == null || StringUtils.isEmpty(duration.toString)) throw new DWCURIException(10002, "The timeout period is not set!(超时时间未设置！)")
+    val timeout = Duration(duration.toString.toLong, TimeUnit.MILLISECONDS)
+    invokeReceiver(message, _.receiveAndReply(_, timeout, _))
+  }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageRPCSpringConfiguration.scala
+++ b/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageRPCSpringConfiguration.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.rpc
+
+import com.webank.wedatasphere.linkis.message.context.{MessageSchedulerContext, SpringMessageSchedulerContext}
+import com.webank.wedatasphere.linkis.message.publisher.{AbstractMessagePublisher, DefaultMessagePublisher, MessagePublisher}
+import org.springframework.context.annotation.Bean
+
+/**
+ * @date 2020/8/4
+ *
+ */
+class MessageRPCSpringConfiguration {
+
+  @Bean
+  def getPublisher: AbstractMessagePublisher = {
+    new DefaultMessagePublisher()
+  }
+
+  @Bean
+  def getMessageSchedulerContext(messagePublisher: AbstractMessagePublisher): MessageSchedulerContext = {
+    val context = new SpringMessageSchedulerContext
+    messagePublisher.setContext(context)
+    context.setPublisher(messagePublisher)
+    context
+  }
+
+  @Bean
+  def getReceiverChooser(messagePublisher: MessagePublisher): ReceiverChooser = {
+    new MessageReceiverChooser(Option(new MessageReceiver(messagePublisher)))
+  }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageReceiver.scala
+++ b/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageReceiver.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.rpc
+
+import java.util.concurrent.{TimeUnit, TimeoutException}
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.message.builder.{DefaultServiceMethodContext, MessageJobTimeoutPolicy, ServiceMethodContext}
+import com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf.{SENDER_KEY, _}
+import com.webank.wedatasphere.linkis.message.publisher.MessagePublisher
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+import com.webank.wedatasphere.linkis.server.security.SecurityFilter
+import javax.servlet.http.HttpServletRequest
+
+import scala.concurrent.duration.Duration
+import scala.language.implicitConversions
+
+/**
+ * @date 2020/8/3
+ *
+ */
+class MessageReceiver(mesagePublisher: MessagePublisher) extends Receiver {
+
+  private val syncMaxTimeout: Duration = Duration(CommonVars("wds.linkis.ms.rpc.sync.timeout", 60 * 1000 * 5L).getValue, TimeUnit.MILLISECONDS)
+
+  override def receive(message: Any, sender: Sender): Unit = {
+    mesagePublisher.publish(message, (message, syncMaxTimeout, sender))
+  }
+
+  override def receiveAndReply(message: Any, sender: Sender): Any = {
+    receiveAndReply(message, syncMaxTimeout, sender)
+  }
+
+  override def receiveAndReply(message: Any, duration: Duration, sender: Sender): Any = {
+    val job = mesagePublisher.publish(message, (message, duration, sender))
+    Utils.tryCatch(job.get(duration._1, duration._2)) {
+      case t: TimeoutException =>
+        job.getMethodContext.getAttributeOrDefault(TIMEOUT_POLICY, MessageJobTimeoutPolicy.INTERRUPT) match {
+          case MessageJobTimeoutPolicy.CANCEL => job.cancel(false); throw t
+          case MessageJobTimeoutPolicy.INTERRUPT => job.cancel(true); throw t
+          case MessageJobTimeoutPolicy.PARTIAL => job.getPartial
+        }
+      case i: InterruptedException => job.cancel(true); throw i
+      case t: Throwable => job.cancel(true); throw t
+    }
+  }
+
+  implicit def createMessageMethodScheduler(tunple: (Any, Duration, Sender)): ServiceMethodContext = {
+    val methodContext = new DefaultServiceMethodContext
+    methodContext.putAttribute(SENDER_KEY, tunple._3)
+    methodContext.putAttribute(DURATION_KEY, tunple._2)
+    tunple._1 match {
+      case m: java.util.Map[String, Object] => {
+        val req = m.get(REQUEST_KEY).asInstanceOf[HttpServletRequest]
+        methodContext.putAttribute(REQUEST_KEY, req)
+        methodContext.putAttribute(USER_KEY, SecurityFilter.getLoginUser(req))
+      }
+      case _ =>
+    }
+    methodContext
+  }
+
+  implicit def any2RequestProtocol(message: Any): RequestProtocol = message match {
+    case p: RequestProtocol => p
+    case m: java.util.Map[String, Object] => m.get("_request_protocol_").asInstanceOf[RequestProtocol]
+  }
+
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageReceiverChooser.scala
+++ b/linkis-commons/linkis-message-scheduler/src/main/scala/com/webank/wedatasphere/linkis/rpc/MessageReceiverChooser.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.rpc
+
+import java.util
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+/**
+ * @date 2020/8/3
+ *
+ */
+
+class MessageReceiverChooser(receiver: Option[Receiver]) extends ReceiverChooser {
+
+  override def chooseReceiver(event: RPCMessageEvent): Option[Receiver] = event.message match {
+    case _: util.Map[String, Object] => receiver
+    case _: RequestProtocol => receiver
+    case _ => None
+  }
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/DefaultRequestProtocol.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/DefaultRequestProtocol.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+/**
+ * @date 2020/7/14
+ */
+public class DefaultRequestProtocol implements RequestProtocol {
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/ImplicitInterface.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/ImplicitInterface.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+
+/**
+ * @date 2020/7/22
+ */
+public interface ImplicitInterface {
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/ImplicitInterfaceImpl.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/ImplicitInterfaceImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+/**
+ * @date 2020/7/30
+ */
+public class ImplicitInterfaceImpl implements ImplicitInterface {
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/ImplicitObject.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/ImplicitObject.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+import com.webank.wedatasphere.linkis.message.annotation.Implicit;
+
+/**
+ * @date 2020/7/29
+ */
+public class ImplicitObject {
+
+    @Implicit
+    public ImplicitInterfaceImpl implicitMethod02(DefaultRequestProtocol requestProtocol) {
+        return null;
+    }
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/SchedulerMessageTest.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/SchedulerMessageTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+import com.webank.wedatasphere.linkis.message.annotation.Receiver;
+import com.webank.wedatasphere.linkis.message.builder.MessageJob;
+import com.webank.wedatasphere.linkis.message.conf.MessageSchedulerConf;
+import com.webank.wedatasphere.linkis.message.context.AbstractMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.context.DefaultMessageSchedulerContext;
+import com.webank.wedatasphere.linkis.message.parser.ImplicitMethod;
+import com.webank.wedatasphere.linkis.message.parser.ServiceMethod;
+import com.webank.wedatasphere.linkis.message.registry.AbstractImplicitRegistry;
+import com.webank.wedatasphere.linkis.message.registry.AbstractServiceRegistry;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+import org.junit.Before;
+import org.junit.Test;
+import org.reflections.Reflections;
+import org.reflections.scanners.MethodAnnotationsScanner;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+/**
+ * @date 2020/7/14
+ */
+public class SchedulerMessageTest {
+
+    private AbstractMessageSchedulerContext context;
+
+    Reflections reflections = new Reflections(MessageSchedulerConf.SERVICE_SCAN_PACKAGE, new MethodAnnotationsScanner());
+
+    @Before
+    public void before() {
+
+        context = new DefaultMessageSchedulerContext();
+    }
+
+
+    @Test
+    public void servieParserTest() throws InterruptedException {
+        Map<String, List<ServiceMethod>> parse = context.getservieParser().parse(new TestService());
+        System.out.println(parse.size());
+    }
+
+    @Test
+    public void registryTest() throws InterruptedException {
+        TestService testService = new TestService();
+        context.getServiceRegistry().register(testService);
+        context.getImplicitRegistry().register(testService);
+        System.out.println("serviceRegistry");
+    }
+
+    @Test
+    public void implicitParserTest() throws InterruptedException {
+        Map<String, List<ImplicitMethod>> parse = context.getImplicitParser().parse(new TestService());
+        System.out.println(parse.size());
+    }
+
+    @Test
+    public void springRegisterTest() {
+        Set<Method> methodsAnnotatedWith = reflections.getMethodsAnnotatedWith(Receiver.class);
+        Set<? extends Class<?>> collect = methodsAnnotatedWith.stream().map(Method::getDeclaringClass).collect(Collectors.toSet());
+        System.out.println(collect.size());
+    }
+
+    @Test
+    public void test() {
+        System.out.println(RequestProtocol.class.isAssignableFrom(RequestProtocol.class));
+    }
+
+    @Test
+    public void publishTest() throws InterruptedException, ExecutionException, TimeoutException {
+        TestService testService = new TestService();
+        TestService2 testService2 = new TestService2();
+        AbstractImplicitRegistry implicitRegistry = this.context.getImplicitRegistry();
+        implicitRegistry.register(testService);
+        implicitRegistry.register(testService2);
+        implicitRegistry.register(new ImplicitObject());
+        AbstractServiceRegistry serviceRegistry = this.context.getServiceRegistry();
+        serviceRegistry.register(testService);
+        serviceRegistry.register(testService2);
+        long start = System.currentTimeMillis();
+        MessageJob publish = context.getPublisher().publish(new DefaultRequestProtocol());
+        Object o = publish.get();
+        System.out.println(o);
+
+        System.out.println(System.currentTimeMillis() - start);
+    }
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/TestService.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/TestService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+import com.webank.wedatasphere.linkis.message.annotation.*;
+import com.webank.wedatasphere.linkis.message.builder.ServiceMethodContext;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @date 2020/7/14
+ */
+public class TestService {
+    @Receiver
+    @Order(1)
+    public void method01(ImplicitInterface protocol) throws InterruptedException {
+        Thread.sleep(5000);
+        System.out.println("TestService1.method01");
+    }
+
+    @Receiver
+    public void method02(ServiceMethodContext smc, ImplicitInterface protocol) throws InterruptedException {
+        Thread.sleep(2000);
+        System.out.println("TestService1.method02");
+    }
+
+    @Receiver
+    @Chain("fgf")
+    public void method03(ServiceMethodContext smc, ImplicitInterface protocol) throws InterruptedException {
+        Thread.sleep(3000);
+       System.out.println("TestService1.method03");
+    }
+
+    @Receiver
+    public List<Object> method04( ServiceMethodContext smc, @NotImplicit DefaultRequestProtocol protocol) throws InterruptedException {
+        Thread.sleep(2000);
+        System.out.println("TestService1.method04");
+        return new ArrayList<>();
+    }
+
+    @Implicit
+    public ImplicitInterfaceImpl implicitMethod02(DefaultRequestProtocol requestProtocol) {
+        return null;
+    }
+
+    /**
+     * 测试 转换方法的优先级
+     *
+     * @param protocol
+     * @return
+     */
+    @Implicit
+    public ImplicitInterfaceImpl implicitMetho01(RequestProtocol protocol) {
+        return null;
+    }
+
+
+}

--- a/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/TestService2.java
+++ b/linkis-commons/linkis-message-scheduler/src/test/java/com/webank/wedatasphere/linkis/message/TestService2.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.message;
+
+/**
+ * @date 2020/7/29
+ */
+public class TestService2 {
+
+/*    @Receiver
+    public void method01(@Implicit SubRequestProtocol protocol) throws InterruptedException {
+        System.out.println("TestService2.method01");
+    }*/
+
+
+}


### PR DESCRIPTION
###  What is the purpose of the change
closed #569 
Add the Linkis Message-Scheduler module to enhance the processing capacity of Linkis RPC.

### Brief change log
1. Support synchronously and asynchronously processing message, and the receiver is identified through annotations.

2. When processing messages, support sending messages to other receivers in the meanwhile. For example, after EngineConn is started, AM needs to notify Label to register the label information of EC.

3. Messages are able to be processed by multiple receivers at the same time. For example, ECM registration request needs to register basic information in AM and register resource information in RM.

4. Support multiple receivers to execute in a single chain sequence, and multually transfer intermediate variables. For example, when EngineConn exits, you need to complete RM information logout, label information logout and AM instance information processing in order. 

5. Support multiple receivers to execute in the order of multiple chains.

6. Support skipping receivers, for example, after a receiver has been completed and satisfied the conditions, you can skip the subsequent message receivers.      

7. Support integrating RestFul with Message-scheduler, and thus reducing the development of the repeated logic between RPC and RestFul.         