### PR TITLE
Enhance the label management function of Linkis, so it can manage the Label of EngineConnManager and EngineConn

### DIFF
--- a/linkis-computation-governance/linkis-manager/label-manager/pom.xml
+++ b/linkis-computation-governance/linkis-manager/label-manager/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!--<relativePath>../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-label-manager</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-persistence</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/score/DefaultNodeLabelScorer.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/score/DefaultNodeLabelScorer.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.score
+import java.util
+import java.util.function.BiFunction
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.node.ScoreServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+import com.webank.wedatasphere.linkis.manager.label.conf.LabelCommonConfig
+import com.webank.wedatasphere.linkis.manager.label.entity.Feature
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+/**
+ * Default scorer
+ * to traversal the network between node and label
+ */
+@Component
+class DefaultNodeLabelScorer extends NodeLabelScorer{
+  override def calculate(inNodeDegree: util.Map[PersistenceLabel, util.List[ServiceInstance]],
+                         outNodeDegree: util.Map[ServiceInstance, util.List[PersistenceLabel]],
+                         labels: util.List[PersistenceLabel]): util.Map[ScoreServiceInstance, util.List[PersistenceLabel]] = {
+    //First, traversal out degree (Node -> Label)
+    val baseCore = LabelCommonConfig.LABEL_SCORER_BASE_CORE.getValue.toDouble;
+    val nodeScores = new util.HashMap[ServiceInstance, Double]
+    val labelIdToEntity = traversalAndScoreOnOutDegree(baseCore, nodeScores, outNodeDegree, labels)
+    //Second, filter the unknown label on in-degree (Label -> Node)
+    traversalAndScoreOnInDegree(baseCore, nodeScores, inNodeDegree, labelIdToEntity)
+    //At last, normalize and output
+    normalizeAndOutput(nodeScores, outNodeDegree)
+  }
+
+  /**
+   * Traversal out degree
+   * @param nodeScores
+   */
+  private def traversalAndScoreOnOutDegree(baseCore: Double, nodeScores: util.Map[ServiceInstance, Double],
+                                           outNodeDegree: util.Map[ServiceInstance, util.List[PersistenceLabel]],
+                                           labels: util.List[PersistenceLabel]): util.Map[String, PersistenceLabel] = {
+    //Group count feature in labels
+    val ftCounts = new util.HashMap[Feature, Integer]
+    val countFunction: BiFunction[Feature, Integer, Integer] = new BiFunction[Feature, Integer, Integer] {
+      override def apply(t: Feature, count: Integer): Integer = {
+        var count0 = count
+        if (Option(count0).isEmpty) count0 = 0
+        count0 = count0 + 1
+        count0
+      }
+    }
+    val labelIdToEntity = labels.map( label => {
+      ftCounts.compute(label.getFeature, countFunction)
+      (String.valueOf(label.getId), label)
+    }).toMap
+    outNodeDegree.foreach{
+      case(node, outLabels) =>
+        // expression: base_core / feature_count * feature_boost
+        val scoreOutDegree = outLabels.map( label => {
+          if(labelIdToEntity.contains(String.valueOf(label.getId))){
+            val feature = Option(label.getFeature).getOrElse(Feature.OPTIONAL)
+            ( baseCore / ftCounts.get(feature).toDouble) * feature.getBoost
+          }else{ 0 }
+        }).foldLeft(0d)( _ + _)
+        nodeScores.put(node, scoreOutDegree)
+    }
+    labelIdToEntity
+  }
+
+  private def traversalAndScoreOnInDegree(baseCore: Double, nodeScores: util.Map[ServiceInstance, Double],
+                                          inNodeDegree: util.Map[PersistenceLabel, util.List[ServiceInstance]],
+                                          labelIdToEntity: util.Map[String, PersistenceLabel]): Unit = {
+    //Unrelated in-degree
+    val relateLimit = LabelCommonConfig.LABEL_SCORER_RELATE_LIMIT.getValue;
+    var relateSum = 0d
+    var relateCount = 0
+    inNodeDegree.map{
+      case(label, nodes) =>
+        if(nodes.size() <= relateLimit){
+          (label, 0d)
+        }else{
+          (label, nodes.size().asInstanceOf[Double] / nodeScores.size().asInstanceOf[Double])
+        }
+    }.filter {
+      case (label, score) =>
+        val isMatch = !labelIdToEntity.containsKey(String.valueOf(label.getId)) && score > 0
+        if (isMatch) {
+          relateSum += score
+          relateCount += 1
+        }
+        isMatch
+    }.foreach{
+      case (label, score) =>
+        val nodes = inNodeDegree.get(label)
+        if(Option(nodes).isDefined){
+          val minScore = math.min(Feature.UNKNOWN.getBoost * score / relateSum,
+            Feature.UNKNOWN.getBoost * nodes.size().asInstanceOf[Double] / relateCount.asInstanceOf[Double])
+          nodes.foreach( node => {
+            val nodeScore = nodeScores.get(node)
+            if(Option(nodeScore).isDefined){
+              nodeScores.put(node, nodeScore + minScore)
+            }
+          })
+        }
+    }
+  }
+
+  /**
+   * Normalize
+   * @param nodeScores
+   * @param outNodeDegree
+   */
+  private def normalizeAndOutput(nodeScores: util.Map[ServiceInstance, Double],
+                                 outNodeDegree: util.Map[ServiceInstance, util.List[PersistenceLabel]]):util.Map[ScoreServiceInstance, util.List[PersistenceLabel]] = {
+    //Average value
+    val average = nodeScores.values().foldLeft(0d)(_ + _) / nodeScores.size.asInstanceOf[Double]
+    val deviation = math.sqrt(nodeScores.values().foldLeft(0d)((sum, score) => {
+     sum + math.pow(score - average, 2)
+    }) * (1.0d / nodeScores.size.asInstanceOf[Double]))
+    var offset = 0d
+    val rawOutput = nodeScores.map{
+      case(node, score) =>
+        val labelScoreServiceInstance: ScoreServiceInstance = new LabelScoreServiceInstance(node)
+        val scoreCalculate = if (deviation != 0) {(score - average) / deviation} else score
+        if(scoreCalculate < offset){
+           offset = scoreCalculate
+        }
+        labelScoreServiceInstance.setScore(scoreCalculate)
+        (labelScoreServiceInstance, outNodeDegree(node))
+    }
+    rawOutput.foreach{
+      case (instance, _) =>
+        instance.setScore(instance.getScore + math.abs(offset))
+    }
+    mapAsJavaMap(rawOutput.toMap)
+  }
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/score/LabelScoreServiceInstance.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/score/LabelScoreServiceInstance.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.score
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.node.ScoreServiceInstance
+
+
+class LabelScoreServiceInstance(instance: ServiceInstance) extends ScoreServiceInstance{
+  var score = 0d
+  var serviceInstance: ServiceInstance = instance
+  override def getScore: Double = score
+
+  override def setScore(score: Double): Unit = {
+    this.score = score
+  }
+
+  override def getServiceInstance: ServiceInstance = serviceInstance
+
+  override def setServiceInstance(serviceInstance: ServiceInstance): Unit = {
+
+  }
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/score/NodeLabelScorer.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/score/NodeLabelScorer.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.score
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.node.ScoreServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+
+
+trait NodeLabelScorer {
+  /**
+   * Calculate node score
+   * @param inNodeDegree relation(Label -> Node)
+   * @param outNodeDegree relation(Node -> Label)
+   * @param labels labels participated into scoring
+   * @return (Node -> Score)
+   */
+   def calculate(inNodeDegree: util.Map[PersistenceLabel, util.List[ServiceInstance]],
+                 outNodeDegree: util.Map[ServiceInstance, util.List[PersistenceLabel]],
+                 labels: util.List[PersistenceLabel]): util.Map[ScoreServiceInstance, util.List[PersistenceLabel]]
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/NodeLabelAddService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/NodeLabelAddService.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.label.LabelReportRequest
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelAddRequest
+
+
+trait NodeLabelAddService {
+
+  def addNodeLabels(nodeLabelAddRequest: NodeLabelAddRequest): Unit
+
+  def dealNodeLabelReport(labelReportRequest: LabelReportRequest): Unit
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/NodeLabelRemoveService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/NodeLabelRemoveService.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service
+
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelRemoveRequest
+
+
+trait NodeLabelRemoveService {
+
+  def removeNodeLabel(nodeLabelRemoveRequest: NodeLabelRemoveRequest): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/NodeLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/NodeLabelService.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.node.ScoreServiceInstance
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait NodeLabelService {
+
+  /**
+   * Attach labels to node instance
+   *
+   * @param instance node instance
+   * @param labels   label list
+   */
+  def addLabelsToNode( instance: ServiceInstance, labels: util.List[Label[_]]): Unit
+
+  def addLabelToNode(instance: ServiceInstance, label: Label[_]): Unit
+
+  /**
+   * Update
+   * @param instance node instance
+   * @param label label
+   */
+  def updateLabelToNode(instance: ServiceInstance, label: Label[_]): Unit
+
+  /**
+   * Remove the labels related by node instance
+   *
+   * @param instance node instance
+   * @param labels   labels
+   */
+  def removeLabelsFromNode(instance: ServiceInstance, labels: util.List[Label[_]]): Unit
+
+  def removeLabelsFromNode(instance: ServiceInstance): Unit
+
+
+  /**
+   * Get node instances by labels
+   *
+   * @param labels searchableLabel or other normal labels
+   * @return
+   */
+  def getNodesByLabels(labels: util.List[Label[_]]): util.List[ServiceInstance]
+
+
+  def getNodesByLabel(label: Label[_]): util.List[ServiceInstance]
+
+
+  def getNodeLabels(instance: ServiceInstance): util.List[Label[_]]
+
+
+  /**
+   * Get scored node instances
+   *
+   * @param labels searchableLabel or other normal labels
+   * @return
+   */
+  def getScoredNodesByLabels(labels: util.List[Label[_]]): util.List[ScoreServiceInstance]
+
+
+  def getScoredNodeMapsByLabels(labels: util.List[Label[_]]): util.Map[ScoreServiceInstance, util.List[Label[_]]]
+
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/ResourceLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/ResourceLabelService.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service
+
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait ResourceLabelService {
+
+  def setEngineConnResourceToLabel(label: Label[_], nodeResource: NodeResource):Unit
+
+
+  /**
+    * 通过传入的Labels 查找所有和Resource相关的Label
+    * 包含CombineLabel，需要CombineLabel的所有Label Key 出现过
+    *
+    * @param labels
+    * @return
+    */
+  def getResourceLabels(labels: java.util.List[Label[_]]): java.util.List[Label[_]]
+
+
+  /**
+    * 设置某个Label的资源数值，如果不存在add，存在对应的Label update
+    *
+    * @param label
+    * @param resource
+    */
+  def setResourceToLabel(label: Label[_], resource: NodeResource)
+
+  /**
+    * 通过Label 返回对应的Resource
+    *
+    * @param label
+    * @return
+    */
+  def getResourceByLabel(label: Label[_]): NodeResource
+
+
+  /**
+    * 清理Label的资源信息和记录
+    * 1. 清理Label对应的Resource信息
+    * 2. 清理包含改Label的CombinedLabel的Resource信息
+    *
+    * @param label
+    */
+  def removeResourceByLabel(label: Label[_]): Unit
+
+
+  def removeResourceByLabels(labels: java.util.List[Label[_]]): Unit
+
+
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/UserLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/UserLabelService.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait UserLabelService {
+
+  def addLabelToUser(user: String, labels: util.List[Label[_]]): Unit
+
+  def addLabelToUser(user: String, label: Label[_]): Unit
+
+  def removeLabelFromUser(user: String, labels: util.List[Label[_]]): Unit
+
+
+  def getUserByLabel(label: Label[_]): util.List[String]
+
+  def getUserByLabels(labels: util.List[Label[_]]): util.List[String]
+
+  def getUserLabels(user: String): util.List[Label[_]]
+
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelAddService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelAddService.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service.impl
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.protocol.label.LabelReportRequest
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.service.{NodeLabelAddService, NodeLabelService}
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelAddRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+
+@Service
+class DefaultNodeLabelAddService extends NodeLabelAddService with Logging {
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Receiver
+  override def addNodeLabels(nodeLabelAddRequest: NodeLabelAddRequest): Unit = {
+    info(s"Start to add labels for node ${nodeLabelAddRequest.getServiceInstance}")
+    val labelList: util.List[Label[_]] = LabelBuilderFactoryContext.getLabelBuilderFactory.getLabels(nodeLabelAddRequest.getLabels)
+    nodeLabelService.addLabelsToNode(nodeLabelAddRequest.getServiceInstance, labelList)
+    info(s"Finished to add labels for node ${nodeLabelAddRequest.getServiceInstance}")
+  }
+
+  @Receiver
+  override def dealNodeLabelReport(labelReportRequest: LabelReportRequest): Unit = {
+    info(s"Start to deal labels for node ${labelReportRequest.serviceInstance}")
+    val labelList = labelReportRequest.labels
+    nodeLabelService.addLabelsToNode(labelReportRequest.serviceInstance, labelList)
+    info(s"Finished to deal labels for node ${labelReportRequest.serviceInstance}")
+  }
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelRemoveService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelRemoveService.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service.impl
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.em.EMInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.service.{NodeLabelRemoveService, NodeLabelService}
+import com.webank.wedatasphere.linkis.manager.persistence.LabelManagerPersistence
+import com.webank.wedatasphere.linkis.message.annotation.Receiver
+import com.webank.wedatasphere.linkis.protocol.label.NodeLabelRemoveRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+
+@Service
+class DefaultNodeLabelRemoveService extends NodeLabelRemoveService with Logging {
+
+  @Autowired
+  private var nodeLabelService: NodeLabelService = _
+
+  @Autowired
+  private var labelPersistence: LabelManagerPersistence = _
+
+
+  @Receiver
+  override def removeNodeLabel(nodeLabelRemoveRequest: NodeLabelRemoveRequest): Unit = {
+    info(s"Start to remove labels from node ${nodeLabelRemoveRequest.getServiceInstance}")
+    nodeLabelService.removeLabelsFromNode(nodeLabelRemoveRequest.getServiceInstance)
+    val persistenceLabel = if (nodeLabelRemoveRequest.isEngine) {
+      val engineLabel = LabelBuilderFactoryContext.getLabelBuilderFactory.createLabel(classOf[EngineInstanceLabel])
+      engineLabel.setInstance(nodeLabelRemoveRequest.getServiceInstance.getInstance)
+      engineLabel.setServiceName(nodeLabelRemoveRequest.getServiceInstance.getApplicationName)
+      LabelBuilderFactoryContext.getLabelBuilderFactory.convertLabel(engineLabel, classOf[PersistenceLabel])
+    } else {
+
+      val eMInstanceLabel = LabelBuilderFactoryContext.getLabelBuilderFactory.createLabel(classOf[EMInstanceLabel])
+      eMInstanceLabel.setServiceName(nodeLabelRemoveRequest.getServiceInstance.getApplicationName)
+      eMInstanceLabel.setInstance(nodeLabelRemoveRequest.getServiceInstance.getInstance)
+      LabelBuilderFactoryContext.getLabelBuilderFactory.convertLabel(eMInstanceLabel, classOf[PersistenceLabel])
+    }
+
+    labelPersistence.removeLabel(persistenceLabel)
+    info(s"Finished to remove labels from node ${nodeLabelRemoveRequest.getServiceInstance}")
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelService.scala
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service.impl
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.entity.node.ScoreServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.Label.ValueRelation
+import com.webank.wedatasphere.linkis.manager.label.entity.{Feature, Label}
+import com.webank.wedatasphere.linkis.manager.label.score.NodeLabelScorer
+import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
+import com.webank.wedatasphere.linkis.manager.persistence.LabelManagerPersistence
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+
+@Service
+class DefaultNodeLabelService extends NodeLabelService with Logging {
+
+  @Autowired
+  var labelManagerPersistence: LabelManagerPersistence = _
+
+  private val labelFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
+
+  @Autowired
+  private var nodeLabelScorer: NodeLabelScorer = _
+  /**
+    * Attach labels to node instance
+    * TODO 该方法需要优化,应该batch插入
+    *
+    * @param instance node instance
+    * @param labels   label list
+    */
+  @Transactional(rollbackFor = Array(classOf[Exception]))
+  override def addLabelsToNode( instance: ServiceInstance, labels: util.List[Label[_]]): Unit = {
+    if (null != labels && !labels.isEmpty) labels.foreach(addLabelToNode(instance, _))
+  }
+
+  @Transactional(rollbackFor = Array(classOf[Exception]))
+  override def addLabelToNode(instance: ServiceInstance, label: Label[_]): Unit = {
+    // TODO: 上层应该有个初始化清理表格的方法
+    val persistenceLabel = labelFactory.convertLabel(label, classOf[PersistenceLabel])
+    //Try to add
+    tryToAddLabel(persistenceLabel);
+    //2.查询出当前label的id
+    val dbLabel = labelManagerPersistence.getLabelByKeyValue(persistenceLabel.getLabelKey, persistenceLabel.getStringValue)
+    //3.根据instance 找出当前关联当前isntance的所有labels,看下有没和当前id重复的
+    //2020/09/14 如果已经存在关联，则不关联
+    //TODO 对于这样的记录查询，插入时有并发问题，可以考虑提供getLabelByServiceInstanceAndId方法，配合for update关键字，使用间隙锁
+    val serviceRelationLabels = labelManagerPersistence.getLabelByServiceInstance(instance)
+    if (!serviceRelationLabels.exists(_.getId.equals(dbLabel.getId))){
+      //5.插入新的relation 需要抛出duplicateKey异常，回滚
+      labelManagerPersistence.addLabelToNode(instance, util.Arrays.asList(dbLabel.getId))
+    }
+  }
+
+  @Transactional(rollbackFor = Array(classOf[Exception]))
+  override def updateLabelToNode(instance: ServiceInstance, label: Label[_]): Unit = {
+    val persistenceLabel = this.labelFactory.convertLabel(label, classOf[PersistenceLabel])
+    //Try to add
+    tryToAddLabel(persistenceLabel)
+    val dbLabel = labelManagerPersistence.getLabelByKeyValue(persistenceLabel.getLabelKey, persistenceLabel.getStringValue)
+    //TODO: add method: getLabelsByServiceInstanceAndKey(instance, labelKey)
+    val nodeLabels = this.labelManagerPersistence.getLabelByServiceInstance(instance)
+    var needUpdate = true
+    nodeLabels.filter(_.getLabelKey.equals(label.getLabelKey)).foreach( nodeLabel =>{
+      if(nodeLabel.getId.equals(dbLabel.getId)){
+        needUpdate = false
+      }else{
+        //TODO: add batch method: removeLabels(Ids)
+        this.labelManagerPersistence.removeLabel(nodeLabel.getId)
+      }
+    })
+    if (needUpdate) {
+      this.labelManagerPersistence.addLabelToNode(instance, util.Arrays.asList())
+    }
+  }
+  /**
+   * Remove the labels related by node instance
+   *
+   * @param instance node instance
+   * @param labels   labels
+   */
+  @Transactional(rollbackFor = Array(classOf[Exception]))
+  override def removeLabelsFromNode(instance: ServiceInstance, labels: util.List[Label[_]]): Unit = {
+    //这里前提是表中保证了同个key，只会有最新的value保存在数据库中
+    val dbLabels = labelManagerPersistence.getLabelByServiceInstance(instance).map(l => (l.getLabelKey, l)).toMap
+    labelManagerPersistence.removeNodeLabels(instance, labels.map(l => dbLabels(l.getLabelKey).getId))
+  }
+
+  @Transactional(rollbackFor = Array(classOf[Exception]))
+  override def removeLabelsFromNode(instance: ServiceInstance): Unit = {
+    labelManagerPersistence.removeNodeLabels(instance, labelManagerPersistence.getLabelByServiceInstance(instance).map(_.getId))
+  }
+
+  /**
+   * Get node instances by labels
+   *
+   * @param labels searchableLabel or other normal labels
+   * @return
+   */
+  override def getNodesByLabels(labels: util.List[Label[_]]): util.List[ServiceInstance] = {
+    labels.flatMap(getNodesByLabel).distinct
+  }
+
+  override def getNodesByLabel(label: Label[_]): util.List[ServiceInstance] = {
+    labelManagerPersistence.getNodeByLabelKeyValue(label.getLabelKey,label.getStringValue).distinct
+  }
+
+  override def getNodeLabels(instance: ServiceInstance): util.List[Label[_]] = {
+    labelManagerPersistence.getLabelByServiceInstance(instance).map { label =>
+      val realyLabel:Label[_] = labelFactory.createLabel(label.getLabelKey, label.getValue)
+      realyLabel
+    }
+  }
+
+  /**
+    * Get scored node instances
+    *
+    * @param labels searchableLabel or other normal labels
+    * @return
+    */
+  override def getScoredNodesByLabels(labels: util.List[Label[_]]): util.List[ScoreServiceInstance] = {
+    getScoredNodeMapsByLabels(labels).map(_._1).toList
+  }
+  override def getScoredNodeMapsByLabels(labels: util.List[Label[_]]): util.Map[ScoreServiceInstance, util.List[Label[_]]] = {
+    //Try to convert the label list to key value list
+    val kvList = labels.map( label => Option(labelFactory.convertLabel(label, classOf[PersistenceLabel])))
+      .filter(option => option.isDefined && Option(option.get.getValue).isDefined).map(_.get.getValue).toList
+    if (kvList.nonEmpty) {
+      //Get the persistence labels by kvList
+      val persistenceLabels = labelManagerPersistence.getLabelsByValueList(kvList, ValueRelation.ALL)
+
+      if (null != persistenceLabels && persistenceLabels.nonEmpty) {
+        val labelsFromDB = persistenceLabels.map(label => labelFactory.createLabel(label.getLabelKey, label.getValue).asInstanceOf[Label[_]])
+        val requireLabels = labels.filter(_.getFeature == Feature.CORE)
+        val oldSize = requireLabels.size
+        val newSize = requireLabels.count(label => labelsFromDB.exists { dbLabel =>
+          dbLabel.getLabelKey.equals(label.getLabelKey) && label.getStringValue.equalsIgnoreCase(dbLabel.getStringValue)
+        })
+        if (oldSize != newSize) return new util.HashMap[ScoreServiceInstance, util.List[Label[_]]]()
+        //Extra the necessary labels whose feature equals Feature.CORE or Feature.SUITABLE
+        val necessaryLabels = persistenceLabels.filter(label => requireLabels.exists(_.getLabelKey.equalsIgnoreCase(label.getLabelKey))).toList
+        return getScoredNodeMapsByLabels(persistenceLabels, necessaryLabels)
+      }
+
+    }
+    new util.HashMap[ScoreServiceInstance, util.List[Label[_]]]()
+  }
+
+  private def getScoredNodeMapsByLabels(labels: util.List[PersistenceLabel],
+                                        necessaryLabels: util.List[PersistenceLabel]): util.Map[ScoreServiceInstance, util.List[Label[_]]] = {
+    //Get the in-degree relations ( Label -> Node )
+    val inNodeDegree = labelManagerPersistence.getNodeRelationsByLabels(if (necessaryLabels.nonEmpty) necessaryLabels else labels)
+    if (inNodeDegree.isEmpty) {
+      return new util.HashMap[ScoreServiceInstance, util.List[Label[_]]]()
+    }
+    val instanceLabels = new mutable.HashMap[ServiceInstance, ArrayBuffer[Label[_]]]()
+    inNodeDegree.foreach { keyValue =>
+      keyValue._2.foreach { instance =>
+        if (!instanceLabels.contains(instance)) {
+          instanceLabels.put(instance, new ArrayBuffer[Label[_]]())
+        }
+        val labelList = instanceLabels.get(instance)
+        labelList.get.add(keyValue._1)
+      }
+    }
+    val instances = if (necessaryLabels.nonEmpty) {
+      //Cut the in-degree relations, drop inconsistent nodes
+      instanceLabels.filter(entry => entry._2.size >= necessaryLabels.size).keys
+    } else {
+      instanceLabels.keys
+    }
+    //Get the out-degree relations ( Node -> Label )
+    val outNodeDegree = labelManagerPersistence.getLabelRelationsByServiceInstance(instances.toList)
+    //outNodeDegree cannot be empty
+    if (outNodeDegree.nonEmpty) {
+      //Rebuild in-degree relations
+       inNodeDegree.clear()
+       outNodeDegree.foreach{
+         case(node, labels) =>
+           labels.foreach( label => {
+             if (!inNodeDegree.contains(label)) {
+               val inNodes = new util.ArrayList[ServiceInstance]()
+               inNodeDegree.put(label, inNodes)
+             }
+             val inNodes = inNodeDegree.get(label)
+             inNodes.add(node)
+           })
+       }
+       return nodeLabelScorer.calculate( inNodeDegree, outNodeDegree, labels).asInstanceOf[util.Map[ScoreServiceInstance, util.List[Label[_]]]]
+    }
+    new util.HashMap[ScoreServiceInstance, util.List[Label[_]]]()
+  }
+
+  private def tryToAddLabel(persistenceLabel: PersistenceLabel): Unit = {
+    //1.插入linkis_manager_label 表，这里表应该有唯一约束，key和valueStr　调用Persistence的addLabel即可，忽略duplicateKey异常
+    persistenceLabel.setLabelValueSize(persistenceLabel.getValue.size())
+    Utils.tryCatch(labelManagerPersistence.addLabel(persistenceLabel)) { t: Throwable =>
+      warn(s"Failed to add label ${t.getMessage}")
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultResourceLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultResourceLabelService.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service.impl
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.manager.common.entity.label.LabelKeyValue
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+import com.webank.wedatasphere.linkis.manager.common.entity.resource.NodeResource
+import com.webank.wedatasphere.linkis.manager.common.utils.ResourceUtils
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineInstanceLabel
+import com.webank.wedatasphere.linkis.manager.label.service.ResourceLabelService
+import com.webank.wedatasphere.linkis.manager.persistence.ResourceLabelPersistence
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import scala.collection.JavaConversions._
+
+
+
+@Component
+class DefaultResourceLabelService extends ResourceLabelService with Logging {
+
+  @Autowired
+  private var resourceLabelPersistence: ResourceLabelPersistence = _
+
+  private val labelBuilderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
+
+
+  private def convertPersistenceLabel(label: Label[_]): PersistenceLabel = {
+    label match {
+      case persistenceLabel: PersistenceLabel =>
+        persistenceLabel
+      case _ =>
+        labelBuilderFactory.convertLabel[PersistenceLabel](label, classOf[PersistenceLabel])
+    }
+  }
+
+  /**
+    * 通过传入的Labels 查找所有和Resource相关的Label
+    * 包含CombineLabel，需要CombineLabel的所有Label Key 出现过
+    * 默认返回的是PersistenceLabel，方便加快性能
+    *
+    * @param labels
+    * @return
+    */
+  override def getResourceLabels(labels: util.List[Label[_]]): util.List[Label[_]] = {
+    val labelKeyValueList = labels.flatMap { label =>
+      val persistenceLabel = convertPersistenceLabel(label)
+      persistenceLabel.getValue.map { keyValue =>
+        new LabelKeyValue(keyValue._1, keyValue._2)
+      }
+    }.filter(null != _).toList
+    val resourceLabels = resourceLabelPersistence.getResourceLabels(labelKeyValueList)
+    resourceLabels.map{ label =>
+      val realyLabel:Label[_] = labelBuilderFactory.createLabel(label.getLabelKey, label.getValue)
+      realyLabel
+    }
+  }
+
+  /**
+    * 设置某个Label的资源数值，如果不存在add，存在对应的Label update
+    * lABEL 不存在需要插入Label先
+    *
+    * @param label
+    * @param resource
+    */
+  override def setResourceToLabel(label: Label[_], resource: NodeResource): Unit = {
+
+    resourceLabelPersistence.setResourceToLabel(convertPersistenceLabel(label), ResourceUtils.toPersistenceResource(resource))
+  }
+
+  /**
+    * 通过Label 返回对应的Resource
+    *
+    * @param label
+    * @return
+    */
+  override def getResourceByLabel(label: Label[_]): NodeResource = {
+    val persistenceResource = label match {
+      case p: PersistenceLabel => resourceLabelPersistence.getResourceByLabel(p)
+      case _ =>  resourceLabelPersistence.getResourceByLabel(convertPersistenceLabel(label))
+    }
+    if(persistenceResource.isEmpty){
+      null
+    } else {
+      // TODO: 判断取哪个resource
+      ResourceUtils.fromPersistenceResource(persistenceResource.get(0))
+    }
+  }
+
+  /**
+    * 清理Label的资源信息和记录
+    * 1. 清理Label对应的Resource信息
+    * 2. 清理包含改Label的CombinedLabel的Resource信息
+    *
+    * @param label
+    */
+  override def removeResourceByLabel(label: Label[_]): Unit = {
+    resourceLabelPersistence.removeResourceByLabel(convertPersistenceLabel(label))
+  }
+
+  override def removeResourceByLabels(labels: util.List[Label[_]]): Unit = {
+    resourceLabelPersistence.removeResourceByLabels(labels.map(convertPersistenceLabel))
+  }
+
+  override def setEngineConnResourceToLabel(label: Label[_], nodeResource: NodeResource): Unit = {
+    label match {
+      case label:EngineInstanceLabel =>
+        val resource = ResourceUtils.toPersistenceResource(nodeResource)
+        resource.setTicketId(label.getInstance())
+        resourceLabelPersistence.setResourceToLabel(convertPersistenceLabel(label), resource)
+      case _ =>
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultUserLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultUserLabelService.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.service.impl
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.constant.LabelConstant
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.exception.LabelErrorException
+import com.webank.wedatasphere.linkis.manager.label.service.UserLabelService
+import com.webank.wedatasphere.linkis.manager.persistence.LabelManagerPersistence
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+import scala.collection.JavaConversions._
+
+
+@Service
+class DefaultUserLabelService extends UserLabelService with Logging {
+
+  @Autowired
+  var labelManagerPersistence: LabelManagerPersistence = _
+
+  private val labelFactory = LabelBuilderFactoryContext.getLabelBuilderFactory
+
+  override def addLabelToUser(user: String, labels: util.List[Label[_]]): Unit = {
+    //逻辑基本同 addLabelsToNode
+    labels.foreach(addLabelToUser(user, _))
+  }
+
+  override def addLabelToUser(user: String, label: Label[_]): Unit = {
+    //instance 存在
+    //1.插入linkis_manager_label 表，这里表应该有唯一约束，key和valueStr　调用Persistence的addLabel即可，忽略duplicateKey异常
+    val persistenceLabel = labelFactory.convertLabel(label, classOf[PersistenceLabel])
+    Utils.tryAndWarn(labelManagerPersistence.addLabel(persistenceLabel))
+    //2.查询出当前label的id
+    val dbLabel = labelManagerPersistence
+      .getLabelsByKey(label.getLabelKey)
+      .find(_.getStringValue.equals(persistenceLabel.getStringValue))
+      .get
+    //3.根据usr 找出当前关联当前user的所有labels,看下有没和当前key重复的
+    // TODO: persistence 这里最好提供个一次查询的方法
+    val userRelationLabels = labelManagerPersistence.getLabelsByUser(user)
+    val duplicatedKeyLabel = userRelationLabels.find(_.getLabelKey.equals(dbLabel.getLabelKey))
+    //4.找出重复key,删除这个relation
+    duplicatedKeyLabel.foreach(l => {
+      labelManagerPersistence.removeLabelFromUser(user, util.Arrays.asList(l.getId))
+      userRelationLabels.toList.remove(duplicatedKeyLabel.get)
+    })
+    //5.插入新的relation 需要抛出duplicateKey异常，回滚
+    labelManagerPersistence.addLabelToUser(user, util.Arrays.asList(dbLabel.getId))
+    //6.重新查询，确认更新，如果没对上，抛出异常，回滚
+    userRelationLabels.add(dbLabel)
+    val newUserRelationLabels = labelManagerPersistence.getLabelsByUser(user)
+
+    if (newUserRelationLabels.size != userRelationLabels.size
+      || !newUserRelationLabels.map(_.getId).containsAll(userRelationLabels.map(_.getId))) {
+      throw new LabelErrorException(LabelConstant.LABEL_BUILDER_ERROR_CODE, "update label realtion failed")
+    }
+  }
+
+  override def removeLabelFromUser(user: String, labels: util.List[Label[_]]): Unit = {
+    //这里前提是表中保证了同个key，只会有最新的value保存在数据库中
+    val dbLabels = labelManagerPersistence.getLabelsByUser(user).map(l => (l.getLabelKey, l)).toMap
+    labelManagerPersistence.removeLabelFromUser(user, labels.map(l => dbLabels(l.getLabelKey).getId))
+  }
+
+  override def getUserByLabel(label: Label[_]): util.List[String] = {
+    // TODO: persistence 需要提供 key，valueString 找到相关label的方法
+    //1.找出当前label 对应的数据库的label
+    val labels = labelManagerPersistence.getLabelsByKey(label.getLabelKey).filter(_.getStringValue.equals(label.getStringValue))
+    //2.获取用户并且去重
+    labelManagerPersistence.getUserByLabels(labels.map(_.getId)).distinct
+  }
+
+  override def getUserByLabels(labels: util.List[Label[_]]): util.List[String] = {
+    //去重
+    labels.flatMap(getUserByLabel).distinct
+  }
+
+  override def getUserLabels(user: String): util.List[Label[_]] = {
+    labelManagerPersistence.getLabelsByUser(user).map { label =>
+      labelFactory.createLabel(label.getLabelKey, label.getValue)
+    }
+  }
+}


### PR DESCRIPTION
close #574

### What is the purpose of the change
Enhance the label management function of Linkis, so it can manage the Label of EngineConnManager and EngineConn

### Brief change log
Achieve the ability of LabelManager to manage EngineConnManager and EngineConn's Label

1.provide the addition, deletion, modification, and inspection of Label
2.provide the establishment of EngineConnManager and Label relationship mapping
3.provide the establishment of EngineConn and Label relationship mapping
4.provide  the interface provided to the outside to modify EngineConn and EngineConnManager