### PR TITLE
[SECURITY] Remove hardcoded default wds.linkis.crypt.key, fail-closed on insecure values

### DIFF
--- a/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/ServerConfiguration.scala
+++ b/linkis-commons/linkis-module/src/main/scala/org/apache/linkis/server/conf/ServerConfiguration.scala
@@ -47,9 +47,45 @@ object ServerConfiguration extends Logging {
     )
   }
 
-  val cryptKey = Base64.getMimeEncoder.encodeToString(
-    CommonVars("wds.linkis.crypt.key", "bdp-for-server").getValue.getBytes
-  )
+  // CVE-2026-XXXX (session ticket auth bypass): remove hardcoded default cryptKey
+  private val INSECURE_DEFAULTS = Set("bdp-for-server", "")
+  private val CRYPT_KEY_MIN_LENGTH = 16
+
+  private val cryptKeyRaw: String = CommonVars("wds.linkis.crypt.key", "").getValue
+  private val allowInsecureCryptKey: Boolean = CommonVars("linkis.crypt.key.allow.insecure", "false").getValue.toBoolean
+
+  private def validateCryptKey(key: String): Unit = {
+    val issues = scala.collection.mutable.ArrayBuffer.empty[String]
+    if (key == null || key.isEmpty) {
+      issues += "wds.linkis.crypt.key not set"
+    } else {
+      if (INSECURE_DEFAULTS.contains(key)) {
+        issues += s"wds.linkis.crypt.key is the insecure default '$key'"
+      }
+      if (key.length < CRYPT_KEY_MIN_LENGTH) {
+        issues += s"wds.linkis.crypt.key length ${key.length} < $CRYPT_KEY_MIN_LENGTH"
+      }
+    }
+    if (issues.nonEmpty) {
+      if (allowInsecureCryptKey) {
+        logger.error("=" * 72)
+        logger.error("INSECURE CRYPT KEY IN USE — session ticket forgery risk!")
+        issues.foreach(s => logger.error(s"  - $s"))
+        logger.error("Rotate wds.linkis.crypt.key to a random 24+ char value immediately.")
+        logger.error("=" * 72)
+      } else {
+        throw new BDPInitServerException(
+          CRYPT_KEY_INSECURE.getErrorCode,
+          s"${CRYPT_KEY_INSECURE.getErrorDesc}: ${issues.mkString("; ")} " +
+            "(override with -Dlinkis.crypt.key.allow.insecure=true AT YOUR OWN RISK)"
+        )
+      }
+    }
+  }
+
+  validateCryptKey(cryptKeyRaw)
+
+  val cryptKey = Base64.getMimeEncoder.encodeToString(cryptKeyRaw.getBytes)
 
   private val ticketHeader = CommonVars("wds.linkis.ticket.header", "bfs_").getValue
 


### PR DESCRIPTION
## Summary

Remove the well-known hardcoded default cryptKey `"bdp-for-server"` that was shared by all Linkis deployments not explicitly configuring `wds.linkis.crypt.key`.

## Changes

- Default value changed from `"bdp-for-server"` to empty string
- Startup validation: empty / legacy default / keys < 16 chars cause `BDPInitServerException` (fail-closed)
- Escape hatch: `linkis.crypt.key.allow.insecure=true` (default false)
- All instances must share the same key — generate 24+ random chars before upgrading

## Affected files

- `linkis-commons/linkis-module/.../ServerConfiguration.scala` (+39/-3)

## Deployment impact

| Scenario | Behavior |
|---|---|
| cryptKey not configured | Refuses to start |
| cryptKey = bdp-for-server | Refuses to start |
| cryptKey = 16+ random | No impact |

🤖 Generated with [Claude Code](https://claude.com/claude-code)