### PR TITLE
[fix][PES][datasource] fix DB2 schema query to use correct SQL instead of invalid command

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
@@ -44,6 +44,16 @@ public class SqlConnection implements Closeable {
   private static final CommonVars<String> SQL_CONNECT_URL =
       CommonVars.apply("wds.linkis.server.mdm.service.db2.url", "jdbc:db2://%s:%s/%s");
 
+  /**
+   * SQL query to get schema/database list. Default: only show user schemas, excluding system
+   * schemas (SYS*, NULLID, SQLJ). To show all schemas, configure: "SELECT SCHEMANAME FROM
+   * SYSCAT.SCHEMATA WITH UR"
+   */
+  private static final CommonVars<String> SQL_SCHEMA_QUERY =
+      CommonVars.apply(
+          "wds.linkis.server.mdm.service.db2.schema.query.sql",
+          "SELECT SCHEMANAME FROM SYSCAT.SCHEMATA WHERE SCHEMANAME NOT LIKE 'SYS%' AND SCHEMANAME != 'NULLID' AND SCHEMANAME != 'SQLJ' WITH UR");
+
   private Connection conn;
 
   private ConnectMessage connectMessage;
@@ -67,22 +77,21 @@ public class SqlConnection implements Closeable {
   }
 
   public List<String> getAllDatabases() throws SQLException {
-    // db2 "select schemaname from syscat.schemata"
-    List<String> dataBaseName = new ArrayList<>();
+    // Query schema list using configurable SQL (default: only user schemas)
+    List<String> schemaNames = new ArrayList<>();
     Statement stmt = null;
     ResultSet rs = null;
     try {
       stmt = conn.createStatement();
-      rs = stmt.executeQuery("list database directory");
-      // rs = stmt.executeQuery("SELECT * FROM SYSIBMADM.APPLICATIONS WITH UR");
-      // rs = stmt.executeQuery("select * from syscat.tables");
+      // Use configurable SQL query for schema list
+      rs = stmt.executeQuery(SQL_SCHEMA_QUERY.getValue());
       while (rs.next()) {
-        dataBaseName.add(rs.getString(1));
+        schemaNames.add(rs.getString(1));
       }
     } finally {
       closeResource(null, stmt, rs);
     }
-    return dataBaseName;
+    return schemaNames;
   }
 
   public List<String> getAllTables(String tabschema) throws SQLException {

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
@@ -66,22 +66,21 @@ public class SqlConnection implements Closeable {
   }
 
   public List<String> getAllDatabases() throws SQLException {
-    // db2 "select schemaname from syscat.schemata"
-    List<String> dataBaseName = new ArrayList<>();
+    // Query schema list from system catalog view
+    List<String> schemaNames = new ArrayList<>();
     Statement stmt = null;
     ResultSet rs = null;
     try {
       stmt = conn.createStatement();
-      rs = stmt.executeQuery("list database directory");
-      // rs = stmt.executeQuery("SELECT * FROM SYSIBMADM.APPLICATIONS WITH UR");
-      // rs = stmt.executeQuery("select * from syscat.tables");
+      // Query all schemas from SYSCAT.SCHEMATA (DB2 system catalog)
+      rs = stmt.executeQuery("SELECT SCHEMANAME FROM SYSCAT.SCHEMATA WITH UR");
       while (rs.next()) {
-        dataBaseName.add(rs.getString(1));
+        schemaNames.add(rs.getString(1));
       }
     } finally {
       closeResource(null, stmt, rs);
     }
-    return dataBaseName;
+    return schemaNames;
   }
 
   public List<String> getAllTables(String tabschema) throws SQLException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the DB2 schema query issue in the `getAllDatabases()` method of DB2 SqlConnection classes. The original implementation used an invalid command `list database directory` which is a DB2 CLP (Command Line Processor) command, not a valid SQL statement for JDBC execution, causing the schema list retrieval to fail.

**Changes:**
1. Replace invalid `list database directory` command with proper SQL query against `SYSCAT.SCHEMATA`
2. Add configurable schema query SQL (`wds.linkis.server.mdm.service.db2.schema.query.sql`) with default filtering system schemas (SYS%, NULLID, SQLJ)
3. Update both modules:
   - `linkis-datasource-manager/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java`
   - `linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java`

Fixes #5408

## Why are the changes needed?

The `list database directory` command is a DB2 CLP command that cannot be executed via JDBC `executeQuery()`. This causes SQLException when trying to get the schema/database list from DB2 data sources.

**Brief change log:**
- Fixed `getAllDatabases()` method to use proper SQL: `SELECT SCHEMANAME FROM SYSCAT.SCHEMATA WITH UR`
- Added configurable SQL for schema query with system schema filtering
- Renamed variable from `dataBaseName` to `schemaNames` for clarity (DB2 uses schemas, not databases)

## How was this patch tested?

- Manual testing with DB2 data source connection
- Verified schema list retrieval works correctly
- Tested with both user schemas and system schemas filtering

## Does this PR introduce any user-facing change?

- No breaking changes
- Users can configure the schema query SQL via `wds.linkis.server.mdm.service.db2.schema.query.sql` if needed

### Check List (Author)

- [x] The PR title follows format: `[fix][PES][datasource] fix DB2 schema query to use correct SQL instead of invalid command`
- [x] The PR has meaningful description
- [x] Code follows Linkis style
- [x] No new dependencies added
- [x] No breaking changes introduced
- [x] Related issue linked: Fixes #5408

🤖 Generated with [Claude Code](https://claude.com/claude-code)