### PR TITLE
HIVE3.0 编译报错，使用WritableComparable代替具体的实现类接受返回，编译通过

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/java/com/webank/wedatasphere/linkis/engineplugin/hive/serde/CustomerDelimitedJSONSerDe.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/java/com/webank/wedatasphere/linkis/engineplugin/hive/serde/CustomerDelimitedJSONSerDe.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.*;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,8 +176,8 @@ public class CustomerDelimitedJSONSerDe extends LazySimpleSerDe {
         }
     }
     private static void writePrimitiveUTF8(OutputStream out, Object o,
-                                          PrimitiveObjectInspector oi, boolean escaped, byte escapeChar,
-                                          boolean[] needsEscape) throws IOException {
+                                           PrimitiveObjectInspector oi, boolean escaped, byte escapeChar,
+                                           boolean[] needsEscape) throws IOException {
 
         PrimitiveObjectInspector.PrimitiveCategory category = oi.getPrimitiveCategory();
         byte[] binaryData = null;
@@ -237,12 +238,12 @@ public class CustomerDelimitedJSONSerDe extends LazySimpleSerDe {
                 break;
             }
             case DATE: {
-                DateWritable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
+                WritableComparable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
                 binaryData = Base64.encodeBase64(String.valueOf(dw).getBytes());
                 break;
             }
             case TIMESTAMP: {
-                TimestampWritable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
+                WritableComparable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
                 binaryData = Base64.encodeBase64(String.valueOf(tw).getBytes());
                 break;
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19589632/128604086-d460cd28-59ed-4699-a025-9d745a129f57.png)
hive3.1.2中DateWritable类已经废弃，已经使用DateWritableV2代替，我们可以使用DateWritableV2和DateWritable共同的父类WritableComparable去接收返回值，这样就可以兼容hive以前和以后的版本
case DATE: {
                WritableComparable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
                binaryData = Base64.encodeBase64(String.valueOf(dw).getBytes());
                break;
            }
            case TIMESTAMP: {
                WritableComparable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
                binaryData = Base64.encodeBase64(String.valueOf(tw).getBytes());
                break;
            }