### PR TITLE
Add the linkis-manager-service-common module, it can be used by AppManager and ResourceManager

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/pom.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>dev-1.0.0</version>
+        <!-- <relativePath>../../pom.xml</relativePath>-->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-manager-service-common</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-manager-common</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-engineconn-plugin-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/label/LabelChecker.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/label/LabelChecker.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait LabelChecker {
+
+  def checkEngineLabel(labelList: util.List[Label[_]]): Boolean
+
+  def checkEMLabel(labelList: util.List[Label[_]]): Boolean
+
+  def checkCorrespondingLabel(labelList: util.List[Label[_]], clazz: Class[_]*): Boolean
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/label/LabelFilter.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/label/LabelFilter.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait LabelFilter {
+
+  def choseEngineLabel(labelList: util.List[Label[_]]): util.List[Label[_]]
+
+  def choseEMLabel(labelList: util.List[Label[_]]): util.List[Label[_]]
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/label/ManagerLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/label/ManagerLabelService.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.label
+
+import java.util
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait ManagerLabelService {
+
+  def isEngine(serviceInstance: ServiceInstance): Boolean
+
+  def isEngine(labels: util.List[Label[_]]): Boolean
+
+  def isEM(serviceInstance: ServiceInstance): Boolean
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/metrics/MetricsConverter.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/metrics/MetricsConverter.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.metrics
+
+import com.webank.wedatasphere.linkis.common.ServiceInstance
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.{NodeHealthy, NodeStatus}
+import com.webank.wedatasphere.linkis.manager.common.entity.metrics._
+import com.webank.wedatasphere.linkis.manager.common.entity.node.AMNode
+
+
+trait MetricsConverter {
+
+  def parseTaskInfo(nodeMetrics: NodeMetrics): NodeTaskInfo
+
+  def parseHealthyInfo(nodeMetrics: NodeMetrics): NodeHealthyInfo
+
+  def parseOverLoadInfo(nodeMetrics: NodeMetrics): NodeOverLoadInfo
+
+  def parseStatus(nodeMetrics: NodeMetrics): NodeStatus
+
+  def convertTaskInfo(nodeTaskInfo: NodeTaskInfo): String
+
+  def convertHealthyInfo(nodeHealthyInfo: NodeHealthyInfo): String
+
+  def convertOverLoadInfo(nodeOverLoadInfo: NodeOverLoadInfo): String
+
+  def convertStatus(nodeStatus: NodeStatus): Int
+
+  def fillMetricsToNode(amNode: AMNode, metrics: NodeMetrics): AMNode
+
+  def getInitMetric(serviceInstance: ServiceInstance): NodeMetrics = {
+    val nodeMetrics: AMNodeMetrics = new AMNodeMetrics
+
+    nodeMetrics.setStatus(NodeStatus.Starting.ordinal)
+
+    val nodeHealthyInfo: NodeHealthyInfo = new NodeHealthyInfo
+    nodeHealthyInfo.setNodeHealthy(NodeHealthy.Healthy)
+    nodeMetrics.setHealthy(convertHealthyInfo(nodeHealthyInfo))
+    nodeMetrics.setServiceInstance(serviceInstance)
+    nodeMetrics
+  }
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/EMNodPointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/EMNodPointer.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.EngineNode
+import com.webank.wedatasphere.linkis.manager.common.protocol.engine.EngineStopRequest
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnBuildRequest
+
+
+trait EMNodPointer extends NodePointer {
+
+  def createEngine(engineBuildRequest: EngineConnBuildRequest): EngineNode
+
+  def stopEngine(engineStopRequest: EngineStopRequest): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/EngineNodePointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/EngineNodePointer.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.protocol.{RequestEngineLock, RequestEngineUnlock}
+
+
+trait EngineNodePointer extends NodePointer {
+
+  def lockEngine(requestEngineLock: RequestEngineLock): Option[String]
+
+
+  def releaseLock(requestEngineUnlock: RequestEngineUnlock): Unit
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/NodePointer.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/NodePointer.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.common.entity.node.Node
+import com.webank.wedatasphere.linkis.manager.common.protocol.node.NodeHeartbeatMsg
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+
+
+trait NodePointer {
+
+
+  /**
+    * 与该远程指针关联的node信息
+    *
+    * @return
+    */
+  def getNode(): Node
+
+  /**
+    * 向对应的Node发送请求获取节点状态
+    *
+    * @return
+    */
+  def getNodeStatus(): NodeStatus
+
+  /**
+    * 向对应的Node发送请求获取节点心跳信息
+    *
+    * @return
+    */
+  def getNodeHeartbeatMsg(): NodeHeartbeatMsg
+
+  /**
+    * 向对应的Node发送Kill 请求
+    *
+    * @return
+    */
+  def stopNode(): Unit
+
+  /**
+    * 向对应的Node发送Label更新 请求
+    *
+    * @return
+    */
+  def updateLabels(labels: Array[Label[_]]): Unit
+
+  override def equals(obj: Any): Boolean = obj match {
+    case nodeB: Node => getNode().getServiceInstance.equals(nodeB.getServiceInstance)
+    case _ => false
+  }
+
+}

--- a/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/NodePointerBuilder.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-commons/linkis-manager-service-common/src/main/scala/com/webank/wedatasphere/linkis/manager/service/common/pointer/NodePointerBuilder.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.service.common.pointer
+
+import com.webank.wedatasphere.linkis.manager.common.entity.node.{EMNode, EngineNode}
+
+
+trait NodePointerBuilder {
+
+  def buildEMNodePointer(node: EMNode): EMNodPointer
+
+  def buildEngineNodePointer(node: EngineNode): EngineNodePointer
+
+}


### PR DESCRIPTION
close #600

### What is the purpose of the change
Add the linkis-manager-service-common module, it can be used by AppManager and ResourceManager

### Brief change log
The linkis-manager-service-common module is a common module in the service layer of the Manager service, providing common service interface definitions.It needs to provide some functions as follows.
1.Implement the interface of Label inspection and filtering
2.Provide the definition of the Metric parser interface
3.Provide the definition of EningeConn and EngineConnManager interface