### PR TITLE
support both ip address and hostname for service discovery service call  #946

### DIFF
--- a/assembly-combined-package/assembly-combined/sbin/ext/linkis-common-start
+++ b/assembly-combined-package/assembly-combined/sbin/ext/linkis-common-start
@@ -29,6 +29,12 @@ then
   export SERVER_JAVA_OPTS=" -DserviceName=$SERVER_NAME -Xmx$SERVER_HEAP_SIZE -XX:+UseG1GC -Xloggc:$LINKIS_LOG_DIR/${SERVER_NAME}-gc.log $DEBUG_CMD "
 fi
 
+#SPRING_ARGS
+if [ "$EUREKA_PREFER_IP" == "true" ]; then
+  SPRING_ARGS="$SPRING_ARGS --eureka.instance.prefer-ip-address=true "
+  SPRING_ARGS="$SPRING_ARGS --eureka.instance.instance-id=\${spring.cloud.client.ip-address}:\${spring.application.name}:\${server.port}"
+fi
+
 ## conf dir
 export SERVER_CONF_PATH=$LINKIS_CONF_DIR
 

--- a/assembly-combined-package/assembly-combined/sbin/ext/linkis-mg-gateway
+++ b/assembly-combined-package/assembly-combined/sbin/ext/linkis-mg-gateway
@@ -36,6 +36,14 @@ fi
 
 export SERVER_CLASS=com.webank.wedatasphere.linkis.gateway.springcloud.LinkisGatewayApplication
 
+
+#SPRING_ARGS
+if [ "$EUREKA_PREFER_IP" == "true" ]; then
+  SPRING_ARGS="$SPRING_ARGS --eureka.instance.prefer-ip-address=true "
+  SPRING_ARGS="$SPRING_ARGS --eureka.instance.instance-id=\${spring.cloud.client.ip-address}:\${spring.application.name}:\${server.port} "
+fi
+
+
 ## conf dir
 export SERVER_CONF_PATH=$LINKIS_CONF_DIR
 

--- a/assembly-combined-package/config/linkis-env.sh
+++ b/assembly-combined-package/config/linkis-env.sh
@@ -85,7 +85,7 @@ SPARK_CONF_DIR=/appcom/config/spark-config
 ###  You can access it in your browser at the address below:http://${EUREKA_INSTALL_IP}:${EUREKA_PORT}
 #EUREKA_INSTALL_IP=127.0.0.1         # Microservices Service Registration Discovery Center
 EUREKA_PORT=20303
-EUREKA_PREFER_IP=true
+export EUREKA_PREFER_IP=true
 
 ###  Gateway install information
 #GATEWAY_INSTALL_IP=127.0.0.1

--- a/assembly-combined-package/config/linkis-env.sh
+++ b/assembly-combined-package/config/linkis-env.sh
@@ -85,7 +85,7 @@ SPARK_CONF_DIR=/appcom/config/spark-config
 ###  You can access it in your browser at the address below:http://${EUREKA_INSTALL_IP}:${EUREKA_PORT}
 #EUREKA_INSTALL_IP=127.0.0.1         # Microservices Service Registration Discovery Center
 EUREKA_PORT=20303
-export EUREKA_PREFER_IP=true
+export EUREKA_PREFER_IP=false
 
 ###  Gateway install information
 #GATEWAY_INSTALL_IP=127.0.0.1

--- a/linkis-commons/linkis-common/src/main/scala/com/webank/wedatasphere/linkis/common/conf/Configuration.scala
+++ b/linkis-commons/linkis-common/src/main/scala/com/webank/wedatasphere/linkis/common/conf/Configuration.scala
@@ -38,6 +38,8 @@ object Configuration extends Logging {
 
   val CLOUD_CONSOLE_VARIABLE_SPRING_APPLICATION_NAME = CommonVars("wds.linkis.console.variable.application.name", "linkis-ps-publicservice")
 
+  //read from env
+  val EUREKA_PREFER_IP = CommonVars("EUREKA_PREFER_IP", false).getValue
 
   def getGateWayURL(): String = {
     val url = GATEWAY_URL.getValue.trim

--- a/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
+++ b/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
@@ -142,7 +142,7 @@ public class DataWorkCloudApplication extends SpringBootServletInitializer {
         String hostName = Utils.getComputerName();
         String eurekaPreferIp = applicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address");
         //set value for future use,for example:CommonVars.apply("eureka.instance.prefer-ip-address","false").get
-        BDPConfiguration.set("eureka.instance.prefer-ip-address", eurekaPreferIp);
+        BDPConfiguration.set("EUREKA_PREFER_IP", eurekaPreferIp);
         if("true".equals(eurekaPreferIp)){
             hostName = applicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address");
             logger.info("using ip address replace hostname,beacause eureka.instance.prefer-ip-address:" + eurekaPreferIp);

--- a/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
+++ b/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
@@ -139,11 +139,17 @@ public class DataWorkCloudApplication extends SpringBootServletInitializer {
     }
 
     private static void initDWCApplication() {
+        String hostName = Utils.getComputerName();
+        String eurekaPreferIp = applicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address");
+        if(eurekaPreferIp.equals("true")){
+            hostName = applicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address");
+            logger.info("using ip address replace hostname,beacause eureka.instance.prefer-ip-address:" + eurekaPreferIp);
+        }
         serviceInstance = new ServiceInstance();
         serviceInstance.setApplicationName(applicationContext.getEnvironment().getProperty("spring.application.name"));
-        serviceInstance.setInstance(Utils.getComputerName() + ":" + applicationContext.getEnvironment().getProperty("server.port"));
+        serviceInstance.setInstance(hostName + ":" + applicationContext.getEnvironment().getProperty("server.port"));
         LinkisException.setApplicationName(serviceInstance.getApplicationName());
-        LinkisException.setHostname(Utils.getComputerName());
+        LinkisException.setHostname(hostName);
         LinkisException.setHostPort(Integer.parseInt(applicationContext.getEnvironment().getProperty("server.port")));
     }
 

--- a/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
+++ b/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
@@ -140,10 +140,8 @@ public class DataWorkCloudApplication extends SpringBootServletInitializer {
 
     private static void initDWCApplication() {
         String hostName = Utils.getComputerName();
-        String eurekaPreferIp = applicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address");
-        //set value for future use,for example:CommonVars.apply("eureka.instance.prefer-ip-address","false").get
-        BDPConfiguration.set("EUREKA_PREFER_IP", eurekaPreferIp);
-        if("true".equals(eurekaPreferIp)){
+        boolean eurekaPreferIp = Configuration.EUREKA_PREFER_IP();
+        if(eurekaPreferIp){
             hostName = applicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address");
             logger.info("using ip address replace hostname,beacause eureka.instance.prefer-ip-address:" + eurekaPreferIp);
         }

--- a/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
+++ b/linkis-commons/linkis-module/src/main/java/com/webank/wedatasphere/linkis/DataWorkCloudApplication.java
@@ -141,7 +141,9 @@ public class DataWorkCloudApplication extends SpringBootServletInitializer {
     private static void initDWCApplication() {
         String hostName = Utils.getComputerName();
         String eurekaPreferIp = applicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address");
-        if(eurekaPreferIp.equals("true")){
+        //set value for future use,for example:CommonVars.apply("eureka.instance.prefer-ip-address","false").get
+        BDPConfiguration.set("eureka.instance.prefer-ip-address", eurekaPreferIp);
+        if("true".equals(eurekaPreferIp)){
             hostName = applicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address");
             logger.info("using ip address replace hostname,beacause eureka.instance.prefer-ip-address:" + eurekaPreferIp);
         }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -132,8 +132,8 @@ trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
       "logging.config" -> s"classpath:${EnvConfiguration.LOG4J2_XML_FILE.getValue}") ++: discoveryMsgGenerator.generate(engineConnManagerEnv)
 
     //get value through CommonVars
-    val eurekaPreferIp = CommonVars.apply("eureka.instance.prefer-ip-address", "false").getValue
-    logger.info(s"eurekaPreferIp(eureka.instance.prefer-ip-address): " + eurekaPreferIp)
+    val eurekaPreferIp = CommonVars.apply("EUREKA_PREFER_IP", "false").getValue
+    logger.info(s"EUREKA_PREFER_IP: " + eurekaPreferIp)
     if("true".equals(eurekaPreferIp)){
       springConf = springConf + ("eureka.instance.prefer-ip-address" -> "true")
       springConf = springConf + ("eureka.instance.instance-id" -> "\\${spring.cloud.client.ip-address}:\\${spring.application.name}:\\${server.port}")

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -34,7 +34,6 @@ import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.commons.lang.StringUtils
 
-import java.util.regex.Pattern
 import scala.collection.JavaConversions._
 
 
@@ -132,9 +131,10 @@ trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
       "server.port" -> engineConnPort, "spring.profiles.active" -> "engineconn",
       "logging.config" -> s"classpath:${EnvConfiguration.LOG4J2_XML_FILE.getValue}") ++: discoveryMsgGenerator.generate(engineConnManagerEnv)
 
-    //暂时通过判断engineConnManagerHost是否为IP地址来判断是否使用eureka.instance.prefer-ip-address，后续需要通过engineConnManagerEnv.properties获取相关属性
-    logger.info(s"engineConnManagerHost:" + engineConnManagerEnv.engineConnManagerHost)
-    if(Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)").matcher(engineConnManagerEnv.engineConnManagerHost).find()){
+    //get value through CommonVars
+    val eurekaPreferIp = CommonVars.apply("eureka.instance.prefer-ip-address", "false").getValue
+    logger.info(s"eurekaPreferIp(eureka.instance.prefer-ip-address): " + eurekaPreferIp)
+    if("true".equals(eurekaPreferIp)){
       springConf = springConf + ("eureka.instance.prefer-ip-address" -> "true")
       springConf = springConf + ("eureka.instance.instance-id" -> "\\${spring.cloud.client.ip-address}:\\${spring.application.name}:\\${server.port}")
     }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -18,8 +18,7 @@ package com.webank.wedatasphere.linkis.ecm.core.launch
 
 import java.io.{File, InputStream, OutputStream}
 import java.net.ServerSocket
-
-import com.webank.wedatasphere.linkis.common.conf.CommonVars
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, Configuration}
 import com.webank.wedatasphere.linkis.common.exception.ErrorException
 import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
 import com.webank.wedatasphere.linkis.ecm.core.conf.ECMErrorCode
@@ -131,10 +130,9 @@ trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
       "server.port" -> engineConnPort, "spring.profiles.active" -> "engineconn",
       "logging.config" -> s"classpath:${EnvConfiguration.LOG4J2_XML_FILE.getValue}") ++: discoveryMsgGenerator.generate(engineConnManagerEnv)
 
-    //get value through CommonVars
-    val eurekaPreferIp = CommonVars.apply("EUREKA_PREFER_IP", "false").getValue
+    val eurekaPreferIp: Boolean = Configuration.EUREKA_PREFER_IP
     logger.info(s"EUREKA_PREFER_IP: " + eurekaPreferIp)
-    if("true".equals(eurekaPreferIp)){
+    if(eurekaPreferIp){
       springConf = springConf + ("eureka.instance.prefer-ip-address" -> "true")
       springConf = springConf + ("eureka.instance.instance-id" -> "\\${spring.cloud.client.ip-address}:\\${spring.application.name}:\\${server.port}")
     }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
@@ -18,8 +18,8 @@ package com.webank.wedatasphere.linkis.ecm.server.service.impl
 
 import java.io.File
 import java.nio.file.Paths
-
 import com.webank.wedatasphere.linkis.DataWorkCloudApplication
+import com.webank.wedatasphere.linkis.common.conf.Configuration
 import com.webank.wedatasphere.linkis.common.io.FsPath
 import com.webank.wedatasphere.linkis.common.utils.{Utils, ZipUtils}
 import com.webank.wedatasphere.linkis.ecm.core.engineconn.EngineConn
@@ -73,8 +73,8 @@ class BmlResourceLocalizationService extends ResourceLocalizationService {
           override val engineConnTempDirs: String = tmpDirs
 
           var hostName = Utils.getComputerName
-          val eurekaPreferIp = DataWorkCloudApplication.getApplicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address")
-          if("true".equals(eurekaPreferIp)){
+          val eurekaPreferIp = Configuration.EUREKA_PREFER_IP
+          if(eurekaPreferIp){
             hostName = DataWorkCloudApplication.getApplicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address")
           }
           override val engineConnManagerHost: String = hostName

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
@@ -74,7 +74,7 @@ class BmlResourceLocalizationService extends ResourceLocalizationService {
 
           var hostName = Utils.getComputerName
           val eurekaPreferIp = DataWorkCloudApplication.getApplicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address")
-          if(eurekaPreferIp.equals("true")){
+          if("true".equals(eurekaPreferIp)){
             hostName = DataWorkCloudApplication.getApplicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address")
           }
           override val engineConnManagerHost: String = hostName

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/com/webank/wedatasphere/linkis/ecm/server/service/impl/BmlResourceLocalizationService.scala
@@ -71,7 +71,13 @@ class BmlResourceLocalizationService extends ResourceLocalizationService {
           override val engineConnWorkDir: String = workDir
           override val engineConnLogDirs: String = logDirs
           override val engineConnTempDirs: String = tmpDirs
-          override val engineConnManagerHost: String = Utils.getComputerName
+
+          var hostName = Utils.getComputerName
+          val eurekaPreferIp = DataWorkCloudApplication.getApplicationContext.getEnvironment().getProperty("eureka.instance.prefer-ip-address")
+          if(eurekaPreferIp.equals("true")){
+            hostName = DataWorkCloudApplication.getApplicationContext.getEnvironment().getProperty("spring.cloud.client.ip-address")
+          }
+          override val engineConnManagerHost: String = hostName
           override val engineConnManagerPort: String = DataWorkCloudApplication.getApplicationContext.getEnvironment.getProperty("server.port")
           override val linkDirs: Map[String, String] = linkDirsP.toMap
           // TODO: 注册发现信息的配置化


### PR DESCRIPTION
### What is the purpose of the change
Linkis support ip address for service discovery service call，Related issues: #946 )

### Brief change log
- Modify sbin/ext/linkis-common-start 、sbin/ext/linkis-common-start，add SPRING_ARGS.
- Modify relate java/scals, depend on "eureka.instance.prefer-ip-address=true" ,replace hostname to ipAdddress.

### Verifying this change
This change is already covered by existing tests, such as (please describe tests).  
 
in config/linkis-env.sh ,set EUREKA_PREFER_IP=true, after install, view eureka page will see services name contains ipAddress,it  works!

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (yes )
- If yes, how is the feature documented? (not documented)
