### PR TITLE
add new linkis-code-orchestrator module

### DIFF
--- a/linkis-orchestrator/linkis-code-orchestrator/pom.xml
+++ b/linkis-orchestrator/linkis-code-orchestrator/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>1.0.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-code-orchestrator</artifactId>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-orchestrator-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.yml</exclude>
+                        <exclude>**/*.properties</exclude>
+                        <exclude>**/*.sh</exclude>
+                        <exclude>log4j2-spring.xml</exclude>
+                        <exclude>${basedir}/src/test/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/ast/CodeJob.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/ast/CodeJob.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.ast
+
+import com.webank.wedatasphere.linkis.orchestrator.plans.ast.{ASTContext, AbstractJob, Job, Stage}
+import com.webank.wedatasphere.linkis.orchestrator.plans.unit.CodeLogicalUnit
+
+class CodeJob(private var parents: Array[Job],
+              private var children: Array[Job]) extends AbstractJob {
+
+  private var name: String = _
+
+  private var submitUser: String = _
+
+  private var stages: Array[Stage] = _
+
+  private var astContext: ASTContext = _
+
+  private var codeLogicalUnit: CodeLogicalUnit = _
+
+  def getSubmitUser: String = submitUser
+
+  def setSubmitUser(submitUser: String): Unit = this.submitUser = submitUser
+
+  override def copyWithNewStages(stages: Array[Stage]): Job = {
+    this.stages = stages
+    val job = copy()
+    job
+  }
+
+  override def verboseString: String = toString
+
+  override def withNewChildren(children: Array[Job]): Unit = {
+    this.children = children
+  }
+
+  override def withNewParents(parents: Array[Job]): Unit = {
+    this.parents = parents
+  }
+
+  override def getASTContext: ASTContext = this.astContext
+
+  def setAstContext(astContext: ASTContext): Unit = this.astContext = astContext
+
+  def getCodeLogicalUnit: CodeLogicalUnit = this.codeLogicalUnit
+
+  def setCodeLogicalUnit(codeLogicalUnit: CodeLogicalUnit): Unit = this.codeLogicalUnit = codeLogicalUnit
+
+  def setName(name: String): Unit = this.name = name
+
+  override def getName: String = name
+
+  override def theSame(other: Job): Boolean = {
+    other match {
+      case codeJob: CodeJob =>
+        sameElements(getAllStages, codeJob.getAllStages)
+      case _ => false
+    }
+  }
+
+  private def sameElements(stages1: Array[Stage], stages2: Array[Stage]): Boolean = {
+    if (null == stages1 && null == stages2) {
+      true
+    } else if (null != stages1 && null != stages2 && stages1.length == stages2.length) {
+      val size = stages1.length
+      var flag = true
+      var index = 0
+      while (flag && index < size) {
+        flag = stages1(index).theSame(stages2(index))
+        index += 1
+      }
+      flag
+    } else {
+      false
+    }
+  }
+
+  override def getAllStages: Array[Stage] = stages
+
+  def setAllStages(stages: Array[Stage]): Unit = this.stages = stages
+
+  override def getParents: Array[Job] = this.parents
+
+  override def getChildren: Array[Job] = this.children
+
+  override protected def newNode(): Job = {
+    val job = new CodeJob(null, null)
+    job.setAstContext(getASTContext)
+    job.setCodeLogicalUnit(getCodeLogicalUnit)
+    job.setAllStages(this.stages)
+    job.setExecuteUser(getExecuteUser)
+    job.setSubmitUser(this.submitUser)
+    job.setLabels(this.getLabels)
+    job.setParams(this.getParams)
+    job.setPriority(this.getPriority)
+    job
+  }
+
+  override def toString = s"CodeJob($name, $submitUser, $codeLogicalUnit)"
+}

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/ast/CodeStage.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/ast/CodeStage.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.ast
+
+import com.webank.wedatasphere.linkis.orchestrator.plans.ast.{AbstractStage, Job, Stage}
+import com.webank.wedatasphere.linkis.orchestrator.plans.unit.CodeLogicalUnit
+
+class CodeStage(job: Job, private var parents: Array[Stage], private var children: Array[Stage]) extends AbstractStage {
+
+  private var codeLogicalUnit: CodeLogicalUnit = _
+
+  override def verboseString: String = ???
+
+  override def theSame(other: Stage): Boolean = {
+    other match {
+      case codeStage: CodeStage =>
+        val childrenSame = sameElements(getChildren, codeStage.getChildren)
+        val parentSame = sameElements(getParents, codeStage.getParents)
+        childrenSame && parentSame
+      case _ => false
+    }
+  }
+
+  private def sameElements(stages1: Array[Stage], stages2: Array[Stage]): Boolean = {
+    if (null == stages1 && null == stages2) {
+      true
+    } else if (null != stages1 && null != stages2 && stages1.length == stages2.length) {
+      val size = stages1.length
+      var flag = true
+      var index = 0
+      while (flag && index < size) {
+        flag = stages1(index).theSame(stages2(index))
+        index += 1
+      }
+      flag
+    } else {
+      false
+    }
+  }
+
+  override def getJob: Job = job
+
+  override def withNewChildren(children: Array[Stage]): Unit = {
+    this.children = children
+  }
+
+  override def withNewParents(parents: Array[Stage]): Unit = {
+    this.parents = parents
+  }
+
+
+  def getCodeLogicalUnit: CodeLogicalUnit = this.codeLogicalUnit
+
+  def setCodeLogicalUnit(codeLogicalUnit: CodeLogicalUnit): Unit = this.codeLogicalUnit = codeLogicalUnit
+
+  override def getParents: Array[Stage] = this.parents
+
+  override def getChildren: Array[Stage] = this.children
+
+  override protected def newNode(): Stage = {
+    val stage = new CodeStage(this.job, null, null)
+    stage.setCodeLogicalUnit(this.codeLogicalUnit)
+    stage.setAstContext(this.getASTContext)
+    stage
+  }
+}

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/execution/CodeExecutionFactory.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/execution/CodeExecutionFactory.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.execution
+
+import com.webank.wedatasphere.linkis.orchestrator.core.SessionState
+import com.webank.wedatasphere.linkis.orchestrator.execution.impl.AbstractExecutionFactory
+import com.webank.wedatasphere.linkis.orchestrator.execution.{TaskConsumer, TaskManager}
+import com.webank.wedatasphere.linkis.orchestrator.listener.OrchestratorListenerBusContext
+import com.webank.wedatasphere.linkis.orchestrator.strategy.async.AsyncTaskManager
+
+class CodeExecutionFactory extends AbstractExecutionFactory{
+
+  override protected def getTaskConsumer(sessionState: SessionState): TaskConsumer = {
+    val taskConsumer = new CodeReheaterNotifyTaskConsumer(sessionState.getReheater)
+    //OrchestratorListenerBusContext.getListenerBusContext().getOrchestratorAsyncListenerBus.addListener(taskConsumer)
+    sessionState.getOrchestratorAsyncListenerBus.addListener(taskConsumer)
+    taskConsumer
+  }
+
+  override protected def getTaskManager(): TaskManager = {
+    val taskManager = new AsyncTaskManager
+    //OrchestratorListenerBusContext.getListenerBusContext().getOrchestratorSyncListenerBus.addListener(taskManager)
+    taskManager
+  }
+
+}

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/execution/CodeReheaterNotifyTaskConsumer.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/execution/CodeReheaterNotifyTaskConsumer.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.execution
+
+import com.webank.wedatasphere.linkis.common.listener.Event
+import com.webank.wedatasphere.linkis.common.utils.Logging
+import com.webank.wedatasphere.linkis.orchestrator.reheater.{Reheater, ReheaterNotifyTaskConsumer}
+
+class CodeReheaterNotifyTaskConsumer(override val reheater: Reheater) extends ReheaterNotifyTaskConsumer with Logging {
+
+
+  override def onEventError(event: Event, t: Throwable): Unit = {
+
+  }
+
+  override def start(): Unit = {
+    val thread = new Thread(this, "CodeReheaterNotifyTaskConsumer")
+    thread.start()
+    info(s"start consumer ${getClass.getSimpleName} success")
+  }
+
+  override def close(): Unit = {
+
+    super.close()
+  }
+}

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/logical/CacheTask.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/logical/CacheTask.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.logical
+
+import com.webank.wedatasphere.linkis.orchestrator.plans.logical.{AbstractTask, Origin, Task}
+import com.webank.wedatasphere.linkis.orchestrator.utils.OrchestratorIDCreator
+
+class CacheTask(private var  parents: Array[Task],
+                private var children: Array[Task]) extends AbstractTask {
+
+  private var realTask: CodeLogicalUnitTask = _
+  private var id: String = _
+
+  override def getOrigin: Origin = getTaskDesc.getOrigin
+
+  override def getParents: Array[Task] = parents
+
+  override def getChildren: Array[Task] = children
+
+  override def withNewChildren(children: Array[Task]): Unit = modifyFamilyNodes(parents, children)
+
+  override def withNewParents(parents: Array[Task]): Unit = modifyFamilyNodes(parents, children)
+
+  private def modifyFamilyNodes(parents: Array[Task], children: Array[Task]): Unit = {
+    this.parents = parents
+    this.children = children
+  }
+
+  override protected def newNode(): Task = {
+    val cacheTask = new CacheTask(null, null)
+    cacheTask.setTaskDesc(getTaskDesc)
+    cacheTask.setRealTask(this.realTask)
+    cacheTask
+  }
+
+  def setRealTask(realTask: CodeLogicalUnitTask) = {
+    this.realTask = realTask
+  }
+
+  def getRealTask() = realTask
+
+  override def getId: String = {
+    if (null == id) synchronized {
+      if (null == id) {
+        id = OrchestratorIDCreator.getLogicalTaskIDCreator.nextID("cache")
+      }
+    }
+    id
+  }
+
+  override def theSame(other: Task): Boolean = if (super.equals(other)) true else if (other == null) false else other match {
+    case jobTask: CacheTask => jobTask.getParents.sameElements(parents) && jobTask.getChildren.sameElements(children) && jobTask.getTaskDesc == getTaskDesc
+    case _ => false
+  }
+
+}

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/logical/CodeLogicalUnitTask.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/logical/CodeLogicalUnitTask.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.logical
+
+import com.webank.wedatasphere.linkis.orchestrator.plans.logical.{AbstractTask, Origin, Task}
+import com.webank.wedatasphere.linkis.orchestrator.plans.unit.CodeLogicalUnit
+import com.webank.wedatasphere.linkis.orchestrator.utils.OrchestratorIDCreator
+
+class CodeLogicalUnitTask(private var  parents: Array[Task],
+                          private var children: Array[Task]) extends AbstractTask {
+
+  private var codeLogicalUnit: CodeLogicalUnit = _
+
+  private var id: String = _
+
+  override def getOrigin: Origin = getTaskDesc.getOrigin
+
+  override def withNewChildren(children: Array[Task]): Unit = modifyFamilyNodes(parents, children)
+
+  override def withNewParents(parents: Array[Task]): Unit = modifyFamilyNodes(parents, children)
+
+  private def modifyFamilyNodes(parents: Array[Task], children: Array[Task]): Unit = {
+    this.parents = parents
+    this.children = children
+  }
+
+  def getCodeLogicalUnit: CodeLogicalUnit = this.codeLogicalUnit
+
+  def setCodeLogicalUnit(codeLogicalUnit: CodeLogicalUnit): Unit = this.codeLogicalUnit = codeLogicalUnit
+
+  override def getId: String = {
+    if (null == id) synchronized {
+      if (null == id) {
+        id = OrchestratorIDCreator.getLogicalTaskIDCreator.nextID("codeLogical")
+      }
+    }
+    id
+  }
+
+  override def getParents: Array[Task] = parents
+
+  override def getChildren: Array[Task] = children
+
+  override protected def newNode(): Task = {
+    val codeLogicalUnitTask = new CodeLogicalUnitTask(null, null)
+    codeLogicalUnitTask.setTaskDesc(getTaskDesc)
+    codeLogicalUnitTask.setCodeLogicalUnit(getCodeLogicalUnit)
+    codeLogicalUnitTask
+  }
+}

--- a/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/logical/CodeLogicalUnitTaskDesc.scala
+++ b/linkis-orchestrator/linkis-code-orchestrator/src/main/scala/com/webank/wedatasphere/linkis/orchestrator/code/plans/logical/CodeLogicalUnitTaskDesc.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.orchestrator.code.plans.logical
+
+import com.webank.wedatasphere.linkis.orchestrator.plans.ast.Stage
+import com.webank.wedatasphere.linkis.orchestrator.plans.logical.{StageTaskDesc, TaskDesc}
+
+case class CodeLogicalUnitTaskDesc(override val stage: Stage) extends StageTaskDesc {
+  override val position: Int = 0
+
+  override def copy(): TaskDesc = CodeLogicalUnitTaskDesc(stage)
+}


### PR DESCRIPTION
## what is the purpose of this change?
fixed #734 
### The linkis-code-orchestrator module provides Linkis with the ability to orchestrate code tasks

The main functions are as follows:
1. Provide the entity class implementation of the Ast and Logical phases of the code task
2. Provides the implementation of the task consumer in the execution phase of the code task