### PR TITLE
Fix bug about PR #950

### DIFF
--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -27,7 +27,7 @@ import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonCon
 import com.webank.wedatasphere.linkis.governance.common.utils.{EngineConnArgumentsBuilder, EngineConnArgumentsParser}
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EnvConfiguration
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
-import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.Environment._
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.Environment.{EUREKA_PREFER_IP, _}
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.LaunchConstants._
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.{Environment, ProcessEngineConnLaunchRequest}
 import org.apache.commons.io.{FileUtils, IOUtils}
@@ -86,6 +86,7 @@ trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
       case HADOOP_CONF_DIR => putIfExists(HADOOP_CONF_DIR)
       case HIVE_CONF_DIR => putIfExists(HIVE_CONF_DIR)
       case RANDOM_PORT => environment.put(RANDOM_PORT.toString, findAvailPort().toString)
+      case EUREKA_PREFER_IP => environment.put(EUREKA_PREFER_IP.toString, Configuration.EUREKA_PREFER_IP.toString)
       case _ =>
     }
   }

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/com/webank/wedatasphere/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -27,7 +27,7 @@ import com.webank.wedatasphere.linkis.governance.common.conf.GovernanceCommonCon
 import com.webank.wedatasphere.linkis.governance.common.utils.{EngineConnArgumentsBuilder, EngineConnArgumentsParser}
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.conf.EnvConfiguration
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.entity.EngineConnLaunchRequest
-import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.Environment.{EUREKA_PREFER_IP, _}
+import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.Environment._
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.LaunchConstants._
 import com.webank.wedatasphere.linkis.manager.engineplugin.common.launch.process.{Environment, ProcessEngineConnLaunchRequest}
 import org.apache.commons.io.{FileUtils, IOUtils}

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/Environment.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/Environment.scala
@@ -22,7 +22,7 @@ object Environment extends Enumeration {
   type Environment = Value
   val USER, ECM_HOME, PWD, PATH, SHELL, JAVA_HOME, CLASSPATH,
       HADOOP_HOME, HADOOP_CONF_DIR, HIVE_CONF_DIR, LOG_DIRS, TEMP_DIRS,
-      ECM_HOST, ECM_PORT, RANDOM_PORT, SERVICE_DISCOVERY = Value
+      ECM_HOST, ECM_PORT, RANDOM_PORT, SERVICE_DISCOVERY,EUREKA_PREFER_IP = Value
 
   def variable(environment: Environment): String = LaunchConstants.EXPANSION_MARKER_LEFT + environment + LaunchConstants.EXPANSION_MARKER_RIGHT
 


### PR DESCRIPTION
### What is the purpose of the change
Fix bug about PR  #950, Related issues: #946.
Problem: engine can't get env EUREKA_PREFER_IP.
Fix: add EUREKA_PREFER_IP into ecm engine Environment.

### Brief change log
(for example:)
- Define EUREKA_PREFER_IP in Environment.scala
- set EUREKA_PREFER_IP  value in ProcessEngineConnLaunch.scala

### Verifying this change 
This change added tests and can be verified as follows:  
1. set EUREKA_PREFER_IP =true, then start all service.
2. through scripts or resful interface to call job excute. if the job success finish,it will be ok.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no)
- Anything that affects deployment: ( no  )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)