### PR TITLE
fix(linkis-storage): 

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/com/webank/wedatasphere/linkis/storage/excel/StorageExcelWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/com/webank/wedatasphere/linkis/storage/excel/StorageExcelWriter.scala
@@ -20,7 +20,7 @@ import java.io._
 import java.util
 
 import com.webank.wedatasphere.linkis.common.io.{MetaData, Record}
-import com.webank.wedatasphere.linkis.storage.domain.DataType
+import com.webank.wedatasphere.linkis.storage.domain.{BigIntType, DataType, IntType, LongType, ShortIntType, TinyIntType}
 import com.webank.wedatasphere.linkis.storage.resultset.table.{TableMetaData, TableRecord}
 import org.apache.commons.io.IOUtils
 import org.apache.poi.ss.usermodel._
@@ -69,7 +69,8 @@ class StorageExcelWriter(val charset: String, val sheetName: String, val dateFor
   def createCellStyle(dataType: DataType): CellStyle = {
     val style = workBook.createCellStyle()
     format = workBook.createDataFormat()
-    dataType.toString match {
+    dataType match {
+      case BigIntType | TinyIntType | ShortIntType | IntType | LongType  => style.setDataFormat(format.getFormat("0"))
       case _ => style.setDataFormat(format.getFormat("@"))
     }
     style
@@ -113,7 +114,10 @@ class StorageExcelWriter(val charset: String, val sheetName: String, val dateFor
     for (elem <- excelRecord) {
       val cell = tableBody.createCell(colunmPoint)
       val dataType = types.apply(colunmPoint)
-      cell.setCellValue(elem.toString) //read时候进行null替换等等
+      dataType match {
+        case BigIntType | TinyIntType | ShortIntType | IntType | LongType => cell.setCellValue(elem.toString.toDouble)
+        case _ => cell.setCellValue(elem.toString) //read时候进行null替换等等
+      }
       cell.setCellStyle(getCellStyle(dataType))
       colunmPoint += 1
     }

--- a/linkis-commons/linkis-storage/src/main/scala/com/webank/wedatasphere/linkis/storage/excel/StorageExcelWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/com/webank/wedatasphere/linkis/storage/excel/StorageExcelWriter.scala
@@ -115,7 +115,7 @@ class StorageExcelWriter(val charset: String, val sheetName: String, val dateFor
       val cell = tableBody.createCell(colunmPoint)
       val dataType = types.apply(colunmPoint)
       dataType match {
-        case BigIntType | TinyIntType | ShortIntType | IntType | LongType => cell.setCellValue(elem.toString.toDouble)
+        case BigIntType | TinyIntType | ShortIntType | IntType | LongType => cell.setCellValue(if (elem.toString.equals("NULL")) 0 else elem.toString.toDouble)
         case _ => cell.setCellValue(elem.toString) //read时候进行null替换等等
       }
       cell.setCellStyle(getCellStyle(dataType))


### PR DESCRIPTION
### What is the purpose of the change
业务同学经常下载数据成excel，但是下载下来的内容都是文本类型，导致一些数字类型的字段没法直接利用excel的功能去做一些统计，需要手动转一次，这个更新针对整型做了一些小的改进，因为无法确定float和double类型要保留的精度还是选择转成文本类型。
![image](https://user-images.githubusercontent.com/54495048/135383688-f6edaa60-b4a2-4c7c-97e6-65815338762c.png)


### Brief change log
Update (linkis-storage) StorageExcelWriter.createCellStyle
Update (linkis-storage) StorageExcelWriter.addRecord

### Verifying this change
(Please pick either of the following options)
This change is already covered by existing tests, such as (please describe tests).

### Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
Anything that affects deployment: ( no )
The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)

### Documentation
Does this pull request introduce a new feature? ( no)