### PR TITLE
Supprort request spnego enabled Yarn resource restful interface When Yarn enable kerberos

### DIFF
--- a/db/linkis_dml.sql
+++ b/db/linkis_dml.sql
@@ -216,8 +216,7 @@ INNER JOIN linkis_cg_manager_label label ON relation.engine_type_label_id = labe
 
 
 insert  into `linkis_cg_rm_external_resource_provider`(`id`,`resource_type`,`name`,`labels`,`config`) values
-(1,'Yarn','sit',NULL,'{\r\n\"rmWebAddress\": \"@YARN_RESTFUL_URL\",\r\n\"hadoopVersion\": \"2.7.2\",\r\n\"authorEnable\":false,\r\n\"user\":\"hadoop\",\r\n\"pwd\":\"123456\"\r\n}');
-
+(1,'Yarn','sit',NULL,'{\r\n\"rmWebAddress\": \"@YARN_RESTFUL_URL\",\r\n\"hadoopVersion\": \"2.7.2\",\r\n\"authorEnable\":false,\r\n\"user\":\"hadoop\",\r\n\"pwd\":\"123456\"\r\n,\r\n\"kerberosEnable\":true,\r\n\"principalName\":\"yarn\",\r\n\"keytabPath\":\"/etc/yarn.keytab\"\r\n,\r\n\"krb5Path\":\"/etc/krb5.conf\"\r\n}');
 -- errorcode 
 INSERT INTO linkis_ps_error_code (error_code,error_desc,error_regex,error_type) VALUES ('10001','会话创建失败，%s队列不存在，请检查队列设置是否正确','queue (\\S+) is not exists in YARN',0);
 INSERT INTO linkis_ps_error_code (error_code,error_desc,error_regex,error_type) VALUES ('10001','会话创建失败，用户%s不能提交应用到队列：%s，请联系提供队列给您的人员','User (\\S+) cannot submit applications to queue (\\S+)',0);

--- a/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/java/com/webank/wedatasphere/linkis/resourcemanager/utils/RequestKerberosUrlUtils.java
+++ b/linkis-computation-governance/linkis-manager/linkis-resource-manager/src/main/java/com/webank/wedatasphere/linkis/resourcemanager/utils/RequestKerberosUrlUtils.java
@@ -1,0 +1,134 @@
+package com.webank.wedatasphere.linkis.resourcemanager.utils;
+
+
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import java.io.IOException;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RequestKerberosUrlUtils {
+    public static Logger logger = LoggerFactory.getLogger(RequestKerberosUrlUtils.class);
+    private String principal;
+    private String keyTabLocation;
+
+
+    public RequestKerberosUrlUtils(String principal, String keyTabLocation) {
+        super();
+        this.principal = principal;
+        this.keyTabLocation = keyTabLocation;
+    }
+
+    public RequestKerberosUrlUtils(String principal, String keyTabLocation, boolean isDebug) {
+        this(principal, keyTabLocation);
+        if (isDebug) {
+            System.setProperty("sun.security.spnego.debug", "true");
+            System.setProperty("sun.security.krb5.debug", "true");
+        }
+    }
+
+    public RequestKerberosUrlUtils(String principal, String keyTabLocation, String krb5Location, boolean isDebug) {
+        this(principal, keyTabLocation, isDebug);
+        System.setProperty("java.security.krb5.conf", krb5Location);
+    }
+
+    private static HttpClient buildSpengoHttpClient() {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        Lookup<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create().
+                register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true)).build();
+        builder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
+        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(null, -1, null), new Credentials() {
+            @Override
+            public Principal getUserPrincipal() {
+                return null;
+            }
+
+            @Override
+            public String getPassword() {
+                return null;
+            }
+        });
+        builder.setDefaultCredentialsProvider(credentialsProvider);
+        CloseableHttpClient httpClient = builder.build();
+        return httpClient;
+    }
+
+    public HttpResponse callRestUrl(final String url, final String userId) {
+        logger.warn(String.format("Calling KerberosHttpClient %s %s %s", this.principal, this.keyTabLocation, url));
+        Configuration config = new Configuration() {
+            @SuppressWarnings("serial")
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                return new AppConfigurationEntry[]{new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, new HashMap<String, Object>() {
+                    {
+                        put("useTicketCache", "false");
+                        put("useKeyTab", "true");
+                        put("keyTab", keyTabLocation);
+                        //Krb5 in GSS API needs to be refreshed so it does not throw the error
+                        //Specified version of key is not available
+                        put("refreshKrb5Config", "true");
+                        put("principal", principal);
+                        put("storeKey", "true");
+                        put("doNotPrompt", "true");
+                        put("isInitiator", "true");
+                        put("debug", "false");
+                    }
+                })};
+            }
+        };
+        Set<Principal> princ = new HashSet<Principal>(1);
+        princ.add(new KerberosPrincipal(userId));
+        Subject sub = new Subject(false, princ, new HashSet<Object>(), new HashSet<Object>());
+        try {
+            //认证模块：Krb5Login
+            LoginContext lc = new LoginContext("Krb5Login", sub, null, config);
+            lc.login();
+            Subject serviceSubject = lc.getSubject();
+            return Subject.doAs(serviceSubject, new PrivilegedAction<HttpResponse>() {
+                HttpResponse httpResponse = null;
+
+                @Override
+                public HttpResponse run() {
+                    try {
+                        HttpUriRequest request = new HttpGet(url);
+                        HttpClient spnegoHttpClient = buildSpengoHttpClient();
+                        httpResponse = spnegoHttpClient.execute(request);
+                        return httpResponse;
+                    } catch (IOException ioe) {
+                        ioe.printStackTrace();
+                    }
+                    return httpResponse;
+                }
+            });
+        } catch (Exception le) {
+            le.printStackTrace();
+        }
+        return null;
+    }
+}
+


### PR DESCRIPTION
Problem Description:
The company's big data platform environment is HDP, and Kerberos is enabled. By default, it cannot directly access http://xx.xx.xx.xx:8088 of yarn. When I use spark engine, the Existing certification methods can not meet the requirements and always report errors

Solution:
add utils to solution of httpclient requets to request kerberos web