### PR TITLE
[branch protection] Restore master branch protection after history cleanup

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -65,10 +65,6 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
-      # Temporarily allow force-push on master to rewrite historical commits
-      # for cleaning leaked corporate sensitive information per security ticket.
-      # This line will be removed in a follow-up PR once cleanup is complete.
-      allow_force_pushes: true
 notifications:
   commits: commits@linkis.apache.org
   issues: dev@linkis.apache.org


### PR DESCRIPTION
## Summary

- Removes the temporary `allow_force_pushes: true` flag added in #5444 to enable rewriting historical commits containing leaked internal credentials.
- The cleanup across all branches (master + 13 release branches + fix-master-compile) and 40 tags is complete; this PR restores master branch protection to its standard configuration.

## Context

Follow-up to the ASF Infra ticket for rewriting leaked corporate credentials in git history. With the history rewrite complete and verified (0 sensitive hits across all 62 refs), the temporary force-push allowance is no longer needed.

## Test plan

- [ ] Verify `.asf.yaml` syntax valid (yaml parser)
- [ ] After merge, confirm GitHub reports master as protected with `allow_force_pushes: false`
- [ ] Confirm `required_status_checks` and `required_pull_request_reviews` still active

🤖 Generated with [Claude Code](https://claude.com/claude-code)