### PR TITLE
Hive3.0 compiles and reports an error. Instead of the specific implementation class, WritableComparable accepts the return, and the compilation passes

### DIFF
--- a/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/java/com/webank/wedatasphere/linkis/engineplugin/hive/serde/CustomerDelimitedJSONSerDe.java
+++ b/linkis-engineconn-plugins/engineconn-plugins/hive/src/main/java/com/webank/wedatasphere/linkis/engineplugin/hive/serde/CustomerDelimitedJSONSerDe.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.*;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,8 +176,8 @@ public class CustomerDelimitedJSONSerDe extends LazySimpleSerDe {
         }
     }
     private static void writePrimitiveUTF8(OutputStream out, Object o,
-                                          PrimitiveObjectInspector oi, boolean escaped, byte escapeChar,
-                                          boolean[] needsEscape) throws IOException {
+                                           PrimitiveObjectInspector oi, boolean escaped, byte escapeChar,
+                                           boolean[] needsEscape) throws IOException {
 
         PrimitiveObjectInspector.PrimitiveCategory category = oi.getPrimitiveCategory();
         byte[] binaryData = null;
@@ -237,12 +238,12 @@ public class CustomerDelimitedJSONSerDe extends LazySimpleSerDe {
                 break;
             }
             case DATE: {
-                DateWritable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
+                WritableComparable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
                 binaryData = Base64.encodeBase64(String.valueOf(dw).getBytes());
                 break;
             }
             case TIMESTAMP: {
-                TimestampWritable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
+                WritableComparable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
                 binaryData = Base64.encodeBase64(String.valueOf(tw).getBytes());
                 break;
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19589632/128604086-d460cd28-59ed-4699-a025-9d745a129f57.png)
The DateWritable class in hive3.1.2 has been abandoned and replaced by DateWritableV2. We can use the common parent class of DateWritableV2 and DateWritable to receive the return value, so that it can be compatible with previous and future versions of hive
case DATE: {
                WritableComparable dw = ((DateObjectInspector) oi).getPrimitiveWritableObject(o);
                binaryData = Base64.encodeBase64(String.valueOf(dw).getBytes());
                break;
            }
            case TIMESTAMP: {
                WritableComparable tw = ((TimestampObjectInspector) oi).getPrimitiveWritableObject(o);
                binaryData = Base64.encodeBase64(String.valueOf(tw).getBytes());
                break;
            }