### PR TITLE
[Security] Enable allow_force_pushes on master for sensitive data cleanup

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,17 +58,17 @@ github:
     merge:  true
     squash: true
     rebase: true
-  # Temporarily disable master branch protection to allow force-push
-  # for cleaning sensitive information (passwords, internal IPs, domains)
-  # from historical commits per security ticket.
-  # Will be restored in a follow-up PR after the cleanup is complete.
-  # protected_branches:
-  #   master:
-  #     required_status_checks:
-  #       strict: true
-  #     required_pull_request_reviews:
-  #       dismiss_stale_reviews: true
-  #       required_approving_review_count: 1
+  protected_branches:
+    master:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
+      # Temporarily allow force-push on master to rewrite historical commits
+      # for cleaning leaked corporate sensitive information per security ticket.
+      # This line will be removed in a follow-up PR once cleanup is complete.
+      allow_force_pushes: true
 notifications:
   commits: commits@linkis.apache.org
   issues: dev@linkis.apache.org


### PR DESCRIPTION
## Motivation

Follow-up to #5443. The previous PR commented out the entire `protected_branches.master` section, but the ASF bot did not sync the change (or the rule is defined at org level). Force-push to `master` is still blocked.

This PR takes a different approach: **keep all existing branch protection rules intact** (status checks, PR reviews) and only **enable `allow_force_pushes`**.

## What this PR does

Restores the original `protected_branches.master` config from before #5443, and adds one new line:

```yaml
protected_branches:
  master:
    required_status_checks:
      strict: true
    required_pull_request_reviews:
      dismiss_stale_reviews: true
      required_approving_review_count: 1
    allow_force_pushes: true   # ← new
```

## Why this approach

- Keeps PR review enforcement intact (committers still review every change)
- Only opens a narrow window: allows rewriting historical commits that contain leaked corporate sensitive information
- Smaller blast radius than fully removing protection

## Plan

1. Merge this PR → ASF bot applies config
2. Verify force-push works: `git push --force origin master`
3. Rewrite history with `git-filter-repo` (already prepared locally, verified in fork)
4. Force-push master + tags
5. Submit follow-up PR to remove `allow_force_pushes: true`

## Test plan

- [ ] Merge PR
- [ ] Wait for ASF bot to sync (~5-30 minutes)
- [ ] Verify via: `gh api repos/apache/linkis/branches/master/protection --jq '.allow_force_pushes.enabled'`
- [ ] Proceed with security cleanup force-push
- [ ] Submit follow-up PR to remove `allow_force_pushes: true`

## Notes

If `allow_force_pushes` is not supported by ASF's `.asf.yaml` parser, we'll need to fall back to contacting ASF Infra directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)