### PR TITLE
[Security] Temporarily disable master branch protection for sensitive data cleanup

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,13 +58,17 @@ github:
     merge:  true
     squash: true
     rebase: true
-  protected_branches:
-    master:
-      required_status_checks:
-        strict: true
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        required_approving_review_count: 1
+  # Temporarily disable master branch protection to allow force-push
+  # for cleaning sensitive information (passwords, internal IPs, domains)
+  # from historical commits per security ticket.
+  # Will be restored in a follow-up PR after the cleanup is complete.
+  # protected_branches:
+  #   master:
+  #     required_status_checks:
+  #       strict: true
+  #     required_pull_request_reviews:
+  #       dismiss_stale_reviews: true
+  #       required_approving_review_count: 1
 notifications:
   commits: commits@linkis.apache.org
   issues: dev@linkis.apache.org


### PR DESCRIPTION
## Motivation

GitHub branch protection on `master` prevents force-push, which is required to clean sensitive information leaked in historical commits per the security ticket.

The following sensitive data needs to be cleaned from the git history:
- **Internal IPs** (e.g., `10.107.x.x`, `172.21.x.x`) → `127.0.0.1`
- **Database passwords** (e.g., `bdpVsbi@2019`, `bdpeasyide@bdpsit`) → `default`
- **Internal domains** (e.g., `weoa.com`) → `localhost`
- **Database names** (e.g., `vsbi_gz_bdap_sit_01`) → `default_db`

## What this PR does

Comments out the `protected_branches.master` section in `.asf.yaml`. Once merged, ASF's puppet bot will sync the configuration to GitHub and remove the protection rule (typically within minutes).

## Plan

1. Merge this PR → ASF bot removes master protection
2. Force-push rewritten history to `master` (and tags)
3. Submit a follow-up PR to restore the `protected_branches.master` configuration

## Precedent

This same mechanism has been used multiple times historically (see commits `9d8fd0372`, `831d80b63`, `613c3b884`).

## Test plan

- [ ] Merge PR
- [ ] Wait ~5 minutes for ASF puppet bot to sync configuration
- [ ] Verify `master` branch protection is removed via `gh api repos/apache/linkis/branches/master`
- [ ] Proceed with security cleanup force-push
- [ ] Submit follow-up PR to restore protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)