### PR TITLE
[fix][EC][jdbc] Add configurable validation query for different database types

### DIFF
--- a/linkis-engineconn-plugins/jdbc/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/jdbc/src/main/assembly/distribution.xml
@@ -45,6 +45,15 @@
                 <exclude>org.apache.hbase:hbase-shaded-protobuf:jar</exclude>
                 <exclude>org.apache.hbase:hbase-shaded-miscellaneous:jar</exclude>
                 <exclude>org.apache.hbase:hbase-protocol-shaded:jar</exclude>
+                <!-- Exclude conflicting Jetty jars - use from public-module -->
+                <exclude>org.eclipse.jetty:jetty-*:jar</exclude>
+                <exclude>org.eclipse.jetty:jetty-runner:jar</exclude>
+                <!-- Exclude SLF4J binding to avoid conflict -->
+                <exclude>org.apache.logging.log4j:log4j-slf4j-impl:jar</exclude>
+                <exclude>org.slf4j:slf4j-reload4j:jar</exclude>
+                <exclude>org.slf4j:slf4j-log4j12:jar</exclude>
+                <!-- Exclude Hadoop jars - use from public-module -->
+                <exclude>org.apache.hadoop:hadoop-*:jar</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/ConnectionManager.java
+++ b/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/ConnectionManager.java
@@ -205,6 +205,8 @@ public class ConnectionManager {
     datasource.setUrl(dbUrl);
     if (dbUrl.toLowerCase().contains("oracle")) {
       datasource.setValidationQuery("SELECT 1 FROM DUAL");
+    } else if (dbUrl.toLowerCase().contains("db2")) {
+      datasource.setValidationQuery("SELECT 1 FROM SYSIBM.SYSDUMMY1");
     }
     datasource.setUsername(username);
     if (AESUtils.LINKIS_DATASOURCE_AES_SWITCH.getValue()) {
@@ -248,6 +250,8 @@ public class ConnectionManager {
     }
     if (url.contains("oracle")) {
       ((DruidDataSource) dataSource).setValidationQuery("SELECT 1 FROM DUAL");
+    } else if (url.contains("db2")) {
+      ((DruidDataSource) dataSource).setValidationQuery("SELECT 1 FROM SYSIBM.SYSDUMMY1");
     }
     return dataSource.getConnection();
   }

--- a/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/ConnectionManager.java
+++ b/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/ConnectionManager.java
@@ -57,6 +57,9 @@ public class ConnectionManager {
   private final Map<String, DataSource> dataSourceFactories;
   private final JDBCDataSourceConfigurations jdbcDataSourceConfigurations;
 
+  // Cache for validation query mapping parsed from configuration
+  private volatile Map<String, String> validationQueryMapping = null;
+
   private static volatile ConnectionManager connectionManager; // NOSONAR
   private ScheduledExecutorService scheduledExecutorService;
   private Integer kinitFailCount = 0;
@@ -64,6 +67,54 @@ public class ConnectionManager {
   private ConnectionManager() {
     jdbcDataSourceConfigurations = new JDBCDataSourceConfigurations();
     dataSourceFactories = new HashMap<>();
+    initValidationQueryMapping();
+  }
+
+  /**
+   * Parse validation query mapping from configuration. Format: dbType1:query1,dbType2:query2,...
+   * Example: oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1
+   */
+  private void initValidationQueryMapping() {
+    String mappingConfig = JDBCConfiguration$.MODULE$.JDBC_VALIDATION_QUERY_MAPPING();
+    Map<String, String> mapping = new HashMap<>();
+    if (StringUtils.isNotBlank(mappingConfig)) {
+      String[] entries = mappingConfig.split(",");
+      for (String entry : entries) {
+        String[] parts = entry.split(":");
+        if (parts.length == 2) {
+          String dbType = parts[0].trim().toLowerCase();
+          String query = parts[1].trim();
+          mapping.put(dbType, query);
+          LOG.info("Loaded validation query mapping: {} -> {}", dbType, query);
+        }
+      }
+    }
+    this.validationQueryMapping = mapping;
+  }
+
+  /**
+   * Get validation query for a specific JDBC URL based on database type. Returns null if no
+   * specific mapping found (will use default "SELECT 1").
+   *
+   * @param jdbcUrl the JDBC connection URL
+   * @return the validation query for this database type, or null if using default
+   */
+  private String getValidationQueryFromUrl(String jdbcUrl) {
+    if (jdbcUrl == null || validationQueryMapping == null || validationQueryMapping.isEmpty()) {
+      return null;
+    }
+    String lowerUrl = jdbcUrl.toLowerCase();
+    for (Map.Entry<String, String> entry : validationQueryMapping.entrySet()) {
+      if (lowerUrl.contains(entry.getKey())) {
+        LOG.debug(
+            "Using validation query '{}' for database type '{}' from URL: {}",
+            entry.getValue(),
+            entry.getKey(),
+            jdbcUrl);
+        return entry.getValue();
+      }
+    }
+    return null;
   }
 
   public static ConnectionManager getInstance() {
@@ -203,11 +254,13 @@ public class ConnectionManager {
     DruidDataSource datasource = new DruidDataSource();
     LOG.info("Database connection address information(数据库连接地址信息)=" + dbUrl);
     datasource.setUrl(dbUrl);
-    if (dbUrl.toLowerCase().contains("oracle")) {
-      datasource.setValidationQuery("SELECT 1 FROM DUAL");
-    } else if (dbUrl.toLowerCase().contains("db2")) {
-      datasource.setValidationQuery("SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+    // Set validation query based on database type from configuration
+    String dbSpecificValidationQuery = getValidationQueryFromUrl(dbUrl);
+    if (dbSpecificValidationQuery != null) {
+      datasource.setValidationQuery(dbSpecificValidationQuery);
     }
+
     datasource.setUsername(username);
     if (AESUtils.LINKIS_DATASOURCE_AES_SWITCH.getValue()) {
       // decrypt
@@ -248,11 +301,13 @@ public class ConnectionManager {
         }
       }
     }
-    if (url.contains("oracle")) {
-      ((DruidDataSource) dataSource).setValidationQuery("SELECT 1 FROM DUAL");
-    } else if (url.contains("db2")) {
-      ((DruidDataSource) dataSource).setValidationQuery("SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+    // Set validation query based on database type from configuration
+    String dbSpecificValidationQuery = getValidationQueryFromUrl(url);
+    if (dbSpecificValidationQuery != null) {
+      ((DruidDataSource) dataSource).setValidationQuery(dbSpecificValidationQuery);
     }
+
     return dataSource.getConnection();
   }
 

--- a/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/constant/JDBCEngineConnConstant.java
+++ b/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/constant/JDBCEngineConnConstant.java
@@ -57,6 +57,12 @@ public class JDBCEngineConnConstant {
   public static final String JDBC_POOL_TEST_WHILE_IDLE = "wds.linkis.jdbc.pool.testWhileIdle";
   public static final String JDBC_POOL_VALIDATION_QUERY = "wds.linkis.jdbc.pool.validationQuery";
   public static final String JDBC_POOL_DEFAULT_VALIDATION_QUERY = "SELECT 1";
+
+  // Configuration for database-specific validation queries
+  // Format: dbType1:query1,dbType2:query2,...
+  // Example: oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1,mysql:SELECT 1
+  public static final String JDBC_VALIDATION_QUERY_MAPPING =
+      "wds.linkis.jdbc.validation.query.mapping";
   public static final String JDBC_POOL_TIME_BETWEEN_MIN_EVIC_IDLE_MS =
       "wds.linkis.jdbc.pool.minEvictableIdleTimeMillis";
   public static final String JDBC_POOL_TIME_BETWEEN_EVIC_RUNS_MS =

--- a/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/conf/JDBCConfiguration.scala
+++ b/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/conf/JDBCConfiguration.scala
@@ -43,4 +43,13 @@ object JDBCConfiguration {
   val SUPPORT_CONN_PARAM_EXECUTE_ENABLE: Boolean =
     CommonVars[Boolean]("linkis.support.conn.param.execute.enable", true).getValue
 
+  // Validation query mapping for different database types
+  // Format: dbType1:query1,dbType2:query2,...
+  // Default includes common databases that need non-standard validation queries
+  val JDBC_VALIDATION_QUERY_MAPPING: String =
+    CommonVars[String](
+      "wds.linkis.jdbc.validation.query.mapping",
+      "oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1"
+    ).getValue
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds configurable validation query support for JDBC engine connection pool, enabling proper connection validation for Oracle, DB2, and other databases that require non-standard validation queries.

Changes:
1. **ConnectionManager.java**: Added validation query mapping logic that auto-detects database type from JDBC URL and selects appropriate validation query
2. **JDBCEngineConnConstant.java**: Added new configuration constant for validation query mapping
3. **JDBCConfiguration.scala**: Added configuration item with default support for Oracle and DB2
4. **distribution.xml**: Excluded conflicting jars from JDBC plugin assembly packaging

### Why are the changes needed?

JDBC engine connection pool uses "SELECT 1" as the default validation query, which works for MySQL and PostgreSQL but fails for:
- Oracle: requires "SELECT 1 FROM DUAL"
- DB2: requires "SELECT 1 FROM SYSIBM.SYSDUMMY1"

Fixes #5411

### How was this patch tested?

- [ ] Oracle database connection pool validation test
- [ ] DB2 database connection pool validation test
- [ ] MySQL/PostgreSQL default validation query compatibility test
- [ ] JDBC plugin assembly packaging test (no jar conflicts)

### Does this PR introduce any user-facing change?

Yes, users can now configure database-specific validation queries via:

```properties
# Format: dbType1:query1,dbType2:query2,...
wds.linkis.jdbc.validation.query.mapping=oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1
```

### How was this patch tested?

- Verified connection pool initialization with Oracle JDBC URL
- Verified connection pool initialization with DB2 JDBC URL
- Verified backward compatibility with MySQL/PostgreSQL

### Check List

- [x] Update License info if needed
- [ ] Add new UT/IT if needed
- [ ] Need to update docs
- [ ] Need to add warning banner in README