### PR TITLE
bug fix: "oldLogIdx == newLogIdx" always be false,beacase they both a…

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-application/src/main/java/com/webank/wedatasphere/linkis/cli/application/presenter/LinkisJobLogPresenter.java
+++ b/linkis-computation-governance/linkis-client/linkis-cli/linkis-cli-application/src/main/java/com/webank/wedatasphere/linkis/cli/application/presenter/LinkisJobLogPresenter.java
@@ -62,7 +62,7 @@ public class LinkisJobLogPresenter extends QueryBasedPresenter {
             Integer newLogIdx = 0;
             int retryCnt = 0;
             final int MAX_RETRY = 30; // continues fails for 300s, then exit thread
-            while (!(incLogModel.isJobCompleted() && oldLogIdx == newLogIdx)) {
+            while (!(incLogModel.isJobCompleted() && oldLogIdx.equals(newLogIdx))) {
                 try {
                     DWSResult jobInfoResult = clientDriver.queryJobInfo(incLogModel.getUser(), incLogModel.getTaskID());
                     incLogModel = updateModelByDwsResult(incLogModel, jobInfoResult);
@@ -82,7 +82,7 @@ public class LinkisJobLogPresenter extends QueryBasedPresenter {
                 }
                 retryCnt = 0;//reset counter
                 newLogIdx = incLogModel.getFromLine();
-                if (oldLogIdx == newLogIdx) {
+                if (oldLogIdx.equals(newLogIdx)) {
                     String msg = MessageFormat.format("Job is still running, status={0}, progress={1}",
                             incLogModel.getJobStatus(),
                             String.valueOf(incLogModel.getJobProgress() * 100) + "%");


### PR DESCRIPTION
What is the purpose of the change
In some extreme cases，linkis cli Print log stalled，until timeout。
bug fix: "oldLogIdx == newLogIdx" always be false,beacase they both are Object.

Brief change log
replace "oldLogIdx == newLogIdx" with oldLogIdx.equals(newLogIdx)

Verifying this change
Theoretically fine, without anyverification

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
Anything that affects deployment: no
The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: no
Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable