### PR TITLE
Deliever original jobId in linkis-entrance module to EngineConn and LinkisManager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ on:
   push:
   pull_request:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
 jobs:
   build:
 

--- a/.github/workflows/check_third_party_dependencies.yml
+++ b/.github/workflows/check_third_party_dependencies.yml
@@ -19,6 +19,9 @@ name: third-party dependencies check
 
 on: [push, pull_request]
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/assembly-combined-package/assembly-combined/sbin/ext/linkis-ps-publicservice
+++ b/assembly-combined-package/assembly-combined/sbin/ext/linkis-ps-publicservice
@@ -23,7 +23,7 @@ export SERVER_SUFFIX="linkis-public-enhancements/linkis-ps-publicservice"
 
 #export DEBUG_PORT=
 
-export SERVER_CLASS=org.apache.linkis.jobhistory.LinkisPublicServiceApp
+export SERVER_CLASS=org.apache.linkis.filesystem.LinkisPublicServiceApp
 
 export COMMON_START_BIN=$LINKIS_HOME/sbin/ext/linkis-common-start
 if [[ ! -f "${COMMON_START_BIN}" ]]; then

--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/Sender.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/Sender.scala
@@ -18,11 +18,11 @@
 package org.apache.linkis.rpc
 
 import java.util
-
 import org.apache.linkis.DataWorkCloudApplication
 import org.apache.linkis.common.ServiceInstance
 import org.apache.linkis.rpc.conf.RPCConfiguration
 import org.apache.linkis.rpc.sender.SpringMVCRPCSender
+import org.apache.linkis.rpc.utils.RPCUtils
 
 import scala.concurrent.duration.Duration
 
