### PR TITLE
Update engine conn name

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.{TimeUnit, TimeoutException}
 import com.webank.wedatasphere.linkis.common.ServiceInstance
 import com.webank.wedatasphere.linkis.common.exception.LinkisRetryException
 import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
 import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf.ENGINE_CONN_MANAGER_SPRING_NAME
 import com.webank.wedatasphere.linkis.manager.am.conf.{AMConfiguration, EngineConnConfigurationService}
 import com.webank.wedatasphere.linkis.manager.am.exception.AMErrorException
@@ -130,8 +131,8 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
     getEngineNodeManager.updateEngineNode(oldServiceInstance, engineNode)
 
     //8. 新增 EngineConn的Label,添加engineConn的Alias
-    val engineConnAliasLabel = new AliasServiceInstanceLabel
-    engineConnAliasLabel.setAlias("EngineConn")
+    val engineConnAliasLabel = labelBuilderFactory.createLabel(classOf[AliasServiceInstanceLabel])
+    engineConnAliasLabel.setAlias(GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue)
     labelList.add(engineConnAliasLabel)
     nodeLabelService.addLabelsToNode(engineNode.getServiceInstance, LabelUtils.distinctLabel(labelList, fromEMGetEngineLabels(emNode.getLabels)))
     Utils.tryCatch{

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineCreateService.scala
@@ -130,7 +130,7 @@ class DefaultEngineCreateService extends AbstractEngineService with EngineCreate
     oldServiceInstance.setInstance(resourceTicketId)
     getEngineNodeManager.updateEngineNode(oldServiceInstance, engineNode)
 
-    //8. 新增 EngineConn的Label,添加engineConn的Alias
+    //8. Add EngineConn's Label, and add engineConn's AliasLabel
     val engineConnAliasLabel = labelBuilderFactory.createLabel(classOf[AliasServiceInstanceLabel])
     engineConnAliasLabel.setAlias(GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue)
     labelList.add(engineConnAliasLabel)

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineStopService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/am/service/engine/DefaultEngineStopService.scala
@@ -3,6 +3,7 @@ package com.webank.wedatasphere.linkis.manager.am.service.engine
 import java.util.concurrent.TimeUnit
 
 import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonConf
 import com.webank.wedatasphere.linkis.manager.am.conf.AMConfiguration
 import com.webank.wedatasphere.linkis.manager.common.protocol.engine.{EngineInfoClearRequest, EngineStopRequest, EngineSuicideRequest}
 import com.webank.wedatasphere.linkis.manager.label.service.NodeLabelService
@@ -21,6 +22,7 @@ class DefaultEngineStopService extends AbstractEngineService with EngineStopServ
 
   @Receiver
   override def stopEngine(engineStopRequest: EngineStopRequest, smc: ServiceMethodContext): Unit = {
+    engineStopRequest.getServiceInstance.setApplicationName(GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue)
     info(s" user ${engineStopRequest.getUser} prepare to stop engine ${engineStopRequest.getServiceInstance}")
     val node = getEngineNodeManager.getEngineNode(engineStopRequest.getServiceInstance)
     if (null == node) {


### PR DESCRIPTION
### What is the purpose of the change

Because engineConn applicationName is changed to linkis-cg-engineconn, modify Alisa's default engineConn name.

### Brief change log

1. Adjust the alias of the default engineConnAliasLabel as a configuration parameter
