### PR TITLE
[ISSUE-2395]SynchronossPartHttpMessageReader should only create temp directory when needed/CVE-2022-22965

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <linkis.version>1.1.3</linkis.version>
         <hadoop.version>2.7.2</hadoop.version>
         <zookeeper.version>3.5.9</zookeeper.version>
-        <spring.boot.version>2.3.12.RELEASE</spring.boot.version>
+        <spring.boot.version>2.6.9</spring.boot.version>
         <guava.version>30.0-jre</guava.version>
         <gson.version>2.8.9</gson.version>
         <scala.version>2.11.12</scala.version>


### PR DESCRIPTION

https://github.com/spring-projects/spring-framework/issues/27092
1 . SynchronossPartHttpMessageReader should only create temp directory when needed 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22965
2. A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE) via data binding. The specific exploit requires the application to run on Tomcat as a WAR deployment. If the application is deployed as a Spring Boot executable jar, i.e. the default, it is not vulnerable to the exploit. However, the nature of the vulnerability is more general, and there may be other ways to exploit it.


### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)

