### PR TITLE
[ISSUE-5130][EC-JDBC] Map NUMERIC columns to decimal

### DIFF
--- a/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCHelper.java
+++ b/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCHelper.java
@@ -145,6 +145,7 @@ public class JDBCHelper {
             case Types.BINARY:
                 retVal = BinaryType.typeName();
                 break;
+            case Types.NUMERIC:
             case Types.DECIMAL:
                 retVal = DecimalType.typeName();
                 break;

--- a/linkis-engineconn-plugins/jdbc/src/test/java/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCHelperTest.java
+++ b/linkis-engineconn-plugins/jdbc/src/test/java/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCHelperTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.manager.engineplugin.jdbc.executor;
+
+import org.apache.linkis.storage.domain.DecimalType;
+
+import java.sql.Types;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class JDBCHelperTest {
+
+  @Test
+  @DisplayName("numeric JDBC columns should map to Linkis decimal type")
+  public void numericColumnsShouldMapToDecimalType() {
+    Assertions.assertEquals(DecimalType.typeName(), JDBCHelper.getTypeStr(Types.NUMERIC));
+  }
+}


### PR DESCRIPTION
### What is changed?

This PR fixes PostgreSQL numeric column metadata mapping in the JDBC engine plugin. PostgreSQL reports `numeric` columns as `java.sql.Types.NUMERIC`, but `JDBCHelper.getTypeStr` only mapped `Types.DECIMAL` to Linkis `decimal`, leaving `NUMERIC` as `null`.

The value extraction path already handles `Types.NUMERIC` and `Types.DECIMAL` together, so this change applies the same mapping in the type-name conversion path.

### Why?

Fixes #5130.

### Tests

- Reproduced with `mvn -pl linkis-engineconn-plugins/jdbc -am -Dtest=org.apache.linkis.manager.engineplugin.jdbc.executor.JDBCHelperTest -Dsurefire.failIfNoSpecifiedTests=false test`: failed before the fix with `expected: <decimal> but was: <null>`.
- Passed after the fix with the same command.
- Passed JDBC unit test set with `mvn -pl linkis-engineconn-plugins/jdbc -am -Dtest=ConnectionManagerTest,ProgressMonitorTest,JDBCErrorCodeSummaryTest,JDBCHelperTest,JdbcParamUtilsTest,JDBCMultiDatasourceParserTest -Dsurefire.failIfNoSpecifiedTests=false test` (13 tests).

Note: direct `mvn -pl linkis-engineconn-plugins/jdbc test` cannot resolve unpublished Linkis 1.9.0 reactor artifacts from the configured mirror in this local environment, so the verified commands use `-am` to build required modules from source.