### PR TITLE
Optimize BML default download user default jvm user

### DIFF
--- a/linkis-public-enhancements/linkis-bml/linkis-bml-server/src/main/java/com/webank/wedatasphere/linkis/bml/restful/BmlProjectRestful.java
+++ b/linkis-public-enhancements/linkis-bml/linkis-bml-server/src/main/java/com/webank/wedatasphere/linkis/bml/restful/BmlProjectRestful.java
@@ -21,6 +21,7 @@ import com.webank.wedatasphere.linkis.bml.common.BmlPermissionDeniedException;
 import com.webank.wedatasphere.linkis.bml.common.BmlProjectNoEditException;
 import com.webank.wedatasphere.linkis.bml.common.BmlResourceExpiredException;
 import com.webank.wedatasphere.linkis.bml.common.BmlServerParaErrorException;
+import com.webank.wedatasphere.linkis.bml.conf.BmlServerConfiguration;
 import com.webank.wedatasphere.linkis.bml.service.*;
 import com.webank.wedatasphere.linkis.bml.util.HttpRequestHelper;
 import com.webank.wedatasphere.linkis.common.exception.ErrorException;
@@ -58,7 +59,7 @@ public class BmlProjectRestful {
     private static final String PROJECT_NAME_STR = "projectName";
     private static final String EDIT_USERS_STR = "editUsers";
     private static final String ACCESS_USERS_STR = "accessUsers";
-    public static final String DEFAULT_PROXY_USER = "hadoop";
+    public static final String DEFAULT_PROXY_USER = BmlServerConfiguration.BML_DEFAULT_PROXY_USER().getValue();
 
     @Autowired
     private BmlProjectService bmlProjectService;

--- a/linkis-public-enhancements/linkis-bml/linkis-bml-server/src/main/scala/com/webank/wedatasphere/linkis/bml/conf/BmlServerConfiguration.scala
+++ b/linkis-public-enhancements/linkis-bml/linkis-bml-server/src/main/scala/com/webank/wedatasphere/linkis/bml/conf/BmlServerConfiguration.scala
@@ -18,6 +18,7 @@ package com.webank.wedatasphere.linkis.bml.conf
 import java.util.concurrent.TimeUnit
 
 import com.webank.wedatasphere.linkis.common.conf.CommonVars
+import com.webank.wedatasphere.linkis.common.utils.Utils
 
 object BmlServerConfiguration {
   val BML_HDFS_PREFIX = CommonVars("wds.linkis.bml.hdfs.prefix", "/apps-data")
@@ -31,5 +32,8 @@ object BmlServerConfiguration {
   val BML_CLEAN_EXPIRED_TIME_TYPE = CommonVars("wds.linkis.bml.clean.time.type", TimeUnit.HOURS)
 
   val BML_MAX_THREAD_SIZE:CommonVars[Int] = CommonVars[Int]("wds.linkis.server.maxThreadSize", 30)
+
+
+  val BML_DEFAULT_PROXY_USER = CommonVars("wds.linkis.bml.default.proxy.user", Utils.getJvmUser)
 
 }


### PR DESCRIPTION
### What is the purpose of the change
Optimize BML default download user default jvm user

### Brief change log
(for example:)
- Optimize BML default download user default jvm user
- Add the configuration parameters of the default proxy download user：`wds.linkis.bml.default.proxy.user`

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)
