### PR TITLE
new function, tenant label will not be delete when EM node restarted

### DIFF
--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/conf/LabelManagerConf.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/conf/LabelManagerConf.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.webank.wedatasphere.linkis.manager.label.conf
+
+import com.webank.wedatasphere.linkis.common.conf.CommonVars
+
+object LabelManagerConf {
+
+
+  val LONG_LIVED_LABEL = CommonVars("wds.linkis.label.node.long.lived.label.keys", "tenant").getValue
+
+}

--- a/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelService.scala
+++ b/linkis-computation-governance/linkis-manager/label-manager/src/main/scala/com/webank/wedatasphere/linkis/manager/label/service/impl/DefaultNodeLabelService.scala
@@ -23,6 +23,7 @@ import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
 import com.webank.wedatasphere.linkis.manager.common.entity.node.ScoreServiceInstance
 import com.webank.wedatasphere.linkis.manager.common.entity.persistence.PersistenceLabel
 import com.webank.wedatasphere.linkis.manager.label.builder.factory.LabelBuilderFactoryContext
+import com.webank.wedatasphere.linkis.manager.label.conf.LabelManagerConf
 import com.webank.wedatasphere.linkis.manager.label.entity.Label.ValueRelation
 import com.webank.wedatasphere.linkis.manager.label.entity.{Feature, Label, UserModifiable}
 import com.webank.wedatasphere.linkis.manager.label.score.NodeLabelScorer
@@ -157,7 +158,8 @@ class DefaultNodeLabelService extends NodeLabelService with Logging {
 
   @Transactional(rollbackFor = Array(classOf[Exception]))
   override def removeLabelsFromNode(instance: ServiceInstance): Unit = {
-    labelManagerPersistence.removeNodeLabels(instance, labelManagerPersistence.getLabelByServiceInstance(instance).map(_.getId))
+    val removeLabels = labelManagerPersistence.getLabelByServiceInstance(instance).filter(label => ! LabelManagerConf.LONG_LIVED_LABEL.contains( label.getLabelKey))
+    labelManagerPersistence.removeNodeLabels(instance, removeLabels.map(_.getId))
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change
fixed #848
1. Tenant label will not be delete when node restarted
在节点重启时，租户标签将不被清理
2. You can determine which labels can be retained when the node restarts by setting LabelManagerConf.LONG_LIVED_LABEL
可以通过设置LabelManagerConf.LONG_LIVED_LABEL来决定哪些label可以在节点重启时被保留

