### PR TITLE
HIVE3.0 编译报错，使用WritableComparable代替具体的实现类接受返回，编译通过

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/java/com/webank/wedatasphere/linkis/engineplugin/hive/serde/CustomerDelimitedJSONSerDe.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/java/com/webank/wedatasphere/linkis/engineplugin/hive/serde/CustomerDelimitedJSONSerDe.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.*;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,8 +176,8 @@ public class CustomerDelimitedJSONSerDe extends LazySimpleSerDe {
         }
     }
     private static void writePrimitiveUTF8(OutputStream out, Object o,
-                                          PrimitiveObjectInspector oi, boolean escaped, byte escapeChar,
-                                          boolean[] needsEscape) throws IOException {
+                                           PrimitiveObjectInspector oi, boolean escaped, byte escapeChar,
+                                           boolean[] needsEscape) throws IOException {
 
         PrimitiveObjectInspector.PrimitiveCategory category = oi.getPrimitiveCategory();
         byte[] binaryData = null;
@@ -237,12 +238,12 @@ public class CustomerDelimitedJSONSerDe extends LazySimpleSerDe {
                 break;
             }
             case DATE: {
-                DateWritable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
+                WritableComparable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
                 binaryData = Base64.encodeBase64(String.valueOf(dw).getBytes());
                 break;
             }
             case TIMESTAMP: {
-                TimestampWritable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
+                WritableComparable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
                 binaryData = Base64.encodeBase64(String.valueOf(tw).getBytes());
                 break;
             }


### PR DESCRIPTION
### What is the purpose of the change
(For example: EngineConn-Core defines the the abstractions and interfaces of the EngineConn core functions.
The Engine Service in Linkis 0.x is refactored, EngineConn will handle the engine connection and session management.
Related issues: #590. )

### Brief change log
(for example:)
- Define the core abstraction and interfaces of the EngineConn Factory;
- Define the core abstraction and interfaces of Executor Manager.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  
(or)  
This change is already covered by existing tests, such as (please describe tests).  
(or)  
This change added tests and can be verified as follows:  
(example:)  
- Added tests for submit and execute all kinds of jobs to go through and verify the lifecycles of different EngineConns.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / no)
- Anything that affects deployment: (yes / no / don't know)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (yes / no)

### Documentation
- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)