### PR TITLE
Provided one-time engine module that support case of one-time task.

### DIFF
--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>linkis</artifactId>
+        <groupId>com.webank.wedatasphere.linkis</groupId>
+        <version>1.0.0</version>
+
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linkis-once-engineconn</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-executor-core</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-accessible-executor</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-resource-executor</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-callback-service</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-bml-client</artifactId>
+            <version>${linkis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-storage</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-message-scheduler</artifactId>
+            <version>${linkis.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.webank.wedatasphere.linkis</groupId>
+            <artifactId>linkis-cs-engine-support</artifactId>
+            <version>${linkis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>reflections</artifactId>
+                    <groupId>org.reflections</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!--<excludes>-->
+                    <!--<exclude>**/*.yml</exclude>-->
+                    <!--<exclude>**/*.properties</exclude>-->
+                    <!--<exclude>**/*.sh</exclude>-->
+                    <!--</excludes>-->
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+
+</project>

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/OnceExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/OnceExecutor.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.once.executor
+import java.util
+
+import com.webank.wedatasphere.linkis.bml.client.BmlClientFactory
+import com.webank.wedatasphere.linkis.common.conf.Configuration
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.engineconn.acessible.executor.entity.AccessibleExecutor
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.core.util.EngineConnUtils
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.{ExecutableExecutor, LabelExecutor, ResourceExecutor}
+import com.webank.wedatasphere.linkis.engineconn.once.executor.exception.OnceEngineConnErrorException
+import com.webank.wedatasphere.linkis.governance.common.protocol.task.RequestTask
+import com.webank.wedatasphere.linkis.governance.common.utils.OnceExecutorContentUtils
+import com.webank.wedatasphere.linkis.manager.common.entity.enumeration.NodeStatus
+import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.entity.{JobLabel, Label}
+import com.webank.wedatasphere.linkis.scheduler.executer.{AsynReturnExecuteResponse, ExecuteResponse}
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang.StringUtils
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.convert.wrapAsScala._
+
+
+trait OnceExecutor extends ExecutableExecutor[ExecuteResponse] with LabelExecutor with Logging {
+
+  private var executorLabels: util.List[Label[_]] = new util.ArrayList[Label[_]]
+
+  override def getExecutorLabels(): util.List[Label[_]] = executorLabels
+
+  override def setExecutorLabels(labels: util.List[Label[_]]): Unit = this.executorLabels = labels
+
+  override final def execute(engineCreationContext: EngineCreationContext): ExecuteResponse = {
+    val onceExecutorExecutionContext = createOnceExecutorExecutionContext(engineCreationContext)
+    onceExecutorExecutionContext.setLabels(executorLabels.toArray[Label[_]])
+    initOnceExecutorExecutionContext(onceExecutorExecutionContext)
+    execute(onceExecutorExecutionContext)
+  }
+
+  def execute(onceExecutorExecutionContext: OnceExecutorExecutionContext): ExecuteResponse
+
+  protected def createOnceExecutorExecutionContext(engineCreationContext: EngineCreationContext): OnceExecutorExecutionContext = {
+    val resource = engineCreationContext.getOptions.get(OnceExecutorContentUtils.ONCE_EXECUTOR_CONTENT_KEY)
+    if(StringUtils.isEmpty(resource)) throw new OnceEngineConnErrorException(12560, OnceExecutorContentUtils.ONCE_EXECUTOR_CONTENT_KEY + " is not exist.")
+    val bmlResource = OnceExecutorContentUtils.valueToResource(resource)
+    val bmlClient = BmlClientFactory.createBmlClient(engineCreationContext.getUser)
+    val contentStr = Utils.tryFinally {
+      val inputStream = bmlClient.downloadResource(engineCreationContext.getUser, bmlResource.getResourceId, bmlResource.getVersion).inputStream
+      Utils.tryFinally(IOUtils.toString(inputStream, Configuration.BDP_ENCODING.getValue))(IOUtils.closeQuietly(inputStream))
+    } (bmlClient.close())
+    val contentMap = EngineConnUtils.GSON.fromJson(contentStr, classOf[util.Map[String, Object]])
+    val onceExecutorContent = OnceExecutorContentUtils.mapToContent(contentMap)
+    new OnceExecutorExecutionContext(engineCreationContext, onceExecutorContent)
+  }
+
+  protected def initOnceExecutorExecutionContext(onceExecutorExecutionContext: OnceExecutorExecutionContext): Unit = {
+    val properties = onceExecutorExecutionContext.getOnceExecutorContent.getRuntimeMap
+    if (properties.containsKey(RequestTask.RESULT_SET_STORE_PATH)) {
+      onceExecutorExecutionContext.setStorePath(properties.get(RequestTask.RESULT_SET_STORE_PATH).toString)
+      info(s"ResultSet storePath: ${onceExecutorExecutionContext.getStorePath}.")
+    }
+    if(onceExecutorExecutionContext.getOnceExecutorContent.getExtraLabels != null) {
+      val extraLabels = LabelBuilderFactoryContext.getLabelBuilderFactory
+        .getLabels(onceExecutorExecutionContext.getOnceExecutorContent.getExtraLabels).toArray[Label[_]]
+      onceExecutorExecutionContext.setLabels(onceExecutorExecutionContext.getLabels ++: extraLabels)
+    }
+    onceExecutorExecutionContext.getLabels.foreach {
+      case jobLabel: JobLabel =>
+        onceExecutorExecutionContext.setJobId(jobLabel.getJobId)
+        info(s"JobId: ${onceExecutorExecutionContext.getJobId}.")
+      case _ =>
+    }
+  }
+
+  override def init(): Unit = tryReady()
+
+  override def tryReady(): Boolean = true
+
+}
+
+trait ManageableOnceExecutor extends AccessibleExecutor with OnceExecutor with ResourceExecutor {
+
+  private val notifyListeners = new ArrayBuffer[ExecuteResponse => Unit]
+  private var response: ExecuteResponse = _
+
+  override def tryReady(): Boolean = {
+    transition(NodeStatus.Running)
+    super.tryReady()
+  }
+
+  override def execute(onceExecutorExecutionContext: OnceExecutorExecutionContext): ExecuteResponse = {
+    submit(onceExecutorExecutionContext)
+    waitToRunning()
+    transition(NodeStatus.Busy)
+    new AsynReturnExecuteResponse {
+      override def notify(rs: ExecuteResponse => Unit): Unit = notifyListeners += rs
+    }
+  }
+
+  protected def submit(onceExecutorExecutionContext: OnceExecutorExecutionContext): Unit
+
+  protected def waitToRunning(): Unit
+
+  def waitForComplete(): Unit = notifyListeners synchronized wait()
+
+  def getResponse: ExecuteResponse = response
+
+  protected def setResponse(response: ExecuteResponse): Unit = this.response = response
+
+  override protected def onStatusChanged(fromStatus: NodeStatus, toStatus: NodeStatus): Unit = {
+    if(NodeStatus.isCompleted(toStatus)) {
+      Utils.tryFinally(notifyListeners.foreach(_(getResponse)))(notifyListeners synchronized notifyAll)
+    }
+    super.onStatusChanged(fromStatus, toStatus)
+  }
+
+  override def tryShutdown(): Boolean = {
+    this.ensureAvailable(transition(NodeStatus.ShuttingDown))
+    close()
+    true
+  }
+
+  def tryFailed(): Boolean = {
+    this.whenStatus(NodeStatus.ShuttingDown, transition(NodeStatus.Failed))
+    true
+  }
+
+  def trySucceed(): Boolean = {
+    this.ensureAvailable(transition(NodeStatus.Success))
+    true
+  }
+
+  override protected def callback(): Unit = {}
+
+  override def supportCallBackLogs(): Boolean = true
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/OnceExecutorExecutionContext.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/OnceExecutorExecutionContext.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.once.executor
+
+import com.webank.wedatasphere.linkis.common.io.resultset.{ResultSet, ResultSetWriter}
+import com.webank.wedatasphere.linkis.common.io.{FsPath, MetaData, Record}
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.executor.ExecutorExecutionContext
+import com.webank.wedatasphere.linkis.governance.common.entity.job.OnceExecutorContent
+import com.webank.wedatasphere.linkis.storage.resultset.{ResultSetFactory, ResultSetWriter}
+
+
+class OnceExecutorExecutionContext(engineCreationContext: EngineCreationContext,
+                                   onceExecutorContent: OnceExecutorContent) extends ExecutorExecutionContext {
+
+  private val resultSetFactory = ResultSetFactory.getInstance
+
+  def getEngineCreationContext: EngineCreationContext = engineCreationContext
+
+  def getOnceExecutorContent: OnceExecutorContent = onceExecutorContent
+
+  override protected def getResultSetByType(resultSetType: String): ResultSet[_ <: MetaData, _ <: Record] =
+    resultSetFactory.getResultSetByType(resultSetType)
+
+  override protected def getDefaultResultSetByType: String = resultSetFactory.getResultSetType(0)
+
+  override protected def newResultSetWriter(resultSet: ResultSet[_ <: MetaData, _ <: Record],
+                                            resultSetPath: FsPath,
+                                            alias: String): ResultSetWriter[_ <: MetaData, _ <: Record] =
+    ResultSetWriter.getResultSetWriter(resultSet, 0, resultSetPath, engineCreationContext.getUser)  // OnceExecutor doesn't need to cache resultSet.
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/creation/OnceExecutorFactory.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/creation/OnceExecutorFactory.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.once.executor.creation
+
+
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.engineconn.core.EngineConnObject
+import com.webank.wedatasphere.linkis.engineconn.core.creation.AbstractCodeLanguageLabelExecutorFactory
+import com.webank.wedatasphere.linkis.engineconn.once.executor.OnceExecutor
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.creation.{MultiExecutorEngineConnFactory, SingleExecutorEngineConnFactory}
+import com.webank.wedatasphere.linkis.manager.label.entity.Label
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineConnMode._
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineConnModeLabel
+
+
+trait OnceExecutorFactory extends AbstractCodeLanguageLabelExecutorFactory {
+
+  override protected def newExecutor(id: Int,
+                                     engineCreationContext: EngineCreationContext,
+                                     engineConn: EngineConn,
+                                     labels: Array[Label[_]]): OnceExecutor
+
+  override def canCreate(labels: Array[Label[_]]): Boolean =
+    super.canCreate(labels) || (labels.exists {
+      case engineConnModeLabel: EngineConnModeLabel =>
+        val mode: EngineConnMode = engineConnModeLabel.getEngineConnMode
+        Array(Once, Computation_With_Once, Once_With_Cluster).contains(mode)
+      case _ => false
+    } && onlyOneOnceExecutorFactory())
+
+  private def onlyOneOnceExecutorFactory(): Boolean = EngineConnObject.getEngineConnPlugin.getEngineConnFactory match {
+    case _: SingleExecutorEngineConnFactory with OnceExecutorFactory => true
+    case engineConnFactory: MultiExecutorEngineConnFactory =>
+      engineConnFactory.getExecutorFactories.count(_.isInstanceOf[OnceExecutorFactory]) == 1
+    case _ => false
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/exception/OnceEngineConnErrorException.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/exception/OnceEngineConnErrorException.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.once.executor.exception
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException
+
+
+class OnceEngineConnErrorException(errCode: Int, desc: String) extends ErrorException(errCode, desc) {
+
+  def this(errCode: Int, desc: String, cause: Throwable) = {
+    this(errCode, desc)
+    initCause(cause)
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/execution/OnceEngineConnExecution.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-clustered-engineconn/linkis-once-engineconn/src/main/scala/com/webank/wedatasphere/linkis/engineconn/once/executor/execution/OnceEngineConnExecution.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 WeBank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.engineconn.once.executor.execution
+
+import com.webank.wedatasphere.linkis.common.exception.LinkisException
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.engineconn.common.creation.EngineCreationContext
+import com.webank.wedatasphere.linkis.engineconn.common.engineconn.EngineConn
+import com.webank.wedatasphere.linkis.engineconn.core.execution.AbstractEngineConnExecution
+import com.webank.wedatasphere.linkis.engineconn.executor.entity.Executor
+import com.webank.wedatasphere.linkis.engineconn.once.executor.exception.OnceEngineConnErrorException
+import com.webank.wedatasphere.linkis.engineconn.once.executor.{ManageableOnceExecutor, OnceExecutor}
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.EngineConnMode._
+import com.webank.wedatasphere.linkis.manager.label.entity.engine.{CodeLanguageLabel, RunType}
+import com.webank.wedatasphere.linkis.scheduler.executer.{AsynReturnExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
+
+import scala.collection.convert.decorateAsScala._
+
+
+class OnceEngineConnExecution extends AbstractEngineConnExecution {
+
+  private var onceExecutor: OnceExecutor = _
+
+  override protected def doExecution(executor: Executor,
+                                     engineCreationContext: EngineCreationContext,
+                                     engineConn: EngineConn): Unit = executor match {
+    case onceExecutor: OnceExecutor =>
+      this.onceExecutor = onceExecutor
+      val response = Utils.tryCatch(onceExecutor.execute(engineCreationContext)) { t =>
+        dealException(s"${onceExecutor.getId} execute failed!", t)
+        return
+      }
+      dealResponse(response)
+      onceExecutor match {
+        case manageableOnceExecutor: ManageableOnceExecutor =>
+          manageableOnceExecutor.waitForComplete()
+        case _ =>
+      }
+    case _ => throw new OnceEngineConnErrorException(12560, s"${executor.getId} is not a OnceExecutor.")
+  }
+
+  private def dealResponse(resp: ExecuteResponse): Unit = resp match {
+    case resp: AsynReturnExecuteResponse =>
+      resp.notify(dealResponse)
+    case _: SuccessExecuteResponse =>
+      onceExecutor.trySucceed()
+    case ErrorExecuteResponse(message, t) =>
+      if(!onceExecutor.isClosed) {
+        dealException(message, t)
+      }
+  }
+
+  @throws[LinkisException]
+  private def dealException(msg: String, t: Throwable): Unit = {
+    onceExecutor.tryShutdown()
+    onceExecutor.tryFailed()
+    t match {
+      case t: LinkisException => throw t
+      case _ => throw new OnceEngineConnErrorException(12560, msg, t)
+    }
+  }
+
+  override protected def canExecute(engineCreationContext: EngineCreationContext): Boolean =
+    super.canExecute(engineCreationContext) || engineCreationContext.getLabels().asScala.exists {
+      case codeLanguageLabel: CodeLanguageLabel =>
+        codeLanguageLabel.getCodeType == RunType.JAR.toString
+      case _ => false
+    }
+
+  override protected def getSupportedEngineConnModes: Array[EngineConnMode] =
+    Array(Once, Computation_With_Once, Once_With_Cluster)
+
+  override protected def getReturnEngineConnModes: Array[EngineConnMode] = Array(Once)
+
+  /**
+    * Once should between on cluster and computation.
+    *
+    * @return
+    */
+  override def getOrder: Int = 2
+
+}

--- a/linkis-computation-governance/linkis-engineconn/pom.xml
+++ b/linkis-computation-governance/linkis-engineconn/pom.xml
@@ -35,6 +35,7 @@
         <module>linkis-engineconn-executor/accessible-executor</module>
         <module>linkis-engineconn-executor/resource-executor</module>
         <module>linkis-engineconn-executor/callback-service</module>
+        <module>linkis-clustered-engineconn/linkis-once-engineconn</module>
         <module>linkis-computation-engineconn</module>
     </modules>
 


### PR DESCRIPTION
### **What is the purpose of the change**
close #736
Provided linkis-once-engineconn module that support case of one-time task

### **Brief change log**
Defines and implements the one-off engine engine connector EngineConn and EngineConnFactory abstract interfaces.
Defines and implements the one-time engine general execution abstract interface OnceEngineConnExecution.
Defines the abstract interface OnceExecutor of the one-time engine Executor.