### PR TITLE
Fixed an automatic stop under the Docker container after startup

### DIFF
--- a/eurekaServer/bin/start-eureka.sh
+++ b/eurekaServer/bin/start-eureka.sh
@@ -25,7 +25,7 @@ fi
 
 export EUREKA_SERVER_JAVA_OPTS=" -Xmx$EUREKA_SERVER_HEAP_SIZE -XX:+UseG1GC  -Xloggc:$HOME/logs/linkis-gc.log"
 
-java $EUREKA_SERVER_JAVA_OPTS -cp $HOME/conf:$HOME/lib/* $EUREKA_SERVER_CLASS --spring.profiles.active=$profiles  2>&1 > $EUREKA_SERVER_LOG_PATH/linkis.out &
+nohup java $EUREKA_SERVER_JAVA_OPTS -cp $HOME/conf:$HOME/lib/* $EUREKA_SERVER_CLASS --spring.profiles.active=$profiles  2>&1 > $EUREKA_SERVER_LOG_PATH/linkis.out &
 pid=$!
 sleep 2
 if [[ -z "${pid}" ]]; then


### PR DESCRIPTION
### What is the purpose of the change
Eureka closes automatically when the container is started

### Brief change log
Modified the Eurekaserver stop script to add the nohup command

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.  
Start validation in Docker

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (yes)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)