### PR TITLE
Solve the recursive calling problem in SparkPythonExecutor's close method

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/spark/executor/SparkPythonExecutor.scala
+++ b/linkis-engineconn-plugins/engineconn-plugins/spark/src/main/scala/com/webank/wedatasphere/linkis/engineplugin/spark/executor/SparkPythonExecutor.scala
@@ -45,8 +45,8 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future, Promise}
 
 /**
-  *
-  */
+ *
+ */
 class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: Int) extends SparkEngineConnExecutor(sparkEngineSession.sparkContext, id) {
 
 
@@ -94,6 +94,7 @@ class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: In
   }
 
   override def close = {
+    info("python executor ready to close")
     if (process != null) {
       if (gatewayServer != null) {
         Utils.tryAndError(gatewayServer.shutdown())
@@ -104,7 +105,7 @@ class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: In
       process.destroy()
       process = null
     }
-    super.close()
+    info("python executor Finished to close")
   }
 
   override def getKind: Kind = PySpark()
@@ -126,11 +127,11 @@ class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: In
     val pythonClasspath = new StringBuilder(pythonPath)
 
     //
-     val files = sc.getConf.get("spark.files", "")
-     info("output spark files "+ sc.getConf.get("spark.files", ""))
-     if(StringUtils.isNotEmpty(files)) {
-       pythonClasspath ++= File.pathSeparator ++= files.split(",").filter(_.endsWith(".zip")).mkString(File.pathSeparator)
-     }
+    val files = sc.getConf.get("spark.files", "")
+    info("output spark files "+ sc.getConf.get("spark.files", ""))
+    if(StringUtils.isNotEmpty(files)) {
+      pythonClasspath ++= File.pathSeparator ++= files.split(",").filter(_.endsWith(".zip")).mkString(File.pathSeparator)
+    }
     //extra python package
     val pyFiles = sc.getConf.get("spark.application.pyFiles", "")
     logger.info(s"spark.application.pyFiles => ${pyFiles}")
@@ -189,7 +190,7 @@ class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: In
       this.engineExecutionContext = engineExecutionContext
       lineOutputStream.reset(engineExecutionContext)
       lineOutputStream.ready()
-//      info("Spark scala executor reset new engineExecutorContext!")
+      //      info("Spark scala executor reset new engineExecutorContext!")
     }
     lazyInitGageWay()
     this.jobGroup= jobGroup


### PR DESCRIPTION
### What is the purpose of the change
Remove the super.close() call in SparkPythonExecutor's close method to avoid recursive calling problem.
- close #817 

### Brief change log
- Remove the super.close() call in SparkPythonExecutor's close method.

### Verifying this change
This change is already covered by existing tests, such as (BVT).  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)