### PR TITLE
Fix bug about PR #950, Related issues: #946.

### DIFF
--- a/assembly-combined-package/assembly-combined/conf/linkis-cg-engineconnmanager.properties
+++ b/assembly-combined-package/assembly-combined/conf/linkis-cg-engineconnmanager.properties
@@ -21,3 +21,6 @@ wds.linkis.engineconn.root.dir=/appcom/tmp
 ##Spring
 spring.server.port=9102
 
+##set engine environment in econn start script, such as EUREKA_PREFER_IP,the value of env will read from ecm host by key.
+#wds.linkis.engineconn.env.keys=EUREKA_PREFER_IP,
+

--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/com/webank/wedatasphere/linkis/governance/common/conf/GovernaceCommonConf.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/com/webank/wedatasphere/linkis/governance/common/conf/GovernaceCommonConf.scala
@@ -45,4 +45,11 @@ object GovernanceCommonConf {
   val ENGINE_DEFAULT_LIMIT = CommonVars("wds.linkis.engine.default.limit", 5000)
 
   val RESULT_SET_STORE_PATH = CommonVars("wds.linkis.resultSet.store.path", CommonVars[String]("wds.linkis.filesystem.hdfs.root.path", "hdfs:///tmp/linkis/").getValue)
+
+  val ENGINECONN_ENVKEYS = CommonVars("wds.linkis.engineconn.env.keys", "").getValue
+
+  def getEngineEnvValue(envKey:String): String = {
+    CommonVars(envKey, "").getValue
+  }
+
 }

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/Environment.scala
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-core/src/main/scala/com/webank/wedatasphere/linkis/manager/engineplugin/common/launch/process/Environment.scala
@@ -22,7 +22,7 @@ object Environment extends Enumeration {
   type Environment = Value
   val USER, ECM_HOME, PWD, PATH, SHELL, JAVA_HOME, CLASSPATH,
       HADOOP_HOME, HADOOP_CONF_DIR, HIVE_CONF_DIR, LOG_DIRS, TEMP_DIRS,
-      ECM_HOST, ECM_PORT, RANDOM_PORT, SERVICE_DISCOVERY = Value
+      ECM_HOST, ECM_PORT, RANDOM_PORT, SERVICE_DISCOVERY,ENGINECONN_ENVKEYS = Value
 
   def variable(environment: Environment): String = LaunchConstants.EXPANSION_MARKER_LEFT + environment + LaunchConstants.EXPANSION_MARKER_RIGHT
 


### PR DESCRIPTION
Problem: engine can't get env EUREKA_PREFER_IP.
Fix : add ENGINECONN_ENVKEYS into ecm engine Environment，so it will add custom env，such as EUREKA_PREFER_IP
if you want Transfer env EUREKA_PREFER_IP to engine ,set "wds.linkis.engineconn.env.keys=EUREKA_PREFER_IP" in linkis-cg-engineconnmanager.properties . you can add other custome envs, separate by “，”。

What is the purpose of the change
Related issues: #590.

Brief change log
Define EUREKA_PREFER_IP in Environment.scala
set EUREKA_PREFER_IP value in ProcessEngineConnLaunch.scala
Verifying this change
This change added tests and can be verified as follows:

set "wds.linkis.engineconn.env.keys=EUREKA_PREFER_IP" in linkis-cg-engineconnmanager.properties， then start all service.
through scripts or resful interface to call job excute. if the job success finish,it will be ok.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no)
Anything that affects deployment: ( no )
The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: ( no)
Documentation
Does this pull request introduce a new feature? no)
If yes, how is the feature documented? (not applicable )