### PR TITLE
Add a new LinkisManager Common module to collect all commonly used interfaces in LinkisManager.

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/pom.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!-- <relativePath>../../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-manager-common</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-computation-governance-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-label-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-protocol</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+            <version>${json4s.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/constant/AMConstant.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/constant/AMConstant.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.constant;
+
+public class AMConstant {
+
+    public static final String EM_NAME = "engineManager";
+
+    public static final String ENGINE_NAME = "engine";
+
+    public static final int ENGINE_ERROR_CODE = 30001;
+
+    public static final int EM_ERROR_CODE = 30002;
+
+    public static final String PROCESS_MARK = "process";
+
+    public static final String THREAD_MARK = "thread";
+
+    public static final String START_REASON = "start_reason";
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/enumeration/NodeHealthy.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/enumeration/NodeHealthy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.enumeration;
+
+
+public enum NodeHealthy {
+
+    /**
+     * 节点监控状态信息
+     * Healthy：状态正常
+     * UnHealthy： EM自己标识自己为UnHealthy 或者 manager把他标识为UnHealthy 处理引擎状态不正常，manager主动要求所有的engine强制退出（engine自杀）
+     * WARN： 引擎处于告警状态，但是可以接受任务
+     * StockAvailable： 存量可用状态，可以接受任务。当EM状态最近n次心跳没有上报，但是已经启动的Engine还是正常的可以接受任务
+     * StockUnavailable： 存量不可用状态，不可以接受任务。（超过n+1没上报心跳）或者（EM自己判断，但是服务正常的情况），但是如果往上面提交任务会出现error失败情况
+     * EM 处于StockUnavailable时，manager主动要求所有的engine非强制退出，manager需要将 EM标识为UnHealthy。如果StockUnavailable状态如果超过n分钟，则发送IMS告警
+     */
+    Healthy, UnHealthy, WARN, StockAvailable, StockUnavailable;
+
+    public static Boolean isAvailable(NodeHealthy nodeHealthy) {
+        if (Healthy == nodeHealthy || WARN == nodeHealthy || StockAvailable == nodeHealthy) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/enumeration/NodeStatus.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/enumeration/NodeStatus.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.enumeration;
+
+
+public enum NodeStatus {
+
+    /**
+     * em 中管理的engineConn状态: Starting running Failed, Success
+     * <p>
+     * manager中管理的engineConn状态：Starting ShuttingDown Unlock Idle Busy
+     */
+    Starting, ShuttingDown, Failed, Success,
+    Idle, Busy,
+    Locked, Unlock,
+    Running;
+
+    public static Boolean isAvailable(NodeStatus status) {
+        if (Idle == status || Busy == status || Locked == status || Unlock == status || Running == status) {
+            return true;
+        }
+        return false;
+    }
+
+    public static Boolean isLocked(NodeStatus status) {
+        if (Busy == status || Locked == status || Idle == status) {
+            return true;
+        }
+        return false;
+    }
+
+    public static Boolean isIdle(NodeStatus status) {
+        if (Idle == status || Unlock == status) {
+            return true;
+        }
+        return false;
+    }
+
+    public static Boolean isCompleted(NodeStatus status) {
+        if (Success == status || Failed == status || ShuttingDown == status) {
+            return true;
+        }
+        return false;
+    }
+
+    public static NodeStatus toNodeStatus(String status) throws IllegalArgumentException {
+        if (null == status || "".equals(status)) {
+            throw new IllegalArgumentException("Invalid status : " + status + " cannot be matched in NodeStatus");
+        }
+        switch (status) {
+            case "Starting": return NodeStatus.Starting;
+            case "ShuttingDown": return NodeStatus.ShuttingDown;
+            case "Failed": return NodeStatus.Failed;
+            case "Success": return NodeStatus.Success;
+            case "Idle": return NodeStatus.Idle;
+            case "Busy": return NodeStatus.Busy;
+            case "Locked": return NodeStatus.Locked;
+            case "Unlock": return NodeStatus.Unlock;
+            case "Running": return NodeStatus.Running;
+            default:
+                throw new IllegalArgumentException("Invalid status : " + status + " in all values in NodeStatus");
+        }
+    }
+}
+

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/label/LabelKeyValue.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/label/LabelKeyValue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.label;
+
+
+public class LabelKeyValue {
+
+    private String key;
+
+    private String value;
+
+    public LabelKeyValue() {
+
+    }
+
+    public LabelKeyValue(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/AMNodeMetrics.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/AMNodeMetrics.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.metrics;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+import java.util.Date;
+
+
+public class AMNodeMetrics implements NodeMetrics {
+
+    private Integer status;
+
+    private String overLoad;
+
+    private String heartBeatMsg;
+
+    private String healthy;
+
+    private ServiceInstance serviceInstance;
+
+    private Date updateTime;
+
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    @Override
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    @Override
+    public String getOverLoad() {
+        return overLoad;
+    }
+
+    public void setOverLoad(String overLoad) {
+        this.overLoad = overLoad;
+    }
+
+    @Override
+    public String getHeartBeatMsg() {
+        return heartBeatMsg;
+    }
+
+    public void setHeartBeatMsg(String heartBeatMsg) {
+        this.heartBeatMsg = heartBeatMsg;
+    }
+
+    @Override
+    public String getHealthy() {
+        return healthy;
+    }
+
+    @Override
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    @Override
+    public void setHealthy(String healthy) {
+        this.healthy = healthy;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeHealthyInfo.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeHealthyInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.metrics;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeHealthy;
+
+
+public class NodeHealthyInfo {
+
+    private NodeHealthy nodeHealthy;
+
+    private String msg;
+
+    public NodeHealthy getNodeHealthy() {
+        return nodeHealthy;
+    }
+
+    public void setNodeHealthy(NodeHealthy nodeHealthy) {
+        this.nodeHealthy = nodeHealthy;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeMetrics.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.metrics;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+import java.util.Date;
+
+
+public interface NodeMetrics {
+
+    ServiceInstance getServiceInstance();
+
+    Integer getStatus();
+
+    String getOverLoad();
+
+    String getHeartBeatMsg();
+
+    String getHealthy();
+
+    void setHealthy(String healthy);
+
+    Date getUpdateTime();
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeOverLoadInfo.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeOverLoadInfo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.metrics;
+
+
+public class NodeOverLoadInfo {
+
+    private Long maxMemory;
+
+    private Long usedMemory;
+
+    private Float systemCPUUsed;
+
+    private Long systemLeftMemory;
+
+    public Long getMaxMemory() {
+        return maxMemory;
+    }
+
+    public void setMaxMemory(Long maxMemory) {
+        this.maxMemory = maxMemory;
+    }
+
+    public Long getUsedMemory() {
+        return usedMemory;
+    }
+
+    public void setUsedMemory(Long usedMemory) {
+        this.usedMemory = usedMemory;
+    }
+
+    public Float getSystemCPUUsed() {
+        return systemCPUUsed;
+    }
+
+    public void setSystemCPUUsed(Float systemCPUUsed) {
+        this.systemCPUUsed = systemCPUUsed;
+    }
+
+    public Long getSystemLeftMemory() {
+        return systemLeftMemory;
+    }
+
+    public void setSystemLeftMemory(Long systemLeftMemory) {
+        this.systemLeftMemory = systemLeftMemory;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeTaskInfo.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/metrics/NodeTaskInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.metrics;
+
+
+public class NodeTaskInfo {
+
+    private int runningTasks;
+
+    private int pendingTasks;
+
+    private int succeedTasks;
+
+    private int failedTasks;
+
+    public int getTasks() {
+        return runningTasks + pendingTasks;
+    }
+
+    public int getRunningTasks() {
+        return runningTasks;
+    }
+
+    public void setRunningTasks(int runningTasks) {
+        this.runningTasks = runningTasks;
+    }
+
+    public int getPendingTasks() {
+        return pendingTasks;
+    }
+
+    public void setPendingTasks(int pendingTasks) {
+        this.pendingTasks = pendingTasks;
+    }
+
+    public int getSucceedTasks() {
+        return succeedTasks;
+    }
+
+    public void setSucceedTasks(int succeedTasks) {
+        this.succeedTasks = succeedTasks;
+    }
+
+    public int getFailedTasks() {
+        return failedTasks;
+    }
+
+    public void setFailedTasks(int failedTasks) {
+        this.failedTasks = failedTasks;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/AMEMNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/AMEMNode.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeHealthyInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeTaskInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.Date;
+import java.util.List;
+
+
+public class AMEMNode implements EMNode, ScoreServiceInstance {
+
+    private List<Label> labels;
+
+    private double score;
+
+    private ServiceInstance serviceInstance;
+
+    private NodeStatus nodeStatus;
+
+    private NodeResource nodeResource;
+
+    private String owner;
+
+    private String mark;
+
+    private NodeTaskInfo nodeTaskInfo;
+
+    private NodeOverLoadInfo nodeOverLoadInfo;
+
+    private NodeHealthyInfo nodeHealthyInfo;
+
+    private Date startTime;
+
+    public AMEMNode() {
+
+    }
+
+    public AMEMNode(double score, ServiceInstance serviceInstance) {
+        this.score = score;
+        this.serviceInstance = serviceInstance;
+    }
+
+    @Override
+    public List<Label> getLabels() {
+        return this.labels;
+    }
+
+    @Override
+    public void setLabels(List<Label> labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public double getScore() {
+        return this.score;
+    }
+
+    @Override
+    public void setScore(double score) {
+        this.score = score;
+    }
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return this.serviceInstance;
+    }
+
+    @Override
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+
+    @Override
+    public NodeStatus getNodeStatus() {
+        return this.nodeStatus;
+    }
+
+    @Override
+    public void setNodeStatus(NodeStatus status) {
+        this.nodeStatus = status;
+    }
+
+    @Override
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public String getMark() {
+        return mark;
+    }
+
+    public void setMark(String mark) {
+        this.mark = mark;
+    }
+
+    @Override
+    public NodeResource getNodeResource() {
+        return nodeResource;
+    }
+
+    @Override
+    public void setNodeResource(NodeResource nodeResource) {
+        this.nodeResource = nodeResource;
+    }
+
+    @Override
+    public NodeTaskInfo getNodeTaskInfo() {
+        return nodeTaskInfo;
+    }
+
+    @Override
+    public void setNodeTaskInfo(NodeTaskInfo nodeTaskInfo) {
+        this.nodeTaskInfo = nodeTaskInfo;
+    }
+
+    @Override
+    public void setNodeOverLoadInfo(NodeOverLoadInfo nodeOverLoadInfo) {
+        this.nodeOverLoadInfo = nodeOverLoadInfo;
+    }
+
+    @Override
+    public NodeOverLoadInfo getNodeOverLoadInfo() {
+        return nodeOverLoadInfo;
+    }
+
+    @Override
+    public NodeHealthyInfo getNodeHealthyInfo() {
+        return nodeHealthyInfo;
+    }
+
+    @Override
+    public void setNodeHealthyInfo(NodeHealthyInfo nodeHealthyInfo) {
+        this.nodeHealthyInfo = nodeHealthyInfo;
+    }
+
+    @Override
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    @Override
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/AMEngineNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/AMEngineNode.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeHealthyInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeTaskInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+
+public class AMEngineNode implements EngineNode, ScoreServiceInstance {
+
+
+
+    private EMNode emNode;
+
+    private NodeStatus nodeStatus;
+
+    private String lock;
+
+    private List<Label> labels;
+
+    private double score;
+
+    private ServiceInstance serviceInstance;
+
+    private NodeResource nodeResource;
+
+    private String owner;
+
+    private String mark;
+
+    private NodeTaskInfo nodeTaskInfo;
+
+    private NodeOverLoadInfo nodeOverLoadInfo;
+
+    private NodeHealthyInfo nodeHealthyInfo;
+
+    private Date startTime;
+
+    public AMEngineNode() {
+
+    }
+
+    public AMEngineNode(double score, ServiceInstance serviceInstance) {
+        this.score = score;
+        this.serviceInstance = serviceInstance;
+    }
+
+    public AMEngineNode(double score, ServiceInstance serviceInstance, List<Label> labels) {
+        this(score, serviceInstance);
+        this.labels = labels;
+    }
+
+    @Override
+    public NodeTaskInfo getNodeTaskInfo() {
+        return this.nodeTaskInfo;
+    }
+
+    @Override
+    public void setNodeTaskInfo(NodeTaskInfo nodeTaskInfo) {
+        this.nodeTaskInfo = nodeTaskInfo;
+    }
+
+    @Override
+    public void setNodeOverLoadInfo(NodeOverLoadInfo nodeOverLoadInfo) {
+        this.nodeOverLoadInfo = nodeOverLoadInfo;
+    }
+
+    @Override
+    public NodeOverLoadInfo getNodeOverLoadInfo() {
+        return nodeOverLoadInfo;
+    }
+
+    @Override
+    public NodeHealthyInfo getNodeHealthyInfo() {
+        return nodeHealthyInfo;
+    }
+
+    @Override
+    public void setNodeHealthyInfo(NodeHealthyInfo nodeHealthyInfo) {
+        this.nodeHealthyInfo = nodeHealthyInfo;
+    }
+
+  /*  public EMNode getEmNode() {
+        return emNode;
+    }
+
+    public void setEmNode(EMNode emNode) {
+        this.emNode = emNode;
+    }*/
+
+    @Override
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public String getMark() {
+        return mark;
+    }
+
+    public void setMark(String mark) {
+        this.mark = mark;
+    }
+
+    @Override
+    public EMNode getEMNode() {
+        return this.emNode;
+    }
+
+    @Override
+    public void setEMNode(EMNode emNode) {
+        this.emNode = emNode;
+    }
+
+
+    @Override
+    public List<Label> getLabels() {
+        return this.labels;
+    }
+
+    @Override
+    public void setLabels(List<Label> labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public double getScore() {
+        return this.score;
+    }
+
+    @Override
+    public void setScore(double score) {
+        this.score = score;
+    }
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return this.serviceInstance;
+    }
+
+    @Override
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    @Override
+    public NodeStatus getNodeStatus() {
+        return this.nodeStatus;
+    }
+
+    @Override
+    public void setNodeStatus(NodeStatus status) {
+        this.nodeStatus = status;
+    }
+
+    @Override
+    public String getLock() {
+        return this.lock;
+    }
+
+    @Override
+    public void setLock(String lock) {
+        this.lock = lock;
+    }
+
+    @Override
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    @Override
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AMEngineNode that = (AMEngineNode) o;
+        return Objects.equals(serviceInstance, that.serviceInstance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serviceInstance);
+    }
+
+    @Override
+    public NodeResource getNodeResource() {
+        return nodeResource;
+    }
+
+    @Override
+    public void setNodeResource(NodeResource nodeResource) {
+        this.nodeResource = nodeResource;
+    }
+
+    @Override
+    public String toString() {
+        return "AMEngineNode{" +
+                "nodeStatus=" + nodeStatus +
+                ", lock='" + lock + '\'' +
+                ", serviceInstance=" + serviceInstance +
+                ", owner='" + owner + '\'' +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/AMNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/AMNode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeHealthyInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeTaskInfo;
+
+import java.util.Date;
+
+
+public interface AMNode extends Node {
+
+    NodeTaskInfo getNodeTaskInfo();
+
+    void setNodeTaskInfo(NodeTaskInfo nodeTaskInfo);
+
+    void setNodeOverLoadInfo(NodeOverLoadInfo nodeOverLoadInfo);
+
+    NodeOverLoadInfo getNodeOverLoadInfo();
+
+    NodeHealthyInfo getNodeHealthyInfo();
+
+    void setNodeHealthyInfo(NodeHealthyInfo nodeHealthyInfo);
+
+    Date getStartTime();
+
+    void setStartTime(Date startTime);
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/DefaultScoreServiceInstance.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/DefaultScoreServiceInstance.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public class DefaultScoreServiceInstance implements ScoreServiceInstance {
+
+    private double score;
+
+    private ServiceInstance serviceInstance;
+
+    @Override
+    public double getScore() {
+        return this.score;
+    }
+
+    @Override
+    public void setScore(double score) {
+        this.score = score;
+    }
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return this.serviceInstance;
+    }
+
+    @Override
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/EMNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/EMNode.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+
+public interface EMNode extends AMNode, RMNode, LabelNode {
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/EngineNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/EngineNode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+
+public interface EngineNode extends AMNode, RMNode, LabelNode {
+
+    EMNode getEMNode();
+
+    void setEMNode(EMNode emNode);
+
+
+    String getLock();
+
+    void setLock(String lock);
+
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/InfoRMNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/InfoRMNode.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource;
+
+public class InfoRMNode implements RMNode {
+
+    private ServiceInstance serviceInstance;
+
+    private NodeResource nodeResource;
+
+    private String owner;
+
+    private String mark;
+
+    private NodeStatus nodeStatus;
+
+
+    @Override
+    public NodeResource getNodeResource() {
+        return nodeResource;
+    }
+
+    @Override
+    public void setNodeResource(NodeResource nodeResource) {
+        this.nodeResource = nodeResource;
+    }
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    @Override
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    @Override
+    public NodeStatus getNodeStatus() {
+        return nodeStatus;
+    }
+
+    @Override
+    public void setNodeStatus(NodeStatus status) {
+        this.nodeStatus = status;
+    }
+
+    @Override
+    public String getOwner() {
+        return owner;
+    }
+
+    @Override
+    public String getMark() {
+        return mark;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/LabelNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/LabelNode.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+
+import java.util.List;
+
+
+public interface LabelNode extends Node{
+
+    List<Label> getLabels();
+
+    void setLabels(List<Label> labels);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/Node.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/Node.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+public interface Node extends RequestProtocol {
+
+
+    ServiceInstance getServiceInstance();
+
+    void setServiceInstance(ServiceInstance serviceInstance);
+
+
+    NodeStatus getNodeStatus();
+
+    void setNodeStatus(NodeStatus status);
+
+    String getOwner();
+
+    String getMark();
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/RMNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/RMNode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource;
+
+
+public interface RMNode extends Node {
+
+    NodeResource getNodeResource();
+
+    void setNodeResource(NodeResource nodeResource);
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/ScoreServiceInstance.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/node/ScoreServiceInstance.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.node;
+
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public interface ScoreServiceInstance  {
+
+
+    double getScore() ;
+
+    void setScore(double score);
+
+    ServiceInstance getServiceInstance();
+
+    void setServiceInstance(ServiceInstance serviceInstance);
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceLabel.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceLabel.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import com.webank.wedatasphere.linkis.manager.label.entity.GenericLabel;
+import com.webank.wedatasphere.linkis.manager.label.utils.LabelUtils;
+
+import java.util.Date;
+
+
+public class PersistenceLabel extends GenericLabel {
+    private int id;
+    private int labelValueSize;
+
+    private Date updateTime;
+    private Date createTime;
+    private String updator;
+    private String creator;
+    private String stringValue;
+
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public int getLabelValueSize() {
+        return labelValueSize;
+    }
+
+    public void setLabelValueSize(int labelValueSize) {
+        this.labelValueSize = labelValueSize;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public String getUpdator() {
+        return updator;
+    }
+
+    public void setUpdator(String updator) {
+        this.updator = updator;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    public String getStringValue() {
+        return this.stringValue == null ? LabelUtils.Jackson.toJson(value, null) : this.stringValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        PersistenceLabel that = (PersistenceLabel) o;
+
+        if (!this.getLabelKey().equals(that.getLabelKey())) return false;
+        return stringValue.equals(that.stringValue);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.getLabelKey().hashCode();
+        result = 31 * result + this.stringValue.hashCode();
+        return result;
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceLock.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceLock.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import java.util.Date;
+
+
+public class PersistenceLock {
+    private int id;
+    private String lockObject;
+    private Long timeOut;
+
+    private Date updateTime;
+    private Date createTime;
+    private String updator;
+    private String creator;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getLockObject() {
+        return lockObject;
+    }
+
+    public void setLockObject(String lockObject) {
+        this.lockObject = lockObject;
+    }
+
+    public Long getTimeOut() {
+        return timeOut;
+    }
+
+    public void setTimeOut(Long timeOut) {
+        this.timeOut = timeOut;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public String getUpdator() {
+        return updator;
+    }
+
+    public void setUpdator(String updator) {
+        this.updator = updator;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNode.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import java.util.Date;
+
+
+public class PersistenceNode {
+    private int id;
+    private String instance;
+    private String name;
+    private String owner;
+
+    private String mark;
+
+    private Date updateTime;
+    private Date createTime;
+    private String updator;
+    private String creator;
+
+    public String getMark() {
+        return mark;
+    }
+
+    public void setMark(String mark) {
+        this.mark = mark;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public String getUpdator() {
+        return updator;
+    }
+
+    public void setUpdator(String updator) {
+        this.updator = updator;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNodeEntity.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNodeEntity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node;
+
+import java.util.Date;
+
+
+public class PersistenceNodeEntity implements Node {
+
+    private ServiceInstance serviceInstance;
+    private String owner;
+    private String mark;
+    private NodeStatus nodeStatus;
+
+    private Date startTime;
+
+    public Date getStartTime() {
+        return startTime;
+    }
+
+
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
+    }
+
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return this.serviceInstance;
+    }
+
+    @Override
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    @Override
+    public NodeStatus getNodeStatus() {
+        return this.nodeStatus;
+    }
+
+    @Override
+    public void setNodeStatus(NodeStatus status) {
+        this.nodeStatus = status;
+    }
+
+    @Override
+    public String getOwner() {
+        return this.owner;
+    }
+
+    public void setMark(String mark) {
+        this.mark = mark;
+    }
+
+    @Override
+    public String getMark() {
+        return this.mark;
+    }
+
+    public void setOwner(String owner){
+        this.owner = owner;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNodeMetrics.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNodeMetrics.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeMetrics;
+
+import java.util.Date;
+
+
+public class PersistenceNodeMetrics implements NodeMetrics {
+
+    private String  instance;
+
+    private int status;
+    private String overLoad;
+    private String heartBeatMsg;
+    private String healthy;
+
+    private Date updateTime;
+    private Date createTime;
+
+
+    private ServiceInstance serviceInstance;
+
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+
+    @Override
+    public ServiceInstance getServiceInstance() {
+        return this.serviceInstance;
+    }
+
+    @Override
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    @Override
+    public String getOverLoad() {
+        return overLoad;
+    }
+
+    public void setOverLoad(String overLoad) {
+        this.overLoad = overLoad;
+    }
+
+    @Override
+    public String getHeartBeatMsg() {
+        return heartBeatMsg;
+    }
+
+    public void setHeartBeatMsg(String heartBeatMsg) {
+        this.heartBeatMsg = heartBeatMsg;
+    }
+
+    @Override
+    public String getHealthy() {
+        return healthy;
+    }
+
+    @Override
+    public void setHealthy(String healthy) {
+        this.healthy = healthy;
+    }
+
+    @Override
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNodeMetricsEntity.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceNodeMetricsEntity.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import java.util.Date;
+
+
+public class PersistenceNodeMetricsEntity {
+    private String  instance;
+    private String  name;
+
+    private int status;
+    private String overLoad;
+    private String heartBeatMsg;
+    private String healthy;
+    private Date updateTime;
+    private Date createTime;
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public String getOverLoad() {
+        return overLoad;
+    }
+
+    public void setOverLoad(String overLoad) {
+        this.overLoad = overLoad;
+    }
+
+    public String getHeartBeatMsg() {
+        return heartBeatMsg;
+    }
+
+    public void setHeartBeatMsg(String heartBeatMsg) {
+        this.heartBeatMsg = heartBeatMsg;
+    }
+
+    public String getHealthy() {
+        return healthy;
+    }
+
+    public void setHealthy(String healthy) {
+        this.healthy = healthy;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/persistence/PersistenceResource.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.persistence;
+
+import java.util.Date;
+
+
+public class PersistenceResource {
+    private int id;
+    private String maxResource;
+    private String minResource;
+    private String usedResource;
+    private String leftResource;
+    private String expectedResource;
+    private String lockedResource;
+
+    private String resourceType;
+
+    public String getTicketId() {
+        return ticketId;
+    }
+
+    public void setTicketId(String ticketId) {
+        this.ticketId = ticketId;
+    }
+
+    private String ticketId;
+
+    private Date updateTime;
+    private Date createTime;
+    private String updator;
+    private String creator;
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+
+
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getMaxResource() {
+        return maxResource;
+    }
+
+    public void setMaxResource(String maxResource) {
+        this.maxResource = maxResource;
+    }
+
+    public String getMinResource() {
+        return minResource;
+    }
+
+    public void setMinResource(String minResource) {
+        this.minResource = minResource;
+    }
+
+    public String getUsedResource() {
+        return usedResource;
+    }
+
+    public void setUsedResource(String usedResource) {
+        this.usedResource = usedResource;
+    }
+
+    public String getLeftResource() {
+        return leftResource;
+    }
+
+    public void setLeftResource(String leftResource) {
+        this.leftResource = leftResource;
+    }
+
+    public String getExpectedResource() {
+        return expectedResource;
+    }
+
+    public void setExpectedResource(String expectedResource) {
+        this.expectedResource = expectedResource;
+    }
+
+    public String getLockedResource() {
+        return lockedResource;
+    }
+
+    public void setLockedResource(String lockedResource) {
+        this.lockedResource = lockedResource;
+    }
+
+    public Date getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Date updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public String getUpdator() {
+        return updator;
+    }
+
+    public void setUpdator(String updator) {
+        this.updator = updator;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/resource/CommonNodeResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/resource/CommonNodeResource.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.resource;
+
+public class CommonNodeResource implements NodeResource {
+
+    private ResourceType resourceType;
+
+    private Resource maxResource;
+
+    private Resource minResource;
+
+    private Resource usedResource;
+
+    private Resource lockedResource;
+
+    private Resource expectedResource;
+
+    private Resource leftResource;
+
+    public static NodeResource initNodeResource(ResourceType resourceType){
+        CommonNodeResource commonNodeResource = new CommonNodeResource();
+        commonNodeResource.setResourceType(resourceType);
+        Resource zeroResource = Resource.initResource(resourceType);
+        commonNodeResource.setMaxResource(zeroResource);
+        commonNodeResource.setMinResource(zeroResource);
+        commonNodeResource.setUsedResource(zeroResource);
+        commonNodeResource.setLockedResource(zeroResource);
+        commonNodeResource.setExpectedResource(zeroResource);
+        commonNodeResource.setLeftResource(zeroResource);
+        return commonNodeResource;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+    @Override
+    public void setResourceType(ResourceType resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    @Override
+    public Resource getMaxResource() {
+        return maxResource;
+    }
+
+    @Override
+    public void setMaxResource(Resource maxResource) {
+        this.maxResource = maxResource;
+    }
+
+    @Override
+    public Resource getMinResource() {
+        return minResource;
+    }
+
+    @Override
+    public void setMinResource(Resource minResource) {
+        this.minResource = minResource;
+    }
+
+    @Override
+    public Resource getUsedResource() {
+        return usedResource;
+    }
+
+    @Override
+    public void setUsedResource(Resource usedResource) {
+        this.usedResource = usedResource;
+    }
+
+    @Override
+    public Resource getLockedResource() {
+        return lockedResource;
+    }
+
+    @Override
+    public void setLockedResource(Resource lockedResource) {
+        this.lockedResource = lockedResource;
+    }
+
+    @Override
+    public Resource getExpectedResource() {
+        return expectedResource;
+    }
+
+    @Override
+    public void setExpectedResource(Resource expectedResource) {
+        this.expectedResource = expectedResource;
+    }
+
+    @Override
+    public Resource getLeftResource() {
+        if(this.leftResource == null && getMaxResource() != null && getUsedResource() != null) {
+            return getMaxResource().minus(getUsedResource());
+        } else {
+            return this.leftResource;
+        }
+    }
+
+    @Override
+    public void setLeftResource(Resource leftResource) {
+        this.leftResource = leftResource;
+    }
+
+    @Override
+    public String toString() {
+        return "CommonNodeResource{" +
+                "resourceType=" + resourceType +
+                ", maxResource=" + maxResource +
+                ", minResource=" + minResource +
+                ", usedResource=" + usedResource +
+                ", lockedResource=" + lockedResource +
+                ", expectedResource=" + expectedResource +
+                ", leftResource=" + leftResource +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/resource/NodeResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/resource/NodeResource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.resource;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+import java.io.Serializable;
+
+
+public interface NodeResource extends Serializable, RequestProtocol {
+
+    ResourceType getResourceType();
+
+    void setResourceType(ResourceType resourceType);
+
+    void setMinResource(Resource minResource);
+
+    Resource getMinResource();
+
+    void setMaxResource(Resource maxResource);
+
+    Resource getMaxResource();
+
+    void setUsedResource(Resource usedResource);
+
+    Resource getUsedResource();
+
+    void setLockedResource(Resource lockedResource);
+
+    Resource getLockedResource();
+
+    void setExpectedResource(Resource expectedResource);
+
+    Resource getExpectedResource();
+
+    void setLeftResource(Resource leftResource);
+
+    Resource
+    getLeftResource();
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/resource/ResourceType.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/entity/resource/ResourceType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.resource;
+
+public enum ResourceType {
+    Default, Memory, CPU, Load, Instance, LoadInstance, Yarn, DriverAndYarn, Special
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/exception/ResourceWarnException.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/exception/ResourceWarnException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.WarnException;
+
+public class ResourceWarnException  extends WarnException {
+    public ResourceWarnException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public ResourceWarnException(int errCode, String desc, String ip, int port, String serviceKind) {
+        super(errCode, desc, ip, port, serviceKind);
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/bml/BmlResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/bml/BmlResource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.bml;
+
+
+import java.io.Serializable;
+
+ public class BmlResource implements Serializable {
+    private String fileName;
+    private String resourceId;
+    private String version;
+    private BmlResourceVisibility visibility;
+    private String visibleLabels;
+    private String owner;
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+     public BmlResourceVisibility getVisibility() {
+         return visibility;
+     }
+
+     public void setVisibility(BmlResourceVisibility visibility) {
+         this.visibility = visibility;
+     }
+
+     public String getVisibleLabels() {
+         return visibleLabels;
+     }
+
+     public void setVisibleLabels(String visibleLabels) {
+         this.visibleLabels = visibleLabels;
+     }
+
+     public String getOwner() {
+         return owner;
+     }
+
+     public void setOwner(String owner) {
+         this.owner = owner;
+     }
+
+     public static enum BmlResourceVisibility {
+        Public, Private, Label
+    }
+
+/*    @Override
+    public String toString() {
+        return "{" +
+                "fileName='" + fileName + '\'' +
+                ", resourceId='" + resourceId + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }*/
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/bml/LocalResource.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/bml/LocalResource.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.bml
+
+import java.util.Date
+
+
+trait LocalResource extends BmlResource {
+
+  def setIsPublicPath(isPublicPath:Boolean):Unit
+
+  def getIsPublicPath:Boolean
+
+  def setPath(path:String):Unit
+
+  def getPath:String
+
+  def setDownloadTime(date:Date):Unit
+
+  def getDownloadTime:Date
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/EMInfoClearRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/EMInfoClearRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EMNode;
+
+
+public class EMInfoClearRequest implements EMRequest {
+
+    private String user;
+
+    private EMNode em;
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public EMNode getEm() {
+        return em;
+    }
+
+    public void setEm(EMNode em) {
+        this.em = em;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/EMRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/EMRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+public interface EMRequest extends RequestProtocol {
+    String getUser();
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/GetEMEnginesRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/GetEMEnginesRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public class GetEMEnginesRequest implements EMRequest {
+
+    private String user;
+
+    private ServiceInstance em;
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public ServiceInstance getEm() {
+        return em;
+    }
+
+    public void setEm(ServiceInstance em) {
+        this.em = em;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/GetEMInfoRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/GetEMInfoRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public class GetEMInfoRequest implements EMRequest {
+
+    private String user;
+
+    private ServiceInstance em;
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public ServiceInstance getEm() {
+        return em;
+    }
+
+    public void setEm(ServiceInstance em) {
+        this.em = em;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/PauseEMRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/PauseEMRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public class PauseEMRequest implements EMRequest {
+
+    private String user;
+
+    private ServiceInstance em;
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public ServiceInstance getEm() {
+        return em;
+    }
+
+    public void setEm(ServiceInstance em) {
+        this.em = em;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/StopEMRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/em/StopEMRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public class StopEMRequest implements EMRequest {
+
+    private String user;
+
+    private ServiceInstance em;
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public ServiceInstance getEm() {
+        return em;
+    }
+
+    public void setEm(ServiceInstance em) {
+        this.em = em;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineAskRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineAskRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestMethod;
+
+import java.util.Map;
+
+
+public class EngineAskRequest implements EngineRequest, RequestMethod {
+
+    private Map<String, String> properties;
+
+    private Map<String, Object> labels;
+
+    private long timeOut;
+
+    private String user;
+
+    private String createService;
+
+    private String description;
+
+    public long getTimeOut() {
+        return timeOut;
+    }
+
+    public void setTimeOut(long timeOut) {
+        this.timeOut = timeOut;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, Object> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, Object> labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getCreateService() {
+        return createService;
+    }
+
+    public void setCreateService(String createService) {
+        this.createService = createService;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String method() {
+        return "/engine/ask";
+    }
+
+    @Override
+    public String toString() {
+        return "EngineAskRequest{" +
+                "labels=" + labels +
+                ", timeOut=" + timeOut +
+                ", user='" + user + '\'' +
+                ", createService='" + createService + '\'' +
+                ", description='" + description + '\'' +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineConnReleaseRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineConnReleaseRequest.java
@@ -18,10 +18,7 @@ package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
 
 import com.webank.wedatasphere.linkis.common.ServiceInstance;
 
-/**
- * @author peacewong
- * @date 2020/9/14 19:27
- */
+
 public class EngineConnReleaseRequest implements EngineRequest {
 
 

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineConnReleaseRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineConnReleaseRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+/**
+ * @author peacewong
+ * @date 2020/9/14 19:27
+ */
+public class EngineConnReleaseRequest implements EngineRequest {
+
+
+    private ServiceInstance serviceInstance;
+
+    private String user;
+
+    private String msg;
+
+    public String getTicketId() {
+        return ticketId;
+    }
+
+    public void setTicketId(String ticketId) {
+        this.ticketId = ticketId;
+    }
+
+    private String ticketId;
+
+    public EngineConnReleaseRequest() {
+
+    }
+
+    public EngineConnReleaseRequest(ServiceInstance serviceInstance, String user, String msg, String ticketId) {
+        this.serviceInstance = serviceInstance;
+        this.user = user;
+        this.msg = msg;
+        this.ticketId = ticketId;
+    }
+
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineCreateRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineCreateRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestMethod;
+
+import java.util.Map;
+
+
+public class EngineCreateRequest implements EngineRequest, RequestMethod {
+
+    private Map<String, String> properties;
+
+    private Map<String, Object> labels;
+
+    private long timeOut;
+
+    private String user;
+
+    private String createService;
+
+    private String description;
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, Object> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, Object> labels) {
+        this.labels = labels;
+    }
+
+    public long getTimeOut() {
+        return timeOut;
+    }
+
+    public void setTimeOut(long timeOut) {
+        this.timeOut = timeOut;
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getCreateService() {
+        return createService;
+    }
+
+    public void setCreateService(String createService) {
+        this.createService = createService;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String method() {
+        return "/engine/create";
+    }
+
+    @Override
+    public String toString() {
+        return "EngineCreateRequest{" +
+                "labels=" + labels +
+                ", timeOut=" + timeOut +
+                ", user='" + user + '\'' +
+                ", createService='" + createService + '\'' +
+                ", description='" + description + '\'' +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineInfoClearRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineInfoClearRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode;
+
+
+public class EngineInfoClearRequest implements EngineRequest {
+
+
+    private EngineNode engineNode;
+
+    private String user;
+
+    public EngineInfoClearRequest() {
+
+    }
+
+    public EngineNode getEngineNode() {
+        return engineNode;
+    }
+
+    public void setEngineNode(EngineNode engineNode) {
+        this.engineNode = engineNode;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineLockType.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineLockType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+
+public enum EngineLockType {
+
+    /**
+     * Always - 除非主动释放，否则不释放
+     * Once - 加锁后访问一次便释放，且超时也会释放
+     * Timed - 加锁后，超时或主动释放都会释放
+     */
+    Always,
+    Once,
+    Timed
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineRecyclingRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineRecyclingRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.recycle.RecyclingRule;
+
+import java.util.List;
+
+
+public class EngineRecyclingRequest implements EngineRequest {
+
+    private String user;
+
+    private List<RecyclingRule> recyclingRuleList;
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public List<RecyclingRule> getRecyclingRuleList() {
+        return recyclingRuleList;
+    }
+
+    public void setRecyclingRuleList(List<RecyclingRule> recyclingRuleList) {
+        this.recyclingRuleList = recyclingRuleList;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+public interface EngineRequest extends RequestProtocol {
+    String getUser();
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineReuseRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineReuseRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import java.util.Map;
+
+
+public class EngineReuseRequest implements EngineRequest {
+
+    private Map<String, Object> labels;
+
+    private long timeOut;
+
+    private int reuseCount;
+
+    private String user;
+
+    public Map<String, Object> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, Object> labels) {
+        this.labels = labels;
+    }
+
+    public long getTimeOut() {
+        return timeOut;
+    }
+
+    public void setTimeOut(long timeOut) {
+        this.timeOut = timeOut;
+    }
+
+    public int getReuseCount() {
+        return reuseCount;
+    }
+
+    public void setReuseCount(int reuseCount) {
+        this.reuseCount = reuseCount;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public String toString() {
+        return "EngineReuseRequest{" +
+                "timeOut=" + timeOut +
+                ", reuseCount=" + reuseCount +
+                ", user='" + user + '\'' +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineStopRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineStopRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.protocol.message.RequestMethod;
+
+
+public class EngineStopRequest implements EngineRequest, RequestMethod {
+
+    private ServiceInstance serviceInstance;
+
+    private String user;
+
+    public EngineStopRequest() {
+
+    }
+
+    public EngineStopRequest(ServiceInstance serviceInstance, String user) {
+        this.serviceInstance = serviceInstance;
+        this.user = user;
+    }
+
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+
+    @Override
+    public String method() {
+        return "/engine/stop";
+    }
+
+    @Override
+    public String toString() {
+        return "EngineStopRequest{" +
+                "serviceInstance=" + serviceInstance +
+                ", user='" + user + '\'' +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineStopResponse.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineStopResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+
+public class EngineStopResponse {
+
+    public EngineStopResponse() {}
+
+    public EngineStopResponse(boolean stopStatus, String msg) {
+        this.stopStatus = stopStatus;
+        this.msg = msg;
+    }
+
+    private boolean stopStatus;
+    private String msg;
+
+    public boolean getStopStatus() {
+        return stopStatus;
+    }
+
+    public void setStopStatus(boolean status) {
+        this.stopStatus = status;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineSuicideRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineSuicideRequest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+
+
+public class EngineSuicideRequest implements EngineRequest {
+
+    private ServiceInstance serviceInstance;
+
+    private String user;
+
+    public EngineSuicideRequest() {
+
+    }
+
+    public EngineSuicideRequest(ServiceInstance serviceInstance, String user) {
+        this.serviceInstance = serviceInstance;
+        this.user = user;
+    }
+
+
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    public void setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+
+    @Override
+    public String toString() {
+        return "EngineSuicideRequest{" +
+                "serviceInstance=" + serviceInstance +
+                ", user='" + user + '\'' +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineSwitchRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineSwitchRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine;
+
+
+public class EngineSwitchRequest implements EngineRequest {
+    @Override
+    public String getUser() {
+        return null;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/HeartbeatProtocol.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/HeartbeatProtocol.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+public interface HeartbeatProtocol extends RequestProtocol {
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeHeartbeatMsg.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeHeartbeatMsg.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance;
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeHealthyInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics.NodeOverLoadInfo;
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource;
+import com.webank.wedatasphere.linkis.protocol.AbstractRetryableProtocol;
+
+
+public class NodeHeartbeatMsg extends AbstractRetryableProtocol implements HeartbeatProtocol {
+
+    private NodeStatus status;
+
+    private NodeHealthyInfo healthyInfo;
+
+    private String heartBeatMsg;
+
+    private NodeOverLoadInfo overLoadInfo;
+
+    private ServiceInstance serviceInstance;
+
+    private NodeResource nodeResource;
+
+    public NodeStatus getStatus() {
+        return status;
+    }
+
+    public NodeHeartbeatMsg setStatus(NodeStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public NodeHealthyInfo getHealthyInfo() {
+        return healthyInfo;
+    }
+
+    public NodeHeartbeatMsg setHealthyInfo(NodeHealthyInfo healthyInfo) {
+        this.healthyInfo = healthyInfo;
+        return this;
+    }
+
+    public String getHeartBeatMsg() {
+        return heartBeatMsg;
+    }
+
+    public NodeHeartbeatMsg setHeartBeatMsg(String heartBeatMsg) {
+        this.heartBeatMsg = heartBeatMsg;
+        return this;
+    }
+
+    public NodeOverLoadInfo getOverLoadInfo() {
+        return overLoadInfo;
+    }
+
+    public NodeHeartbeatMsg setOverLoadInfo(NodeOverLoadInfo overLoadInfo) {
+        this.overLoadInfo = overLoadInfo;
+        return this;
+    }
+
+    public ServiceInstance getServiceInstance() {
+        return serviceInstance;
+    }
+
+    public NodeHeartbeatMsg setServiceInstance(ServiceInstance serviceInstance) {
+        this.serviceInstance = serviceInstance;
+        return this;
+    }
+
+    public NodeResource getNodeResource() {
+        return nodeResource;
+    }
+
+    public NodeHeartbeatMsg setNodeResource(NodeResource nodeResource) {
+        this.nodeResource = nodeResource;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeHeartbeatMsg{" +
+                "status=" + status +
+                ", serviceInstance=" + serviceInstance +
+                '}';
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeHeartbeatRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeHeartbeatRequest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+
+public class NodeHeartbeatRequest implements HeartbeatProtocol {
+    private String name = "NodeHeartbeatRequest";
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeRequestProtocol.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeRequestProtocol.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+public interface NodeRequestProtocol extends RequestProtocol {
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeStatusProtocol.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/NodeStatusProtocol.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol;
+
+
+public interface NodeStatusProtocol extends RequestProtocol {
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/RequestNodeStatus.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/RequestNodeStatus.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+
+public class RequestNodeStatus implements NodeStatusProtocol {
+    private String name = "RequestNodeStatus";
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/ResponseNodeStatus.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/ResponseNodeStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus;
+
+
+public class ResponseNodeStatus implements NodeStatusProtocol {
+
+    private NodeStatus nodeStatus;
+
+    public NodeStatus getNodeStatus() {
+        return nodeStatus;
+    }
+
+    public void setNodeStatus(NodeStatus nodeStatus) {
+        this.nodeStatus = nodeStatus;
+    }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/StopNodeRequest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/protocol/node/StopNodeRequest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.node;
+
+
+public class StopNodeRequest implements NodeRequestProtocol {
+    private String name = "StopNodeRequest";
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/utils/ManagerUtils.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/java/com/webank/wedatasphere/linkis/manager/common/utils/ManagerUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.utils;
+
+import com.webank.wedatasphere.linkis.manager.common.conf.ManagerCommonConf;
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactory;
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext;
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Map;
+
+
+public class ManagerUtils {
+
+    private final static LabelBuilderFactory labelFactory = LabelBuilderFactoryContext.getLabelBuilderFactory();
+
+
+    public static <T> T getValueOrDefault(Map<String, Object> map, String key, T defaultValue) {
+        Object value = defaultValue;
+        if (null != map && null != map.get(key)) {
+            value = map.get(key);
+        }
+        return (T) value;
+    }
+
+    public static String getAdminUser() {
+
+        if (StringUtils.isNotBlank(ManagerCommonConf.DEFAULT_ADMIN().getValue())) {
+            return ManagerCommonConf.DEFAULT_ADMIN().getValue();
+        }
+        return System.getProperty("user.name");
+    }
+
+    public static Label<?> persistenceLabelToRealLabel(Label<?> label) {
+        return labelFactory.createLabel(label.getLabelKey(),label.getValue());
+    }
+
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/conf/ManagerCommonConf.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/conf/ManagerCommonConf.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.conf
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+
+
+object ManagerCommonConf {
+
+  val DEFAULT_ENGINE_TYPE = CommonVars("wds.linkis.default.engine.type", "spark")
+
+  val DEFAULT_ENGINE_VERSION = CommonVars("wds.linkis.default.engine.type", "2.4.3")
+
+  val DEFAULT_ADMIN = CommonVars("wds.linkis.manager.admin", "hadoop")
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/entity/recycle/RecyclingRule.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/entity/recycle/RecyclingRule.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.recycle
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+
+
+trait RecyclingRule {
+  val user: String
+}
+
+case class AssignNodeRule(serviceInstance: ServiceInstance, override val user: String) extends RecyclingRule
+
+case class AssignUserRule(override val user: String) extends RecyclingRule
+
+case class AssignEMNodeRule(serviceInstance: ServiceInstance, override val user: String) extends RecyclingRule

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/entity/resource/Resource.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/entity/resource/Resource.scala
@@ -1,0 +1,638 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.entity.resource
+
+import com.webank.wedatasphere.linkis.common.utils.{ByteTimeUtils, Logging}
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.ResourceType._
+import com.webank.wedatasphere.linkis.manager.common.exception.ResourceWarnException
+import org.apache.commons.lang.StringUtils
+import org.json4s.JsonAST.JObject
+import org.json4s.JsonDSL._
+import org.json4s.jackson.Serialization
+import org.json4s.{CustomSerializer, DefaultFormats, Extraction}
+
+import scala.collection.JavaConversions
+
+
+abstract class Resource {
+  def add(r: Resource): Resource
+
+  def minus(r: Resource): Resource
+
+  def multiplied(r: Resource): Resource
+
+  def multiplied(rate: Float): Resource
+
+  def divide(r: Resource): Resource
+
+  def divide(rate: Int): Resource
+
+  def moreThan(r: Resource): Boolean
+
+  /**
+    * Part is greater than(部分大于)
+    *
+    * @param r
+    * @return
+    */
+  def caseMore(r: Resource): Boolean
+
+  def equalsTo(r: Resource): Boolean
+
+  def notLess(r: Resource): Boolean
+
+  def +(r: Resource) = add(r)
+
+  def -(r: Resource) = minus(r)
+
+  def *(rate: Float) = multiplied(rate)
+
+  def *(rate: Double) = multiplied(rate.toFloat)
+
+  def /(rate: Int) = divide(rate)
+
+  def ==(r: Resource) = equalsTo(r)
+
+  def >(r: Resource) = moreThan(r)
+
+  def >=(r: Resource) = notLess(r)
+
+  def <(r: Resource) = ! >=(r)
+
+  def <=(r: Resource) = ! >(r)
+
+  def toJson: String
+}
+
+object Resource extends Logging {
+
+  def initResource(resourceType: ResourceType): Resource = resourceType match {
+    case CPU => new CPUResource(0)
+    case Memory => new MemoryResource(0)
+    case Load => new LoadResource(0, 0)
+    case Instance => new InstanceResource(0)
+    case LoadInstance => new LoadInstanceResource(0, 0, 0)
+    case Yarn => new YarnResource(0, 0, 0)
+    case DriverAndYarn => new DriverAndYarnResource(new LoadInstanceResource(0, 0, 0), new YarnResource(0, 0, 0))
+    case Special => new SpecialResource(new java.util.HashMap[String, AnyVal]())
+    case Default => new LoadResource(0, 0)
+    case _ => throw new ResourceWarnException(11003, "not supported resource result policy ")
+  }
+
+  def getZeroResource(resource: Resource): Resource = resource match {
+    case m: MemoryResource => new MemoryResource(0)
+    case c: CPUResource => new CPUResource(0)
+    case i: InstanceResource => new InstanceResource(0)
+    case l: LoadResource => new LoadResource(0, 0)
+    case li: LoadInstanceResource => new LoadInstanceResource(0, 0, 0)
+    case yarn: YarnResource => new YarnResource(0, 0, 0)
+    case dy: DriverAndYarnResource =>
+      if (dy.yarnResource != null && dy.yarnResource.queueName != null) {
+        new DriverAndYarnResource(new LoadInstanceResource(0, 0, 0), new YarnResource(0, 0, 0, dy.yarnResource.queueName))
+      } else {
+        new DriverAndYarnResource(new LoadInstanceResource(0, 0, 0), new YarnResource(0, 0, 0))
+      }
+    case s: SpecialResource => new SpecialResource(new java.util.HashMap[String, AnyVal]())
+    case r: Resource => throw new ResourceWarnException(11003, "not supported resource type " + r.getClass)
+  }
+
+  /* implicit def toYarnResource(r: Resource): YarnResource = r match {
+    case t: YarnResource => t
+    case _ => new YarnResource(0, 0, 0, "default")
+  }
+
+   implicit def toLoadInstanceResource(r: Resource): LoadInstanceResource = r match {
+    case t: LoadInstanceResource => t
+    case _ => new LoadInstanceResource(0, 0, 0)
+  }*/
+}
+
+case class UserAvailableResource(moduleName: String, resource: Resource)
+
+class MemoryResource(val memory: Long) extends Resource {
+  private implicit def toMemoryResource(r: Resource): MemoryResource = r match {
+    case t: MemoryResource => t
+    case _ => new MemoryResource(Long.MaxValue)
+  }
+
+  override def add(r: Resource): Resource = new MemoryResource(memory + r.memory)
+
+  override def minus(r: Resource): Resource = new MemoryResource(memory - r.memory)
+
+  override def multiplied(r: Resource): Resource = new MemoryResource(memory * r.memory)
+
+  override def multiplied(rate: Float): Resource = new MemoryResource((memory * rate).toLong)
+
+  override def divide(r: Resource): Resource = new MemoryResource(memory / r.memory)
+
+  override def divide(rate: Int): Resource = new MemoryResource(memory / rate)
+
+  override def moreThan(r: Resource): Boolean = memory > r.memory
+
+  override def notLess(r: Resource): Boolean = memory >= r.memory
+
+  /**
+    * Part is greater than(部分大于)
+    *
+    * @param r
+    * @return
+    */
+  override def caseMore(r: Resource): Boolean = moreThan(r)
+
+  override def equalsTo(r: Resource): Boolean = memory == r.memory
+
+  override def toJson: String = s""" "memory":"${ByteTimeUtils.bytesToString(memory)}" """
+
+  override def toString: String = toJson
+
+}
+
+class CPUResource(val cores: Int) extends Resource {
+  private implicit def toCPUResource(r: Resource): CPUResource = r match {
+    case t: CPUResource => t
+    case _ => new CPUResource(Integer.MAX_VALUE)
+  }
+
+  protected def toResource(cores: Int): Resource = new CPUResource(cores)
+
+  override def add(r: Resource): Resource = toResource(cores + r.cores)
+
+  override def minus(r: Resource): Resource = toResource(cores - r.cores)
+
+  override def multiplied(r: Resource): Resource = toResource(cores * r.cores)
+
+  override def multiplied(rate: Float): Resource = toResource((cores * rate).toInt)
+
+  override def divide(r: Resource): Resource = toResource(cores / r.cores)
+
+  override def divide(rate: Int): Resource = toResource(cores / rate)
+
+  override def moreThan(r: Resource): Boolean = cores > r.cores
+
+  /**
+    * Part is greater than(部分大于)
+    *
+    * @param r
+    * @return
+    */
+  override def caseMore(r: Resource): Boolean = moreThan(r)
+
+  override def notLess(r: Resource): Boolean = cores >= r.cores
+
+  override def equalsTo(r: Resource): Boolean = cores == r.cores
+
+  override def toJson: String = s""" "cpu":$cores """
+
+  override def toString: String = toJson
+}
+
+class LoadResource(val memory: Long, val cores: Int) extends Resource {
+  private implicit def toLoadResource(r: Resource): LoadResource = r match {
+    case t: LoadResource => t
+    case m: MemoryResource => new LoadResource(m.memory, 0)
+    case c: CPUResource => new LoadResource(0, c.cores)
+    case _ => new LoadResource(Long.MaxValue, Integer.MAX_VALUE)
+  }
+
+  def add(r: Resource): LoadResource =
+    new LoadResource(memory + r.memory, cores + r.cores)
+
+  def minus(r: Resource): LoadResource =
+    new LoadResource(memory - r.memory, cores - r.cores)
+
+  def multiplied(r: Resource): LoadResource =
+    new LoadResource(memory * r.memory, cores * r.cores)
+
+  def multiplied(rate: Float): LoadResource =
+    new LoadResource((memory * rate).toLong, math.round(cores * rate))
+
+  def divide(r: Resource): LoadResource =
+    new LoadResource(memory / r.memory, cores / r.cores)
+
+  def divide(rate: Int): LoadResource =
+    new LoadResource(memory / rate, cores / rate)
+
+  def moreThan(r: Resource): Boolean =
+    memory > r.memory && cores > r.cores
+
+  def caseMore(r: Resource): Boolean =
+    memory > r.memory || cores > r.cores
+
+  def equalsTo(r: Resource): Boolean =
+    memory == r.memory && cores == r.cores
+
+  override def notLess(r: Resource): Boolean =
+    memory >= r.memory && cores >= r.cores
+
+  override def toJson: String = s"""{"memory":"${ByteTimeUtils.bytesToString(memory)}","cpu":$cores}"""
+
+  override def toString: String = toJson
+}
+
+class LoadInstanceResource(val memory: Long, val cores: Int, val instances: Int) extends Resource {
+
+  implicit def toLoadInstanceResource(r: Resource): LoadInstanceResource = r match {
+    case t: LoadInstanceResource => t
+    case l: LoadResource => new LoadInstanceResource(l.memory, l.cores, 0)
+    case m: MemoryResource => new LoadInstanceResource(m.memory, 0, 0)
+    case c: CPUResource => new LoadInstanceResource(0, c.cores, 0)
+    case d: DriverAndYarnResource =>  d.loadInstanceResource // yarn resource has special logic
+    case _ => new LoadInstanceResource(Long.MaxValue, Integer.MAX_VALUE, Integer.MAX_VALUE)
+  }
+
+  def add(r: Resource): LoadInstanceResource =
+    new LoadInstanceResource(memory + r.memory, cores + r.cores, instances + r.instances)
+
+  def minus(r: Resource): LoadInstanceResource =
+    new LoadInstanceResource(memory - r.memory, cores - r.cores, instances - r.instances)
+
+  def multiplied(r: Resource): LoadInstanceResource =
+    new LoadInstanceResource(memory * r.memory, cores * r.cores, instances * r.instances)
+
+  def multiplied(rate: Float): LoadInstanceResource =
+    new LoadInstanceResource((memory * rate).toLong, math.round(cores * rate), (instances * rate).toInt)
+
+  def divide(r: Resource): LoadInstanceResource =
+    new LoadInstanceResource(memory / r.memory, cores / r.cores, instances / r.instances)
+
+  def divide(rate: Int): LoadInstanceResource =
+    new LoadInstanceResource(memory / rate, cores / rate, instances * rate)
+
+  def moreThan(r: Resource): Boolean =
+    memory > r.memory && cores > r.cores && instances > r.instances
+
+  def caseMore(r: Resource): Boolean =
+    memory > r.memory || cores > r.cores || instances > r.instances
+
+  def equalsTo(r: Resource): Boolean =
+    memory == r.memory && cores == r.cores && instances == r.instances
+
+  override def notLess(r: Resource): Boolean =
+    memory >= r.memory && cores >= r.cores && instances >= r.instances
+
+  override def toJson: String = s"""{"instance":$instances,"memory":"${ByteTimeUtils.bytesToString(memory)}","cpu":$cores}"""
+
+  override def toString: String = s"Number of instances(实例数)：$instances，(RAM)内存：${ByteTimeUtils.bytesToString(memory)},cpu:$cores"
+}
+
+
+class InstanceResource(val instances: Int) extends CPUResource(instances) {
+  override protected def toResource(cores: Int): Resource = new InstanceResource(cores)
+
+  override def toJson: String = s"Instance:$instances"
+
+  override def toString: String = toJson
+}
+
+/**
+  * Queue resource information, no initial registration, only user resource usage limit
+  * 队列资源信息，无初始化注册，只有用户资源使用上限
+  *
+  * @param queueName
+  * @param queueMemory
+  * @param queueCores
+  * @param queueInstances
+  */
+class YarnResource(val queueMemory: Long, val queueCores: Int, val queueInstances: Int, val queueName: String = "default", val applicationId: String = "") extends Resource {
+
+  implicit def toYarnResource(r: Resource): YarnResource = r match {
+    case t: YarnResource => t
+    case _ => new YarnResource(Long.MaxValue, Integer.MAX_VALUE, Integer.MAX_VALUE, "default")
+  }
+
+  def add(r: Resource): YarnResource = {
+    //    if (!queueName.equals(r.queueName))
+    //      throw new ResourceWarnException(111001,s"This queue queueName(${this.queueName}) is different: ${r.queueName} ")
+    new YarnResource(queueMemory + r.queueMemory, queueCores + r.queueCores, queueInstances + r.queueInstances, r.queueName)
+  }
+
+  def minus(r: Resource): YarnResource = {
+    //    if (!queueName.equals(r.queueName))
+    //      throw new ResourceWarnException(111001,s"This queue queueName(${this.queueName}) is different: ${r.queueName} ")
+    new YarnResource(queueMemory - r.queueMemory, queueCores - r.queueCores, queueInstances - r.queueInstances, r.queueName)
+  }
+
+  def multiplied(r: Resource): YarnResource = {
+    //    if (!queueName.equals(r.queueName))
+    //      throw new ResourceWarnException(111001,s"This queue queueName(${this.queueName}) is different: ${r.queueName} ")
+    new YarnResource(queueMemory * r.queueMemory, queueCores * r.queueCores, queueInstances * r.queueInstances, r.queueName)
+  }
+
+  def multiplied(rate: Float): YarnResource =
+    new YarnResource((queueMemory * rate).toInt, (queueCores * rate).toInt, (queueInstances * rate).toInt, queueName)
+
+  def divide(r: Resource): YarnResource = {
+    //    if (!queueName.equals(r.queueName))
+    //      throw new ResourceWarnException(111001,s"This queue queueName(${this.queueName}) is different: ${r.queueName} ")
+    new YarnResource(queueMemory / r.queueMemory, queueCores / r.queueCores, queueInstances / r.queueInstances, r.queueName)
+  }
+
+  def divide(rate: Int): YarnResource =
+    new YarnResource(queueMemory / rate, queueCores / rate, queueInstances / rate, queueName)
+
+  def moreThan(r: Resource): Boolean = {
+    //    if (!queueName.equals(r.queueName))
+    //      throw new ResourceWarnException(111001,s"This queue queueName(${this.queueName}) is different: ${r.queueName} ")
+    queueMemory > r.queueMemory && queueCores > r.queueCores && queueInstances >= r.queueInstances
+  }
+
+  def caseMore(r: Resource): Boolean = {
+    //    if (!queueName.equals(r.queueName))
+    //      throw new ResourceWarnException(111001,s"This queue queueName(${this.queueName}) is different: ${r.queueName} ")
+    queueMemory > r.queueMemory || queueCores > r.queueCores || queueInstances >= r.queueInstances
+  }
+
+  def equalsTo(r: Resource): Boolean =
+    queueName == r.queueName && queueMemory == r.queueMemory && queueCores == r.queueCores && queueInstances == r.queueInstances
+
+  override def notLess(r: Resource): Boolean =
+    queueName >= r.queueName && queueMemory >= r.queueMemory && queueCores >= r.queueCores && queueInstances >= r.queueInstances
+
+
+
+  override def toJson: String = s"""{"queueName":"$queueName","queueMemory":"${ByteTimeUtils.bytesToString(queueMemory)}", "queueCpu":$queueCores, "instance":$queueInstances}"""
+
+  override def toString: String = s"Queue name(队列名)：$queueName，Queue memory(队列内存)：${ByteTimeUtils.bytesToString(queueMemory)}，Queue core number(队列核数)：$queueCores, Number of queue instances(队列实例数)：${queueInstances}"
+}
+
+class DriverAndYarnResource(val loadInstanceResource: LoadInstanceResource, val yarnResource: YarnResource) extends Resource with Logging {
+
+  private implicit def DriverAndYarnResource(r: Resource): DriverAndYarnResource = r match {
+    case t: DriverAndYarnResource => t
+    case y: YarnResource => new DriverAndYarnResource(new LoadInstanceResource(0, 0, 0), y)
+    case t: LoadInstanceResource => new DriverAndYarnResource(t, new YarnResource(0, 0, 0))
+    case l: LoadResource => new DriverAndYarnResource(new LoadInstanceResource(l.memory, l.cores, 0), new YarnResource(0, 0, 0))
+    case m: MemoryResource => new DriverAndYarnResource(new LoadInstanceResource(m.memory, 0, 0), new YarnResource(0, 0, 0))
+    case c: CPUResource => new DriverAndYarnResource(new LoadInstanceResource(0, c.cores, 0), new YarnResource(0, 0, 0))
+    case _ => new DriverAndYarnResource(new LoadInstanceResource(Long.MaxValue, Integer.MAX_VALUE, Integer.MAX_VALUE), new YarnResource(Long.MaxValue, Integer.MAX_VALUE, Integer.MAX_VALUE))
+  }
+
+  def isModuleOperate(r: Resource): Boolean = {
+    if (this.yarnResource != null && r.yarnResource != null &&
+      StringUtils.isNotEmpty(this.yarnResource.queueName) &&
+      StringUtils.isNotEmpty(r.yarnResource.queueName) && this.yarnResource.queueName.equals(r.yarnResource.queueName)) {
+      info(s"Not module operate this:$this other:$r")
+      false
+    }
+    else
+      true
+  }
+
+  def isModuleOperate: Boolean = {
+    if (this.yarnResource != null && StringUtils.isNotEmpty(this.yarnResource.queueName))
+      false
+    else
+      true
+  }
+
+  override def add(r: Resource): DriverAndYarnResource = {
+    if (isModuleOperate(r)) {
+      new DriverAndYarnResource(this.loadInstanceResource.add(r.loadInstanceResource), this.yarnResource)
+    } else {
+      new DriverAndYarnResource(this.loadInstanceResource.add(r.loadInstanceResource), this.yarnResource.add(r.yarnResource))
+    }
+  }
+
+  override def minus(r: Resource): Resource = {
+    if (isModuleOperate(r)) {
+      new DriverAndYarnResource(this.loadInstanceResource.minus(r.loadInstanceResource), this.yarnResource)
+    } else {
+      new DriverAndYarnResource(this.loadInstanceResource.minus(r.loadInstanceResource), this.yarnResource.minus(r.yarnResource))
+    }
+  }
+
+  override def multiplied(r: Resource): Resource = {
+    throw new ResourceWarnException(11002, "Unsupported operation: multiplied")
+  }
+
+  override def multiplied(rate: Float): Resource = {
+    if (isModuleOperate) {
+      new DriverAndYarnResource(this.loadInstanceResource.multiplied(rate), this.yarnResource)
+    } else {
+      new DriverAndYarnResource(this.loadInstanceResource.multiplied(rate), this.yarnResource.multiplied(rate))
+    }
+  }
+
+  override def divide(r: Resource): Resource = throw new ResourceWarnException(11002, "Unsupported operation: multiplied")
+
+  override def divide(rate: Int): Resource = if (isModuleOperate) {
+    new DriverAndYarnResource(this.loadInstanceResource.divide(rate), this.yarnResource)
+  } else {
+    new DriverAndYarnResource(this.loadInstanceResource.divide(rate), this.yarnResource.divide(rate))
+  }
+
+  override def moreThan(r: Resource): Boolean = {
+    if (isModuleOperate(r)) {
+      this.loadInstanceResource.moreThan(r.loadInstanceResource)
+    } else {
+      this.loadInstanceResource.moreThan(r.loadInstanceResource) && this.yarnResource.moreThan(r.yarnResource)
+    }
+  }
+
+  override def caseMore(r: Resource): Boolean = if (isModuleOperate(r)) {
+    this.loadInstanceResource.caseMore(r.loadInstanceResource)
+  } else {
+    this.loadInstanceResource.caseMore(r.loadInstanceResource) || this.yarnResource.caseMore(r.yarnResource)
+  }
+
+  override def equalsTo(r: Resource): Boolean = if (isModuleOperate(r)) {
+    this.loadInstanceResource.equalsTo(r.loadInstanceResource)
+  } else {
+    this.loadInstanceResource.equalsTo(r.loadInstanceResource) && this.yarnResource.equalsTo(r.yarnResource)
+  }
+
+  override def notLess(r: Resource): Boolean = if(isModuleOperate(r)){
+    this.loadInstanceResource.notLess(r.loadInstanceResource)
+  } else {
+    this.loadInstanceResource.notLess(r.loadInstanceResource) && this.yarnResource.notLess(r.yarnResource)
+  }
+
+  override def toJson: String = {
+    var load = "null"
+    var yarn = "null"
+    if (loadInstanceResource != null) load = loadInstanceResource.toJson
+    if (yarnResource != null) yarn = yarnResource.toJson
+    s"""{"driver":${load}, "yarn":${yarn}}"""
+  }
+
+  override def toString: String = s"Driver resources(Driver资源)：$loadInstanceResource,Queue resource(队列资源):$yarnResource"
+}
+
+class SpecialResource(val resources: java.util.Map[String, AnyVal]) extends Resource {
+  def this(resources: Map[String, AnyVal]) = this(JavaConversions.mapAsJavaMap(resources))
+
+  private def specialResourceOperator(r: Resource, op: (AnyVal, AnyVal) => AnyVal): SpecialResource = r match {
+    case s: SpecialResource =>
+      val rs = s.resources
+      new SpecialResource(JavaConversions.mapAsScalaMap(resources).map {
+        case (k, v) =>
+          val v1 = rs.get(k)
+          k -> op(v, v1)
+      }.toMap)
+    case _ => new SpecialResource(Map.empty[String, AnyVal])
+  }
+
+  override def add(r: Resource): Resource = specialResourceOperator(r, (v1, v2) => v1 match {
+    case i: Int => i + v2.asInstanceOf[Int]
+    case d: Double => d + v2.asInstanceOf[Double]
+    case l: Long => l + v2.asInstanceOf[Long]
+    case f: Float => f + v2.asInstanceOf[Float]
+    case s: Short => s + v2.asInstanceOf[Short]
+    case _ => throw new ResourceWarnException(11003, "not supported resource type: " + v1.getClass)
+  })
+
+  override def minus(r: Resource): Resource = specialResourceOperator(r, (v1, v2) => v1 match {
+    case i: Int => i - v2.asInstanceOf[Int]
+    case d: Double => d - v2.asInstanceOf[Double]
+    case l: Long => l - v2.asInstanceOf[Long]
+    case f: Float => f - v2.asInstanceOf[Float]
+    case s: Short => s - v2.asInstanceOf[Short]
+    case _ => throw new ResourceWarnException(11003, "not supported resource type: " + v1.getClass)
+  })
+
+  override def multiplied(r: Resource): Resource = specialResourceOperator(r, (v1, v2) => v1 match {
+    case i: Int => i * v2.asInstanceOf[Int]
+    case d: Double => d * v2.asInstanceOf[Double]
+    case l: Long => l * v2.asInstanceOf[Long]
+    case f: Float => f * v2.asInstanceOf[Float]
+    case s: Short => s * v2.asInstanceOf[Short]
+    case _ => throw new ResourceWarnException(11003, "not supported resource type: " + v1.getClass)
+  })
+
+  override def multiplied(rate: Float): Resource = new SpecialResource(JavaConversions.mapAsScalaMap(resources).map {
+    case (k, i: Int) => k -> (i * rate).toInt
+    case (k, d: Double) => k -> d * rate
+    case (k, l: Long) => k -> (l * rate).toLong
+    case (k, f: Float) => k -> f * rate
+    case (k, s: Short) => k -> (s * rate).toShort
+    case (k, v) => throw new ResourceWarnException(11003, "not supported resource type: " + v.getClass)
+  }.toMap[String, AnyVal])
+
+  override def divide(r: Resource): Resource = specialResourceOperator(r, (v1, v2) => v1 match {
+    case i: Int => i / v2.asInstanceOf[Int]
+    case d: Double => d / v2.asInstanceOf[Double]
+    case l: Long => l / v2.asInstanceOf[Long]
+    case f: Float => f / v2.asInstanceOf[Float]
+    case s: Short => s / v2.asInstanceOf[Short]
+    case _ => throw new ResourceWarnException(11003, "not supported resource type: " + v1.getClass)
+  })
+
+  override def divide(rate: Int): Resource = new SpecialResource(JavaConversions.mapAsScalaMap(resources).map {
+    case (k, i: Int) => k -> i / rate
+    case (k, d: Double) => k -> d / rate
+    case (k, l: Long) => k -> l / rate
+    case (k, f: Float) => k -> f / rate
+    case (k, s: Short) => k -> (s / rate).toShort
+    case (k, v) => throw new ResourceWarnException(11003, "not supported resource type: " + v.getClass)
+  }.toMap[String, AnyVal])
+
+  override def moreThan(r: Resource): Boolean = r match {
+    case s: SpecialResource =>
+      val rs = s.resources
+      !JavaConversions.mapAsScalaMap(resources).exists {
+        case (k, i: Int) => i <= rs.get(k).asInstanceOf[Int]
+        case (k, d: Double) => d <= rs.get(k).asInstanceOf[Double]
+        case (k, l: Long) => l <= rs.get(k).asInstanceOf[Long]
+        case (k, f: Float) => f <= rs.get(k).asInstanceOf[Float]
+        case (k, s: Short) => s <= rs.get(k).asInstanceOf[Short]
+        case (k, v) => throw new ResourceWarnException(11003, "not supported resource type: " + v.getClass)
+      }
+    case _ => true
+  }
+
+  /**
+    * Part is greater than(部分大于)
+    *
+    * @param r
+    * @return
+    */
+  override def caseMore(r: Resource): Boolean = r match {
+    case s: SpecialResource =>
+      val rs = s.resources
+      JavaConversions.mapAsScalaMap(resources).exists {
+        case (k, i: Int) => i > rs.get(k).asInstanceOf[Int]
+        case (k, d: Double) => d > rs.get(k).asInstanceOf[Double]
+        case (k, l: Long) => l > rs.get(k).asInstanceOf[Long]
+        case (k, f: Float) => f > rs.get(k).asInstanceOf[Float]
+        case (k, s: Short) => s > rs.get(k).asInstanceOf[Short]
+        case (k, v) => throw new ResourceWarnException(11003, "not supported resource type: " + v.getClass)
+      }
+    case _ => true
+  }
+
+  override def equalsTo(r: Resource): Boolean = r match {
+    case s: SpecialResource =>
+      val rs = s.resources
+      !JavaConversions.mapAsScalaMap(resources).exists {
+        case (k, i: Int) => i != rs.get(k).asInstanceOf[Int]
+        case (k, d: Double) => d != rs.get(k).asInstanceOf[Double]
+        case (k, l: Long) => l != rs.get(k).asInstanceOf[Long]
+        case (k, f: Float) => f != rs.get(k).asInstanceOf[Float]
+        case (k, s: Short) => s != rs.get(k).asInstanceOf[Short]
+        case (k, v) => throw new ResourceWarnException(11003, "not supported resource type: " + v.getClass)
+      }
+    case _ => true
+  }
+
+  override def notLess(r: Resource): Boolean = r match {
+    case s: SpecialResource =>
+      val rs = s.resources
+      !JavaConversions.mapAsScalaMap(resources).exists {
+        case (k, i: Int) => i < rs.get(k).asInstanceOf[Int]
+        case (k, d: Double) => d < rs.get(k).asInstanceOf[Double]
+        case (k, l: Long) => l < rs.get(k).asInstanceOf[Long]
+        case (k, f: Float) => f < rs.get(k).asInstanceOf[Float]
+        case (k, s: Short) => s < rs.get(k).asInstanceOf[Short]
+        case (k, v) => throw new ResourceWarnException(11003,"not supported resource type: " + v.getClass)
+      }
+    case _ => true
+  }
+
+  override def toJson: String = s"Special:$resources"
+}
+
+object ResourceSerializer extends CustomSerializer[Resource](implicit formats => ( {
+  case JObject(List(("memory", memory))) => new MemoryResource(memory.extract[Long])
+  case JObject(List(("cores", cores))) => new CPUResource(cores.extract[Int])
+  case JObject(List(("instance", instances))) => new InstanceResource(instances.extract[Int])
+  case JObject(List(("memory", memory), ("cores", cores))) => new LoadResource(memory.extract[Long], cores.extract[Int])
+  case JObject(List(("memory", memory), ("cores", cores), ("instance", instances))) =>
+    new LoadInstanceResource(memory.extract[Long], cores.extract[Int], instances.extract[Int])
+  case JObject(List(("applicationId", applicationId), ("queueName", queueName), ("queueMemory", queueMemory), ("queueCores", queueCores), ("queueInstances", queueInstances))) =>
+    new YarnResource(queueMemory.extract[Long], queueCores.extract[Int], queueInstances.extract[Int], queueName.extract[String], applicationId.extract[String])
+  case JObject(List(("DriverAndYarnResource", JObject(List(("loadInstanceResource", loadInstanceResource), ("yarnResource", yarnResource)))))) =>
+    implicit val formats = DefaultFormats
+    new DriverAndYarnResource(loadInstanceResource.extract[LoadInstanceResource],
+      yarnResource.extract[YarnResource])
+  case JObject(List(("resources", resources))) =>
+    new SpecialResource(resources.extract[Map[String, AnyVal]])
+  case JObject(list) => throw new ResourceWarnException(11003, "not supported resource serializable string " + list)
+}, {
+  case m: MemoryResource => ("memory", m.memory)
+  case c: CPUResource => ("cores", c.cores)
+  case i: InstanceResource => ("instance", i.instances)
+  case l: LoadResource => ("memory", l.memory) ~ ("cores", l.cores)
+  case li: LoadInstanceResource => ("memory", li.memory) ~ ("cores", li.cores) ~ ("instance", li.instances)
+  case yarn: YarnResource => ("applicationId", yarn.applicationId) ~ ("queueName", yarn.queueName) ~ ("queueMemory", yarn.queueMemory) ~ ("queueCores", yarn.queueCores) ~ ("queueInstances", yarn.queueInstances)
+  case dy: DriverAndYarnResource =>
+    implicit val formats = DefaultFormats
+    ("DriverAndYarnResource", new JObject(List(("loadInstanceResource", Extraction.decompose(dy.loadInstanceResource)), ("yarnResource", Extraction.decompose(dy.yarnResource)))))
+  case s: SpecialResource => ("resources", Serialization.write(JavaConversions.mapAsScalaMap(s.resources).toMap))
+  case r: Resource => throw new ResourceWarnException(11003, "not supported resource type " + r.getClass)
+}
+)
+)

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/monitor/ManagerMonitor.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/monitor/ManagerMonitor.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.monitor
+
+
+trait ManagerMonitor extends Runnable {
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/EngineLock.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/EngineLock.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineLockType
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+trait EngineLock extends RequestProtocol
+
+case class RequestEngineLock(timeout: Long = -1, lockType: EngineLockType = EngineLockType.Timed) extends EngineLock
+
+case class RequestEngineUnlock(lock: String) extends EngineLock
+
+case class ResponseEngineLock(lockStatus: Boolean, lock: String, msg: String) extends EngineLock
+
+case class RequestManagerUnlock(engineInstance: ServiceInstance, lock: String, clientInstance: ServiceInstance) extends EngineLock
+
+case class ResponseEngineUnlock(unlocked: Boolean)

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/ServiceHealthReport.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/ServiceHealthReport.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol
+
+
+abstract class ServiceHealthReport {
+
+  def getReportTime:Long
+  def setReportTime(reportTime:Long):Unit
+
+  def setServiceState
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/ServiceState.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/ServiceState.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol
+
+
+class ServiceState {
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/em/RegisterEMRequest.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/em/RegisterEMRequest.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.em
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+class RegisterEMRequest extends EMRequest with RequestProtocol with Serializable {
+
+  private var serviceInstance: ServiceInstance = null
+
+  private var labels: util.Map[String, AnyRef] = null
+
+  private var nodeResource: NodeResource = null
+
+  private var user: String = null
+
+  private var alias: String = null
+
+  def getServiceInstance: ServiceInstance = serviceInstance
+
+  def setServiceInstance(serviceInstance: ServiceInstance): Unit = {
+    this.serviceInstance = serviceInstance
+  }
+
+  def getLabels: util.Map[String, AnyRef] = labels
+
+  def setLabels(labels: util.Map[String, AnyRef]): Unit = {
+    this.labels = labels
+  }
+
+  def getNodeResource: NodeResource = nodeResource
+
+  def setNodeResource(nodeResource: NodeResource): Unit = {
+    this.nodeResource = nodeResource
+  }
+
+  def setUser(user: String): Unit = {
+    this.user = user
+  }
+
+  def getAlias: String = alias
+
+  def setAlias(alias: String): Unit = {
+    this.alias = alias
+  }
+
+  override def getUser: String = this.user
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineAsyncResponse.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineAsyncResponse.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+trait EngineAsyncResponse extends RequestProtocol {
+  def id(): String
+}
+
+case class EngineAskAsyncResponse(override val id: String, managerInstance: ServiceInstance) extends EngineAsyncResponse
+
+case class EngineCreateSuccess(override val id: String, engineNode: EngineNode) extends EngineAsyncResponse
+
+case class EngineCreateError(override val id: String, exception: String) extends EngineAsyncResponse
+

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineConnStatusCallback.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/engine/EngineConnStatusCallback.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.engine
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.protocol.RetryableProtocol
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+/**
+  * engineConn to ecm
+  *
+  * @param serviceInstance
+  * @param status starting running
+  * @param initErrorMsg
+  */
+case class EngineConnStatusCallback(serviceInstance: ServiceInstance, ticketId: String, status: NodeStatus, initErrorMsg: String) extends RequestProtocol
+
+/**
+  * engineConnManager send to Manager
+  */
+case class EngineConnStatusCallbackToAM(serviceInstance: ServiceInstance, status: NodeStatus, initErrorMsg: String) extends RequestProtocol with RetryableProtocol

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/label/LabelUpdateRequest.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/label/LabelUpdateRequest.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.label
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+case class LabelUpdateRequest(labels: java.util.List[Label[_]]) extends RequestProtocol
+
+case class LabelReportRequest(labels: java.util.List[Label[_]], serviceInstance: ServiceInstance) extends RequestProtocol

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/resource/ResourceProtocol.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/protocol/resource/ResourceProtocol.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.protocol.resource
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.protocol.message.RequestProtocol
+
+
+trait ResourceProtocol extends RequestProtocol
+
+case class ResourceUsedProtocol(serviceInstance: ServiceInstance, engineResource: NodeResource, ticketId: String = null) extends RequestProtocol
+
+

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/serializer/NodeResourceSerializer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/serializer/NodeResourceSerializer.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.serializer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource._
+import org.json4s.JsonAST.JObject
+import org.json4s.JsonDSL._
+import org.json4s.{CustomSerializer, DefaultFormats, Extraction}
+
+
+object NodeResourceSerializer extends CustomSerializer[NodeResource](implicit formats => ( {
+  case JObject(List(("resourceType", resourceType),
+  ("maxResource", maxResource),
+  ("minResource", minResource),
+  ("usedResource", usedResource),
+  ("lockedResource", lockedResource),
+  ("expectedResource", expectedResource),
+  ("leftResource", leftResource))) =>
+    val resource = new CommonNodeResource
+    resource.setResourceType(ResourceType.valueOf(resourceType.extract[String]))
+    resource.setMaxResource(maxResource.extract[Resource])
+    resource.setMinResource(minResource.extract[Resource])
+    resource.setUsedResource(usedResource.extract[Resource])
+    resource.setLockedResource(lockedResource.extract[Resource])
+    resource.setExpectedResource(expectedResource.extract[Resource])
+    resource.setLeftResource(leftResource.extract[Resource])
+    resource
+} , {
+  case c: CommonNodeResource =>
+    implicit val formats = DefaultFormats + ResourceSerializer
+      ("resourceType", c.getResourceType.toString) ~
+      ("maxResource", Extraction.decompose(c.getMaxResource)) ~
+      ("minResource", Extraction.decompose(c.getMinResource)) ~
+      ("usedResource", Extraction.decompose(c.getUsedResource)) ~
+      ("lockedResource", Extraction.decompose(c.getLockedResource)) ~
+      ("expectedResource", Extraction.decompose(c.getExpectedResource)) ~
+      ("leftResource", Extraction.decompose(c.getLeftResource))
+}))

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/serializer/RegisterEMRequestSerializer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/serializer/RegisterEMRequestSerializer.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.serializer
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.{CommonNodeResource, ResourceSerializer}
+import com.webank.wedatasphere.linkis.manager.common.protocol.em.RegisterEMRequest
+import org.json4s.JsonAST.JObject
+import org.json4s.JsonDSL._
+import org.json4s.{CustomSerializer, DefaultFormats, Extraction}
+
+
+object RegisterEMRequestSerializer extends CustomSerializer[RegisterEMRequest](implicit formats => ( {
+  case JObject(List(("serviceInstance", serviceInstance),
+  ("labels", labels),
+  ("nodeResource", nodeResource),
+  ("user", user),
+  ("alias", alias))) =>
+    val registerEMRequest = new RegisterEMRequest
+    registerEMRequest.setServiceInstance(serviceInstance.extract[ServiceInstance])
+    registerEMRequest.setAlias(alias.extract[String])
+    //registerEMRequest.setLabels(labels.extract[java.util.HashMap[String, Object]])
+    registerEMRequest.setUser(user.extract[String])
+    registerEMRequest.setNodeResource(nodeResource.extract[CommonNodeResource])
+    registerEMRequest
+}, {
+  case c: RegisterEMRequest =>
+    implicit val formats = DefaultFormats + ResourceSerializer + NodeResourceSerializer
+    ("serviceInstance", Extraction.decompose(c.getServiceInstance)) ~
+      ("labels", Extraction.decompose(c.getLabels)) ~
+      ("nodeResource", Extraction.decompose(c.getNodeResource)) ~
+      ("user", c.getUser) ~
+      ("alias", c.getAlias)
+}))

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/utils/ResourceUtils.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-common/src/main/scala/com/webank/wedatasphere/linkis/manager/common/utils/ResourceUtils.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.common.utils
+
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceResource
+import com.webank.wedatasphere.linkis.manager.common.entity.resource._
+import org.json4s.DefaultFormats
+import org.json4s.jackson.Serialization.{read, write}
+
+
+object ResourceUtils {
+
+
+  implicit val formats = DefaultFormats + ResourceSerializer
+
+  def deserializeResource(plainResource: String): Resource = {
+    read[Resource](plainResource)
+  }
+
+  def serializeResource(resource: Resource): String = {
+    write(resource)
+  }
+
+  def toPersistenceResource(nodeResource: NodeResource): PersistenceResource = {
+    val persistenceResource = new PersistenceResource
+    if (nodeResource.getMaxResource != null) persistenceResource.setMaxResource(serializeResource(nodeResource.getMaxResource))
+    if (nodeResource.getMinResource != null) persistenceResource.setMinResource(serializeResource(nodeResource.getMinResource))
+    if (nodeResource.getLockedResource != null) persistenceResource.setLockedResource(serializeResource(nodeResource.getLockedResource))
+    if (nodeResource.getExpectedResource != null) persistenceResource.setExpectedResource(serializeResource(nodeResource.getExpectedResource))
+    if (nodeResource.getLeftResource != null) persistenceResource.setLeftResource(serializeResource(nodeResource.getLeftResource))
+    if (nodeResource.getUsedResource != null) persistenceResource.setUsedResource(serializeResource(nodeResource.getUsedResource))
+    persistenceResource.setResourceType(nodeResource.getResourceType.toString())
+    persistenceResource
+  }
+
+  def fromPersistenceResource(persistenceResource: PersistenceResource): CommonNodeResource = {
+    if(persistenceResource == null) return null
+    val nodeResource = new CommonNodeResource
+    if (persistenceResource.getMaxResource != null) nodeResource.setMaxResource(deserializeResource(persistenceResource.getMaxResource))
+    if (persistenceResource.getMinResource != null) nodeResource.setMinResource(deserializeResource(persistenceResource.getMinResource))
+    if (persistenceResource.getLockedResource != null) nodeResource.setLockedResource(deserializeResource(persistenceResource.getLockedResource))
+    if (persistenceResource.getExpectedResource != null) nodeResource.setMaxResource(deserializeResource(persistenceResource.getExpectedResource))
+    if (persistenceResource.getLeftResource != null) nodeResource.setLeftResource(deserializeResource(persistenceResource.getLeftResource))
+    if (persistenceResource.getUsedResource != null) nodeResource.setUsedResource(deserializeResource(persistenceResource.getUsedResource))
+    nodeResource.setResourceType(ResourceType.valueOf(persistenceResource.getResourceType))
+    nodeResource
+  }
+
+  def getResourceTypeByResource(resource: Resource): ResourceType = resource match {
+    case cpuResource: CPUResource => ResourceType.CPU
+    case loadResource: LoadResource => ResourceType.Load
+    case instanceResource: InstanceResource => ResourceType.Instance
+    case loadInstanceResource: LoadInstanceResource => ResourceType.LoadInstance
+    case yarnResource: YarnResource => ResourceType.Yarn
+    case driverAndYarnResource: DriverAndYarnResource => ResourceType.DriverAndYarn
+    case specialResource: SpecialResource => ResourceType.Special
+    case _ => ResourceType.LoadInstance
+  }
+
+  def convertTo(nodeResource: NodeResource, resourceType: ResourceType) : NodeResource = {
+    if(nodeResource.getResourceType.equals(resourceType)) return nodeResource
+    if(resourceType.equals(ResourceType.LoadInstance)){
+      if(nodeResource.getResourceType.equals(ResourceType.DriverAndYarn)){
+        nodeResource.setResourceType(resourceType)
+        if(nodeResource.getMaxResource != null) nodeResource.setMaxResource(nodeResource.getMaxResource.asInstanceOf[DriverAndYarnResource].loadInstanceResource)
+        if(nodeResource.getMinResource != null) nodeResource.setMinResource(nodeResource.getMinResource.asInstanceOf[DriverAndYarnResource].loadInstanceResource)
+        if(nodeResource.getUsedResource != null) nodeResource.setUsedResource(nodeResource.getUsedResource.asInstanceOf[DriverAndYarnResource].loadInstanceResource)
+        if(nodeResource.getLockedResource != null) nodeResource.setLockedResource(nodeResource.getLockedResource.asInstanceOf[DriverAndYarnResource].loadInstanceResource)
+        if(nodeResource.getExpectedResource != null) nodeResource.setExpectedResource(nodeResource.getExpectedResource.asInstanceOf[DriverAndYarnResource].loadInstanceResource)
+        if(nodeResource.getLeftResource != null && nodeResource.getLeftResource.isInstanceOf[DriverAndYarnResource]){
+          nodeResource.setLeftResource(nodeResource.getLeftResource.asInstanceOf[DriverAndYarnResource].loadInstanceResource)
+        }
+        return nodeResource
+      }
+    }
+    return nodeResource
+  }
+
+
+}


### PR DESCRIPTION
### What is the purpose of the change

Related issues: #584
Add a new LinkisManager Common module to collect all commonly used interfaces in LinkisManager.

### Brief change log

1. Provide general protocols for RPC communication between LinkisManager with ECM and EC

2. Provide general configurations and constants.

3. The interface Resource and its implementations are provided to represent the resources information of EngineConn and EngineManager.