### PR TITLE
[fix][COM][dist] Fix Spring Boot 2.7 deployment compatibility and transitive dependency issues

### DIFF
--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -360,6 +360,11 @@
       <artifactId>spring-retry</artifactId>
       <version>1.3.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/linkis-dist/package/conf/application-engineconn.yml
+++ b/linkis-dist/package/conf/application-engineconn.yml
@@ -15,11 +15,24 @@
 spring:
   application:
     name: linkis-cg-engineconn
+  main:
+    allow-bean-definition-overriding: true
+    # Spring Boot 2.7+ compatibility: required for springfox 3.0.0 + Linkis internal bean cycles
+    allow-circular-references: true
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+    servlet:
+      path: /api/rest_j/v1
   servlet:
     multipart:
       max-file-size: 500MB
       max-request-size: 500MB
       file-size-threshold: 50MB
+  cloud:
+    loadbalancer:
+      cache:
+        enabled: false
 eureka:
   instance:
     # prefer-ip-address: true

--- a/linkis-dist/pom.xml
+++ b/linkis-dist/pom.xml
@@ -168,6 +168,12 @@
       <artifactId>hadoop-hdfs-client</artifactId>
       <version>${hadoop.version}</version>
     </dependency>
+    <!-- Eureka Client 依赖 commons-lang 2.x 的 ExceptionUtils -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
 
   </dependencies>
 

--- a/linkis-dist/pom.xml
+++ b/linkis-dist/pom.xml
@@ -158,6 +158,17 @@
       <artifactId>commons-beanutils</artifactId>
     </dependency>
 
+    <!-- 显式引入正确的 scala/hadoop 依赖，覆盖传递依赖中的错误版本 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_2.12</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/linkis-dist/src/main/assembly/distribution.xml
+++ b/linkis-dist/src/main/assembly/distribution.xml
@@ -301,6 +301,8 @@
             <useStrictFiltering>false</useStrictFiltering>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
+                <exclude>com.fasterxml.jackson.module:jackson-module-scala_2.11:*</exclude>
+                <exclude>org.apache.hadoop:hadoop-hdfs:*</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/linkis-engineconn-plugins/impala/pom.xml
+++ b/linkis-engineconn-plugins/impala/pom.xml
@@ -70,6 +70,14 @@
       <version>${libthrift.version}</version>
     </dependency>
 
+    <!-- slf4j-api must be declared explicitly because both linkis-common (provided) and
+         impala-* artifacts (all transitive deps excluded) do not bring it in.
+         Required by Logging.logger and Utils.tryAndWarn implicit parameter. -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- impala -->
     <dependency>
       <groupId>org.apache.impala</groupId>

--- a/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
+++ b/linkis-spring-cloud-services/linkis-service-discovery/linkis-eureka/pom.xml
@@ -78,11 +78,12 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-logging</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml.version}</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes multiple deployment-blocking issues discovered when building and deploying the current `master` branch with Spring Boot 2.7. Each fix addresses a distinct failure observed during `mvn package -Papache` and the subsequent service startup:

1. **snakeyaml 被错误排除导致服务启动失败** (`63966cfb0`)
   - `linkis-commons/linkis-module/pom.xml` / `linkis-eureka/pom.xml`
   - Add `snakeyaml` back as an explicit compile dependency. The exclusion inherited from `spring-boot-starter` left Eureka/Manager unable to start (Spring needs snakeyaml to parse application.yml).

2. **排除错误的传递依赖 jackson-module-scala_2.11 和 hadoop-hdfs-2.7.2** (`f605e7142`)
   - `linkis-dist/pom.xml` / `linkis-dist/src/main/assembly/distribution.xml`
   - Exclude `jackson-module-scala_2.11` (Scala 2.11 binary, conflicts with the 2.12 the project uses) and `hadoop-hdfs` 2.7.2 (legacy Hadoop 2.x artifact that overrides `hadoop-hdfs-client` 3.3.4 and triggers `NoClassDefFoundError` on HDFS writes).

3. **补全 Spring Boot 2.7 部署兼容性配置** (`a77d0e328`)
   - `linkis-dist/pom.xml`: add explicit `commons-lang:2.6` (Eureka Client depends on its `ExceptionUtils` but `spring-cloud-netflix` no longer pulls it transitively).
   - `linkis-dist/package/conf/application-engineconn.yml`: add the missing Spring Boot 2.7 compatibility keys (`spring.main.allow-circular-references`, `spring.mvc.pathmatch.matching-strategy: ant_path_matcher`, `spring.mvc.servlet.path`, `spring.cloud.loadbalancer.cache.enabled: false`). The sibling `application-eureka.yml` and `application-linkis.yml` already had these on master, but the engineconn yml was missed.

4. **修复 impala 引擎编译失败 (slf4j-api 缺失)** (`ee5a186c1`)
   - `linkis-engineconn-plugins/impala/pom.xml`
   - Add `slf4j-api` as an explicit dependency. Without it, `ImpalaEngineConnExecutor.scala` fails to compile with `Symbol 'type org.slf4j.Logger' is missing from the classpath` because `linkis-common` is `<scope>provided</scope>` and `impala-frontend`/`impala-minimal-hive-exec` exclude all transitive deps.

## Why are the changes needed?

Building and deploying the current `master` from a clean checkout fails end-to-end:

- `mvn package -Papache` fails at the impala module.
- Skipping impala still produces a tarball, but starting services fails with snakeyaml/class loading errors.
- After working around those, RPC `POST /api/rest_j/v1/rpc/receiveAndReply` returns 404 because Spring Boot 2.7's default `path_pattern_parser` is incompatible with springfox 3.0.0 — the engineconn yml was missing the override.
- After fixing the override, Eureka Client still throws `NoClassDefFoundError: org.apache.commons.lang.exception.ExceptionUtils` because commons-lang 2.x is no longer transitively available.

Each fix has been validated independently and the full build now completes (`BUILD SUCCESS, 18:42 min`).

## How was this patch tested?

- `mvn clean package -Papache -DskipTests -Dmaven.javadoc.skip=true` — full reactor build now passes (was: failure at `linkis-engineplugin-impala`).
- Deployed the produced tarball via `deploy-upgrade.sh` and verified:
  - All 6 services (mg-eureka, mg-gateway, ps-publicservice, cg-linkismanager, cg-entrance, cg-engineconnmanager) start and register with Eureka.
  - Shell engine task (`jobId 126376`) succeeds with output matching the echo payload.
  - `PerformanceInterceptor` shows `/rpc/receiveAndReply` returning in 504 ms (no `/error` forward = no 404).
  - Eureka heartbeat `/rpc/receive` steady at 2–3 ms.

## Related

- These were originally prototyped on `fix/dependency-versions` (an older base). This branch was rebased onto the current `master` so the changes apply cleanly to the latest `application-*.yml` layout that master already migrated to.