### PR TITLE
[feat][COM][httpclient] Optimize BML client connection pool parameters and fix datasource client issues

### DIFF
--- a/linkis-commons/linkis-httpclient/src/main/scala/org/apache/linkis/httpclient/AbstractHttpClient.scala
+++ b/linkis-commons/linkis-httpclient/src/main/scala/org/apache/linkis/httpclient/AbstractHttpClient.scala
@@ -93,11 +93,13 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
 
   protected val connectionManager = new PoolingHttpClientConnectionManager
 
+  // 设置连接池参数
+  connectionManager.setMaxTotal(clientConfig.getMaxConnection)
+  connectionManager.setDefaultMaxPerRoute(clientConfig.getMaxConnection / 2)
+
   private val httpClientBuilder: HttpClientBuilder = HttpClients
     .custom()
     .setDefaultCookieStore(cookieStore)
-    .setMaxConnTotal(clientConfig.getMaxConnection)
-    .setMaxConnPerRoute(clientConfig.getMaxConnection / 2)
     .setConnectionManager(connectionManager)
 
   protected val httpClient: CloseableHttpClient = if (clientConfig.isSSL) {
@@ -611,9 +613,11 @@ abstract class AbstractHttpClient(clientConfig: ClientConfig, clientName: String
     clientConnectInfo.put("leased", totalStats.getLeased)
     clientConnectInfo.put("avaiLabel", totalStats.getAvailable)
     clientConnectInfo.put("maxTotal", connectionManager.getMaxTotal)
+    clientConnectInfo.put("pendingCount", totalStats.getPending)
     logger.info(s"BMLClient:总最大连接数：${connectionManager.getMaxTotal}")
     logger.info(s"BMLClient:空闲连接数：${totalStats.getAvailable}")
     logger.info(s"BMLClient:活跃连接数：${totalStats.getLeased}")
+    logger.info(s"BMLClient:等待连接数：${totalStats.getPending}")
     clientConnectInfo
   }
 


### PR DESCRIPTION
## Summary

This PR includes the following main changes:

### 1. BML Client Connection Pool Optimization (linkis-commons/linkis-httpclient)
- Optimized connection pool configuration in `AbstractHttpClient.scala`
- Set connection pool parameters explicitly via `PoolingHttpClientConnectionManager`
- Added pending connection count monitoring and logging
- Improved connection management for better performance and reliability

### 2. DataSource Client Cleanup (linkis-public-enhancements/linkis-pes-client)
- Removed deprecated `getPublishedDataSourceByType` method
- Simplified `LinkisDataSourceRemoteClient` interface

### 3. Other Changes
- Fixed compilation issues across multiple modules
- Updated HBase engineconn plugin resources
- Updated dependencies and build configurations
- Frontend and backend dependency updates

## Related Issues

- Closes #5360

## Test Plan

- [x] Code compiles successfully
- [ ] Unit tests pass
- [ ] Integration tests pass

## Code Change Details

### linkis-commons/linkis-httpclient/src/main/scala/org/apache/linkis/httpclient/AbstractHttpClient.scala
- Added explicit connection pool configuration before building HttpClient
- Moved `setMaxTotal` and `setDefaultMaxPerRoute` to connectionManager
- Added pending connection count to connection stats logging

### linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/impl/LinkisDataSourceRemoteClient.scala
- Removed `getPublishedDataSourceByType` method implementation