### PR TITLE
fix weak password in linkis gateway

### DIFF
--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/com/webank/wedatasphere/linkis/gateway/config/GatewayConfiguration.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/com/webank/wedatasphere/linkis/gateway/config/GatewayConfiguration.scala
@@ -37,6 +37,7 @@ object GatewayConfiguration {
 
   val ADMIN_USER = CommonVars("wds.linkis.admin.user", "hadoop")
 
+  val ADMIN_PASSWORD = CommonVars("wds.linkis.admin.password", ADMIN_USER.getValue)
 
   val USERCONTROL_SWITCH_ON = CommonVars("wds.linkis.gateway.usercontrol_switch_on", false)
 

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/com/webank/wedatasphere/linkis/gateway/security/UserRestful.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/com/webank/wedatasphere/linkis/gateway/security/UserRestful.scala
@@ -227,7 +227,7 @@ abstract class UserPwdAbstractUserRestful extends AbstractUserRestful with Loggi
       }
       //      info("\npasswdOri :" + password)
 
-      if (GatewayConfiguration.ADMIN_USER.getValue.equals(userName.toString) && userName.toString.equals(password.toString)) {
+      if (GatewayConfiguration.ADMIN_USER.getValue.equals(userName.toString) && GatewayConfiguration.ADMIN_PASSWORD.getValue.equals(password)) {
         GatewaySSOUtils.setLoginUser(gatewayContext, userName.toString)
         "login successful(登录成功)！".data("userName", userName)
           .data("isAdmin", true)


### PR DESCRIPTION
### What is the purpose of the change

Fix the weak password in linkis gateway.

Related issues: #924.

### Brief change log
- Add a configuration item ADMIN_PASSWORD and a default strong password.
- Use ADMIN_PASSWORD to validate the password.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)