### PR TITLE
Modify Linkis's Eureka startup call method

### DIFF
--- a/eurekaServer/src/main/resources/application-eureka.yml
+++ b/eurekaServer/src/main/resources/application-eureka.yml
@@ -1,7 +1,6 @@
 spring:
   application:
     name: DataWorkCloud
-  profiles: eureka
 
 server:
   port: 20303
@@ -16,7 +15,7 @@ eureka:
       defaultZone: http://ip:port/eureka/
 #  server:
 #    enableSelfPreservation: false
-    enable-self-preservation: false
-    eviction-interval-timer-in-ms: 3000
   server:
     response-cache-update-interval-ms: 2000
+    enable-self-preservation: false
+    eviction-interval-timer-in-ms: 3000

--- a/eurekaServer/src/main/resources/application-eureka.yml
+++ b/eurekaServer/src/main/resources/application-eureka.yml
@@ -19,5 +19,3 @@ eureka:
     response-cache-update-interval-ms: 2000
     enable-self-preservation: false
     eviction-interval-timer-in-ms: 3000
-
-    tdddd: 222

--- a/eurekaServer/src/main/resources/application-eureka.yml
+++ b/eurekaServer/src/main/resources/application-eureka.yml
@@ -19,3 +19,5 @@ eureka:
     response-cache-update-interval-ms: 2000
     enable-self-preservation: false
     eviction-interval-timer-in-ms: 3000
+
+    tdddd: 222

--- a/eurekaServer/src/main/resources/application.yml
+++ b/eurekaServer/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: eureka


### PR DESCRIPTION
**Modify readson:**
    The default startup method calls applicaion-eureka.yml, causing the startup log to report an error:
_[nfoReplicator-0] cndstdRedirectingEurekaHttpClient: Request execution error com.sun.jersey.api.client.ClientHandlerException: java.net.ConnectException: Connection refused (Connection refused)_  
and 
_WARN 10147 --- [nfoReplicator-0] com.netflix.discovery.DiscoveryClient:DiscoveryClient_DATAWORKCLOUD/tp.runlion.priv:DataWorkCl
oud:20303 - registration failed Cannot execute request on any known server_

**Modify content:**
Added applicaion.yml and called application-eureka.yml content from the changed file