### PR TITLE
When submitting, parameter values containing spaces are supported

### DIFF
--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/DWCArgumentsParser.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/DWCArgumentsParser.scala
@@ -17,6 +17,8 @@
 
 package org.apache.linkis.common.conf
 
+import org.apache.linkis.common.utils.{ParameterUtils, Logging}
+
 import org.apache.commons.lang3.StringUtils
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
@@ -34,24 +36,13 @@ object DWCArgumentsParser {
   def getDWCOptionMap: Map[String, String] = dwcOptionMap
 
   def parse(args: Array[String]): DWCArgumentsParser = {
-    val keyValueRegex = "([^=]+)=(.+)".r
-    var i = 0
     val optionParser = new DWCArgumentsParser
-    while (i < args.length - 1) {
-      args(i) match {
-        case DWC_CONF | SPRING_CONF =>
-          args(i + 1) match {
-            case keyValueRegex(key, value) =>
-              optionParser.setConf(args(i), key, value)
-              i += 1
-            case _ =>
-              throw new IllegalArgumentException("illegal commond line, format: --conf key=value.")
-          }
-        case _ =>
-          throw new IllegalArgumentException(s"illegal commond line, ${args(i)} cannot recognize.")
+    ParameterUtils.parseStartupParams(
+      args,
+      (prefix, key, value) => {
+        optionParser.setConf(s"--$prefix-conf", key, value)
       }
-      i += 1
-    }
+    )
     optionParser.validate()
     optionParser
   }

--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/ParameterUtils.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/utils/ParameterUtils.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.utils
+
+object ParameterUtils {
+
+  private val startupConfRegex =
+    """--([a-z]+)-conf\s+(\S+)=([^=]+?)(?=\s*(?:--engineconn-conf|--spring-conf|$))""".r
+
+  def parseStartupParams(args: Array[String], handler: (String, String, String) => Unit): Unit = {
+    val argString = args.mkString(" ")
+    startupConfRegex.findAllMatchIn(argString).foreach { m =>
+      val prefix = m.group(1).trim
+      val key = m.group(2).trim
+      val value = m.group(3).trim
+      prefix match {
+        case "engineconn" | "spring" =>
+          handler(prefix, key, value)
+        case _ =>
+          throw new IllegalArgumentException(s"illegal command line, $prefix cannot recognize.")
+      }
+    }
+  }
+
+}

--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/EngineConnArguments.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/utils/EngineConnArguments.scala
@@ -17,6 +17,8 @@
 
 package org.apache.linkis.governance.common.utils
 
+import org.apache.linkis.common.utils.{ParameterUtils, Logging}
+
 import org.apache.commons.lang3.StringUtils
 
 import scala.collection.mutable
@@ -105,31 +107,13 @@ class DefaultEngineConnArgumentsParser extends EngineConnArgumentsParser {
   protected val keyValueRegex = "([^=]+)=(.+)".r
 
   override def parseToObj(args: Array[String]): EngineConnArguments = {
-    var i = 0
     val argumentsBuilder = new DefaultEngineConnArgumentsBuilder
-    while (i < args.length) {
-      args(i) match {
-        case ENGINE_CONN_CONF =>
-          addKeyValue(
-            args(i + 1),
-            (key, value) => {
-              argumentsBuilder.addEngineConnConf(key, value)
-              i += 1
-            }
-          )
-        case SPRING_CONF =>
-          addKeyValue(
-            args(i + 1),
-            (key, value) => {
-              argumentsBuilder.addSpringConf(key, value)
-              i += 1
-            }
-          )
-        case _ =>
-          throw new IllegalArgumentException(s"illegal command line, ${args(i)} cannot recognize.")
+    ParameterUtils.parseStartupParams(
+      args,
+      (prefix, key, value) => {
+        argumentsBuilder.addEngineConnConf(key, value)
       }
-      i += 1
-    }
+    )
     argumentsBuilder.build()
   }
 

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/launch/ProcessEngineConnLaunch.scala
@@ -170,7 +170,7 @@ trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
   protected def getCommandArgs: Array[String] = {
     if (
         request.creationDesc.properties.asScala.exists { case (k, v) =>
-          k.contains(" ") || (v != null && v.contains(" "))
+          k.contains(" ")
         }
     ) {
       throw new ErrorException(
@@ -223,6 +223,7 @@ trait ProcessEngineConnLaunch extends EngineConnLaunch with Logging {
     engineConnConf += (ENGINE_CONN_CONTAINERIZATION_MAPPING_PORTS.key -> mappingPorts)
     engineConnConf += (ENGINE_CONN_CONTAINERIZATION_MAPPING_HOST.key -> mappingHost)
 
+    engineConnConf = engineConnConf.map(m => (m._1, s""""${m._2}""""))
     arguments.addEngineConnConf(engineConnConf)
     EngineConnArgumentsParser.getEngineConnArgumentsParser.parseToArgs(arguments.build())
   }


### PR DESCRIPTION
### What is the purpose of the change

When submitting, support for parameter values with spaces is allowed.

### Related issues/PRs

Related issues: close #5271 

### Brief change log

- Parse via regular expressions: --engineconn-conf and --spring-conf;
- When generating the file engineConnExec.sh, enclose the value of --engineconn-conf in double quotes.


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [] I have added tests corresponding to this change
- [] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.
