### PR TITLE
Fix"Failed to generate hive.meta when hive meta URL contains special …

### DIFF
--- a/assembly-combined-package/config/linkis-env.sh
+++ b/assembly-combined-package/config/linkis-env.sh
@@ -48,9 +48,9 @@ ENGINECONN_ROOT_PATH=/appcom/tmp
 #RESULT_SET_ROOT_PATH=hdfs:///tmp/linkis ##hdfs:// required
 
 ### Provide the DB information of Hive metadata database.
-HIVE_META_URL=
-HIVE_META_USER=
-HIVE_META_PASSWORD=
+HIVE_META_URL=""
+HIVE_META_USER=""
+HIVE_META_PASSWORD=""
 
 ##YARN REST URL  spark engine required
 YARN_RESTFUL_URL=http://127.0.0.1:8088

--- a/assembly-combined-package/config/linkis-env.sh
+++ b/assembly-combined-package/config/linkis-env.sh
@@ -48,6 +48,7 @@ ENGINECONN_ROOT_PATH=/appcom/tmp
 #RESULT_SET_ROOT_PATH=hdfs:///tmp/linkis ##hdfs:// required
 
 ### Provide the DB information of Hive metadata database.
+### Attention! If there are special characters like "&", they need to be enclosed in quotation marks.
 HIVE_META_URL=""
 HIVE_META_USER=""
 HIVE_META_PASSWORD=""

--- a/conf/linkis-env.sh
+++ b/conf/linkis-env.sh
@@ -31,6 +31,7 @@ ENGINECONN_ROOT_PATH=/appcom/tmp   ## file://  required
 ENTRANCE_CONFIG_LOG_PATH=hdfs:///tmp/linkis/ ##file:// required
 
 ### Provide the DB information of Hive metadata database.
+### Attention! If there are special characters like "&", they need to be enclosed in quotation marks.
 HIVE_META_URL=""
 HIVE_META_USER=""
 HIVE_META_PASSWORD=""

--- a/conf/linkis-env.sh
+++ b/conf/linkis-env.sh
@@ -31,9 +31,9 @@ ENGINECONN_ROOT_PATH=/appcom/tmp   ## file://  required
 ENTRANCE_CONFIG_LOG_PATH=hdfs:///tmp/linkis/ ##file:// required
 
 ### Provide the DB information of Hive metadata database.
-HIVE_META_URL=
-HIVE_META_USER=
-HIVE_META_PASSWORD=
+HIVE_META_URL=""
+HIVE_META_USER=""
+HIVE_META_PASSWORD=""
 
 ##YARN REST URL  spark engine required
 YARN_RESTFUL_URL=http://127.0.0.1:8088


### PR DESCRIPTION
…characters #834"

### What is the purpose of the change
Fix "Failed to generate hive.meta when hive meta URL contains special characters。"
When the url contains an ampersand, assigning a value to HIVE_META_URL will result in null, because the ampersand has a special meaning in the shell. So add double quotation marks "" to change & into ordinary characters

修复"当 hive 元 URL 包含特殊字符时，无法生成 hive.meta"的问题。
当给HIVE_META_URL赋值会导致为空，因为&在shell中有特殊的含义，因此加上双引号"" 将&变为普通字符


### Brief change log
(for example:)
- change the linkis-env.sh

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)