@@ -72,11 +72,13 @@ object Sender {
   private val serviceInstanceToSenders = new util.HashMap[ServiceInstance, Sender]
   def getSender(applicationName: String): Sender = getSender(ServiceInstance(applicationName, null))
   def getSender(serviceInstance: ServiceInstance): Sender = {
-    if(RPCConfiguration.ENABLE_PUBLIC_SERVICE.getValue && RPCConfiguration.PUBLIC_SERVICE_LIST.contains(serviceInstance.getApplicationName))
+    if (RPCUtils.isPublicService(serviceInstance.getApplicationName)) {
       serviceInstance.setApplicationName(RPCConfiguration.PUBLIC_SERVICE_APPLICATION_NAME.getValue)
-    if(!serviceInstanceToSenders.containsKey(serviceInstance)) serviceInstanceToSenders synchronized {
-      if(!serviceInstanceToSenders.containsKey(serviceInstance))
+    }
+    if (!serviceInstanceToSenders.containsKey(serviceInstance)) serviceInstanceToSenders synchronized {
+      if (!serviceInstanceToSenders.containsKey(serviceInstance)) {
         serviceInstanceToSenders.put(serviceInstance, senderFactory.createSender(serviceInstance))
+      }
     }
     serviceInstanceToSenders.get(serviceInstance)
   }

--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/conf/RPCConfiguration.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/conf/RPCConfiguration.scala
@@ -40,7 +40,7 @@ object RPCConfiguration {
   val ENABLE_PUBLIC_SERVICE = CommonVars("wds.linkis.gateway.conf.enable.publicservice", true)
   val PUBLIC_SERVICE_APPLICATION_NAME = CommonVars("wds.linkis.gateway.conf.publicservice.name", "linkis-ps-publicservice")
   val PUBLIC_SERVICE_LIST = CommonVars("wds.linkis.gateway.conf.publicservice.list", "query,jobhistory,application,configuration,filesystem,udf,variable,microservice,errorcode,bml,datasource").getValue.split(",")
-
+  val PUBLIC_SERVICE_APP_PREFIX = CommonVars("wds.linkis.gateway.conf.publicservice.name", "linkis-ps-").getValue
   val BDP_RPC_INSTANCE_ALIAS_SERVICE_REFRESH_INTERVAL = CommonVars("wds.linkis.rpc.instancealias.refresh.interval", new TimeType("3s"))
 
   val CONTEXT_SERVICE_APPLICATION_NAME = CommonVars("wds.linkis.gateway.conf.contextservice.name", "linkis-ps-cs")

--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/utils/RPCUtils.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/utils/RPCUtils.scala
@@ -19,7 +19,6 @@ package org.apache.linkis.rpc.utils
 
 import java.lang.reflect.UndeclaredThrowableException
 import java.net.ConnectException
-
 import com.netflix.client.ClientException
 import org.apache.linkis.common.ServiceInstance
 import org.apache.linkis.rpc.exception.NoInstanceExistsException
@@ -27,6 +26,7 @@ import org.apache.linkis.rpc.sender.{SpringCloudFeignConfigurationCache, SpringM
 import org.apache.linkis.rpc.{BaseRPCSender, Sender}
 import feign.RetryableException
 import org.apache.commons.lang.StringUtils
+import org.apache.linkis.rpc.conf.RPCConfiguration
 
 import scala.collection.JavaConversions._
 
@@ -70,6 +70,19 @@ object RPCUtils {
         ServiceInstance(baseRPCSender.getApplicationName, null)
       case _ =>
         null
+    }
+  }
+
+  def isPublicService(appName: String): Boolean = {
+    if (! RPCConfiguration.ENABLE_PUBLIC_SERVICE.getValue || StringUtils.isBlank(appName)) {
+      return false
+    }
+    val appNameLower = appName.toLowerCase()
+    if (appNameLower.startsWith(RPCConfiguration.PUBLIC_SERVICE_APP_PREFIX)) {
+      val serviceName = appNameLower.replaceFirst(RPCConfiguration.PUBLIC_SERVICE_APP_PREFIX, "")
+      RPCConfiguration.PUBLIC_SERVICE_LIST.exists(_.equalsIgnoreCase(serviceName))
+    } else {
+      false
     }
   }
 

--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/JobUtils.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/JobUtils.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.governance.common.utils
+
+import org.apache.linkis.governance.common.constant.job.JobRequestConstants
+import org.apache.linkis.protocol.utils.TaskUtils
+
+import java.util;
+
+object JobUtils {
+
+  def getJobIdFromMap(map: util.Map[String, Object]): String = {
+    if (null != map && map.containsKey(JobRequestConstants.JOB_ID)) {
+      val value = map.get(JobRequestConstants.JOB_ID)
+      if (null != value) {
+        return value.toString
+      }
+    }
+    null
+  }
+
+}

--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
@@ -42,6 +42,7 @@ import org.apache.linkis.engineconn.executor.listener.event.EngineConnSyncEvent
 import org.apache.linkis.governance.common.entity.ExecutionNodeStatus
 import org.apache.linkis.governance.common.exception.engineconn.{EngineConnExecutorErrorCode, EngineConnExecutorErrorException}
 import org.apache.linkis.governance.common.protocol.task._
+import org.apache.linkis.governance.common.utils.JobUtils
 import org.apache.linkis.manager.common.entity.enumeration.NodeStatus
 import org.apache.linkis.manager.common.protocol.resource.ResponseTaskYarnResource
 import org.apache.linkis.manager.label.entity.Label
@@ -130,6 +131,8 @@ class TaskExecutionServiceImpl extends TaskExecutionService with Logging with Re
       if (null != retry) retry.asInstanceOf[Boolean]
       else false
     }
+    val jobId = JobUtils.getJobIdFromMap(requestTask.getProperties)
+    logger.info(s"Received job with id ${jobId}.")
     val task = new CommonEngineConnTask(String.valueOf(taskId), retryAble)
     task.setCode(requestTask.getCode)
     task.setProperties(requestTask.getProperties)

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
@@ -187,7 +187,8 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
             runtimeMapOri = TaskUtils.getRuntimeMap(getParams());
         }
         if (!runtimeMapOri.containsKey(JobRequestConstants.JOB_ID())) {
-            runtimeMapOri.put(JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
+            runtimeMapOri.put(
+                    JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
         }
         Map<String, String> runtimeMapTmp = new HashMap<>();
         for (Map.Entry<String, Object> entry : runtimeMapOri.entrySet()) {

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/job/EntranceExecutionJob.java
@@ -25,6 +25,7 @@ import org.apache.linkis.entrance.execute.EntranceJob;
 import org.apache.linkis.entrance.log.*;
 import org.apache.linkis.entrance.persistence.PersistenceManager;
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf;
+import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 import org.apache.linkis.governance.common.entity.job.SubJobDetail;
 import org.apache.linkis.governance.common.entity.job.SubJobInfo;
 import org.apache.linkis.governance.common.protocol.task.RequestTask$;
@@ -169,6 +170,12 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
         // add resultSet path root
         Map<String, String> starupMapTmp = new HashMap<String, String>();
         Map<String, Object> starupMapOri = TaskUtils.getStartupMap(getParams());
+        if (starupMapOri.isEmpty()) {
+            TaskUtils.addStartupMap(getParams(), starupMapOri);
+        }
+        if (!starupMapOri.containsKey(JobRequestConstants.JOB_REQUEST_LIST())) {
+            starupMapOri.put(JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
+        }
         for (Map.Entry<String, Object> entry : starupMapOri.entrySet()) {
             if (null != entry.getKey() && null != entry.getValue()) {
                 starupMapTmp.put(entry.getKey(), entry.getValue().toString());
@@ -178,6 +185,9 @@ public class EntranceExecutionJob extends EntranceJob implements LogHandler {
         if (null == runtimeMapOri || runtimeMapOri.isEmpty()) {
             TaskUtils.addRuntimeMap(getParams(), new HashMap<>());
             runtimeMapOri = TaskUtils.getRuntimeMap(getParams());
+        }
+        if (!runtimeMapOri.containsKey(JobRequestConstants.JOB_ID())) {
+            runtimeMapOri.put(JobRequestConstants.JOB_ID(), String.valueOf(getJobRequest().getId()));
         }
         Map<String, String> runtimeMapTmp = new HashMap<>();
         for (Map.Entry<String, Object> entry : runtimeMapOri.entrySet()) {

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/assembly/distribution.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/assembly/distribution.xml
@@ -60,8 +60,6 @@
                 <exclude>org.springframework:spring-beans:jar</exclude>
                 <exclude>org.springframework:spring-core:jar</exclude>
                 <exclude>org.springframework:spring-jcl:jar</exclude>
-                <exclude>org.springframework:spring-tx:jar</exclude>
-
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/linkis-engineconn-plugin-framework/linkis-engineconn-plugin-server/src/main/assembly/distribution.xml
@@ -47,7 +47,6 @@
                 <exclude>org.springframework:spring-beans:jar</exclude>
                 <exclude>org.springframework:spring-core:jar</exclude>
                 <exclude>org.springframework:spring-jcl:jar</exclude>
-                <exclude>org.springframework:spring-tx:jar</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/linkis-public-enhancements/linkis-context-service/linkis-cs-server/src/main/assembly/distribution.xml
+++ b/linkis-public-enhancements/linkis-context-service/linkis-cs-server/src/main/assembly/distribution.xml
@@ -44,7 +44,6 @@
                 <exclude>org.springframework:spring-beans:jar</exclude>
                 <exclude>org.springframework:spring-core:jar</exclude>
                 <exclude>org.springframework:spring-jcl:jar</exclude>
-                <exclude>org.springframework:spring-tx:jar</exclude>
             </excludes>
 
         </dependencySet>


### PR DESCRIPTION
### What is the purpose of the change
close #1938 
Deliever original jobId in linkis-entrance module to EngineConn and LinkisManager.

### Brief change log
(for example:)
- put original jobId to both startup map and runtime map in linkis-entrance.
- get original jobId in linkis-computation-engineconn.

### Verifying this change
(Please pick either of the following options)  
This change is a trivial rework / code cleanup without any test coverage.  
(yes)  
This change is already covered by existing tests, such as (please describe tests).  
(no)  
This change added tests and can be verified as follows:  


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no )
- The MGS(Microservice Governance Services), i.e., Spring Cloud Gateway, OpenFeign, Eureka.: (no)

### Documentation
- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not applicable)